### PR TITLE
Buff logic rework

### DIFF
--- a/src/scripts/sims/ast_sheet_sim.ts
+++ b/src/scripts/sims/ast_sheet_sim.ts
@@ -62,8 +62,7 @@ class AstSimContext {
 
     getResult(): AstSheetSimResult {
         const cp = new CycleProcessor(120, [astrodyne, ...this.allBuffs], this.stats);
-        cp.use(combust);
-        cp.use(filler); //play, draw
+        cp.use(combust); //play, draw
         cp.use(filler); //play, draw
         cp.use(filler); //div, play
         cp.use(filler); //MA, dyne

--- a/src/scripts/sims/ast_sheet_sim.ts
+++ b/src/scripts/sims/ast_sheet_sim.ts
@@ -42,17 +42,24 @@ const lord: OgcdAbility = {
     attackType: "Ability"
 }
 
-const astrodyne: Buff = {
+const astrodyne: OgcdAbility = {
     name: "Astrodyne",
-    job: "AST",
-    selfOnly: true,
-    duration: 15,
-    cooldown: 0,
-    effects: { //currently assumes 2 seal dynes, can change dmgIncrease based on frequency of 3 seals
-        dmgIncrease: .00,
-        haste: 10,
-    },
-    startTime: null,
+    type: "ogcd",
+    potency: null,
+    activatesBuffs: [
+        {
+            name: "Astrodyne",
+            job: "AST",
+            selfOnly: true,
+            duration: 15,
+            cooldown: 0,
+            effects: { //currently assumes 2 seal dynes, can change dmgIncrease based on frequency of 3 seals
+                // dmgIncrease: 0.00,
+                haste: 10,
+            },
+            startTime: null,
+        }
+    ]
 }
 
 class AstSimContext {
@@ -61,12 +68,12 @@ class AstSimContext {
     }
 
     getResult(): AstSheetSimResult {
-        const cp = new CycleProcessor(120, [astrodyne, ...this.allBuffs], this.stats);
+        const cp = new CycleProcessor(120, this.allBuffs, this.stats);
         cp.use(combust); //play, draw
         cp.use(filler); //play, draw
         cp.use(filler); //div, play
         cp.use(filler); //MA, dyne
-        cp.activateBuff(astrodyne);
+        cp.useOgcd(astrodyne);
         cp.use(filler);
         cp.use(star);
         cp.use(filler);

--- a/src/scripts/sims/ast_sheet_sim.ts
+++ b/src/scripts/sims/ast_sheet_sim.ts
@@ -51,7 +51,7 @@ const astrodyne: Buff = {
     effects: { //currently assumes 2 seal dynes, can change dmgIncrease based on frequency of 3 seals
         dmgIncrease: .00,
         haste: 10,
-    }
+    },
     startTime: null,
 }
 

--- a/src/scripts/sims/ast_sheet_sim.ts
+++ b/src/scripts/sims/ast_sheet_sim.ts
@@ -52,6 +52,7 @@ const astrodyne: Buff = {
         dmgIncrease: .00,
         haste: 10,
     }
+    startTime: null,
 }
 
 class AstSimContext {
@@ -62,9 +63,12 @@ class AstSimContext {
     getResult(): AstSheetSimResult {
         const cp = new CycleProcessor(120, [astrodyne, ...this.allBuffs], this.stats);
         cp.use(combust);
+        cp.use(filler); //play, draw
+        cp.use(filler); //play, draw
+        cp.use(filler); //div, play
+        cp.use(filler); //MA, dyne
+        cp.activateBuff(astrodyne);
         cp.use(filler);
-        cp.use(filler);
-        cp.activateBuffs();
         cp.use(star);
         cp.use(filler);
         cp.use(lord); //with 50% lord, chance, assumes 1 lord per burst window
@@ -72,7 +76,7 @@ class AstSimContext {
         cp.use(combust);
         cp.useUntil(filler, 60);
         cp.use(combust);
-        cp.useUntil(filler, 67);
+        cp.useUntil(filler, 75);
         cp.use(star);
         cp.useUntil(filler, 90);
         cp.use(combust);

--- a/src/scripts/sims/buffs.ts
+++ b/src/scripts/sims/buffs.ts
@@ -9,6 +9,7 @@ export const Mug = {
     effects: {
         dmgIncrease: 0.05,
     },
+    startTime: 3.5,
 } as const satisfies Buff;
 
 export const Litany = {
@@ -18,7 +19,8 @@ export const Litany = {
     cooldown: 120,
     effects: {
         critChanceIncrease: 0.10
-    }
+    },
+    startTime: 7.5,
 } as const satisfies Buff;
 
 export const DragonSight = {
@@ -29,7 +31,8 @@ export const DragonSight = {
     optional: true,
     effects: {
         dmgIncrease: 0.05
-    }
+    },
+    startTime: 5,
 } as const satisfies Buff;
 
 export const Brotherhood = {
@@ -39,7 +42,8 @@ export const Brotherhood = {
     cooldown: 120,
     effects: {
         dmgIncrease: 0.05
-    }
+    },
+    startTime: 7.5,
 } as const satisfies Buff;
 
 export const ArcaneCircle = {
@@ -49,7 +53,8 @@ export const ArcaneCircle = {
     cooldown: 120,
     effects: {
         dmgIncrease: 0.03
-    }
+    },
+    startTime: 5,
 } as const satisfies Buff;
 
 export const SearingLight = {
@@ -59,7 +64,8 @@ export const SearingLight = {
     cooldown: 120,
     effects: {
         dmgIncrease: 0.03
-    }
+    },
+    startTime: 1.5,
 } as const satisfies Buff;
 
 export const Embolden = {
@@ -69,7 +75,8 @@ export const Embolden = {
     cooldown: 120,
     effects: {
         dmgIncrease: 0.05
-    }
+    },
+    startTime: 7,
 } as const satisfies Buff;
 
 export const Devilment = {
@@ -81,7 +88,8 @@ export const Devilment = {
     effects: {
         dhitChanceIncrease: 0.20,
         critChanceIncrease: 0.20
-    }
+    },
+    startTime: 7,
 } as const satisfies Buff;
 
 /* With how the cycle processer script currently handles buffs, this wouldn't properly work
@@ -94,6 +102,7 @@ export const StandardFinish = {
     effects: {
         dmgIncrease: 0.05,
     }
+    startTime: 0,
 } as const satisfies Buff;
 */
 export const TechnicalFinish = {
@@ -103,7 +112,8 @@ export const TechnicalFinish = {
     cooldown: 120,
     effects: {
         dmgIncrease: 0.05,
-    }
+    },
+    startTime: 7,
 } as const satisfies Buff;
 
 export const BattleVoice = {
@@ -113,7 +123,8 @@ export const BattleVoice = {
     cooldown: 120,
     effects: {
         dhitChanceIncrease: 0.20,
-    }
+    },
+    startTime: 6,
 } as const satisfies Buff;
 
 export const RadiantFinale = {
@@ -123,7 +134,8 @@ export const RadiantFinale = {
     cooldown: 120,
     effects: {
         dmgIncrease: 0.06
-    }
+    },
+    startTime: 6.7,
 } as const satisfies Buff;
 
 export const Chain = {
@@ -133,7 +145,8 @@ export const Chain = {
     cooldown: 120,
     effects: {
         critChanceIncrease: 0.10
-    }
+    },
+    startTime: 7,
 } as const satisfies Buff;
 
 export const Divination = {
@@ -143,7 +156,8 @@ export const Divination = {
     cooldown: 120,
     effects: {
         dmgIncrease: 0.06
-    }
+    },
+    startTime: 7,
 } as const satisfies Buff;
 
 export const AstCard = {
@@ -154,7 +168,8 @@ export const AstCard = {
     optional: true,
     effects: {
         dmgIncrease: 0.06
-    }
+    },
+    startTime: 4,
 } as const satisfies Buff;
 
 

--- a/src/scripts/sims/components/ability_used_table.ts
+++ b/src/scripts/sims/components/ability_used_table.ts
@@ -35,13 +35,16 @@ export class AbilitiesUsedTable extends CustomTable<UsedAbility> {
             {
                 shortName: 'unbuffed-pot',
                 displayName: 'Pot',
-                getter: used => used.ability.potency
+                getter: used => used.ability.potency ?? '--',
             },
             {
                 shortName: 'expected-damage',
                 displayName: 'Damage',
                 getter: used => used,
-                renderer: used => {
+                renderer: (used: UsedAbility) => {
+                    if (!used.ability.potency) {
+                        return document.createTextNode('--');
+                    }
                     let text = used.damage.expected.toFixed(2);
                     if ('portion' in used) {
                         text += '*';

--- a/src/scripts/sims/sch_sheet_sim.ts
+++ b/src/scripts/sims/sch_sheet_sim.ts
@@ -9,6 +9,7 @@ import {CycleProcessor} from "./sim_processors";
 import {sum} from "../util/array_utils";
 import {BuffSettingsArea, BuffSettingsExport, BuffSettingsManager} from "./party_comp_settings";
 import {AbilitiesUsedTable} from "./components/ability_used_table";
+import {Chain} from "./buffs";
 
 
 const filler: GcdAbility = {
@@ -18,6 +19,13 @@ const filler: GcdAbility = {
     attackType: "Spell",
     gcd: 2.5,
     cast: 1.5
+}
+
+const chain: OgcdAbility = {
+    type: 'ogcd',
+    name: "Chain",
+    activatesBuffs: [Chain],
+    potency: null
 }
 
 const r2: GcdAbility = {
@@ -50,29 +58,30 @@ class SchSimContext {
     }
 
     getResult(): SchSheetSimResult {
-        const cp = new CycleProcessor(120, this.allBuffs, this.stats);
-        cp.use(bio);
-        cp.use(filler);
-        cp.use(filler);
-        cp.use(filler);
-        cp.use(ed);
-        cp.use(filler);
-        cp.use(ed);
-        cp.use(filler);
-        cp.use(ed);
-        cp.use(filler); //Aetherflow for MP and refreshing EDs
-        cp.use(filler);
-        cp.use(ed);
-        cp.use(filler);
-        cp.use(ed);
-        cp.use(filler);
-        cp.use(ed);
+        const cp = new CycleProcessor(120, this.allBuffs, this.stats, [Chain]);
+        cp.useGcd(bio);
+        cp.useGcd(filler);
+        cp.useGcd(filler);
+        cp.useOgcd(chain);
+        cp.useGcd(filler);
+        cp.useOgcd(ed);
+        cp.useGcd(filler);
+        cp.useOgcd(ed);
+        cp.useGcd(filler);
+        cp.useOgcd(ed);
+        cp.useGcd(filler); //Aetherflow for MP and refreshing EDs
+        cp.useGcd(filler);
+        cp.useOgcd(ed);
+        cp.useGcd(filler);
+        cp.useOgcd(ed);
+        cp.useGcd(filler);
+        cp.useOgcd(ed);
         cp.useUntil(filler, 30);
-        cp.use(bio);
+        cp.useGcd(bio);
         cp.useUntil(filler, 60);
-        cp.use(bio);
+        cp.useGcd(bio);
         cp.useUntil(filler, 90);
-        cp.use(bio);
+        cp.useGcd(bio);
         cp.useUntil(filler, 120);
 
         const used = cp.usedAbilities;

--- a/src/scripts/sims/sch_sheet_sim.ts
+++ b/src/scripts/sims/sch_sheet_sim.ts
@@ -3,7 +3,6 @@ import {CharacterGearSet} from "../gear";
 import {ComputedSetStats} from "../geartypes";
 
 import {quickElement} from "../components/util";
-import {CustomTable, HeaderRow} from "../tables";
 import {GcdAbility, Buff, UsedAbility, OgcdAbility} from "./sim_types";
 import {CycleProcessor} from "./sim_processors";
 import {sum} from "../util/array_utils";

--- a/src/scripts/sims/sch_sheet_sim.ts
+++ b/src/scripts/sims/sch_sheet_sim.ts
@@ -54,7 +54,6 @@ class SchSimContext {
         cp.use(bio);
         cp.use(filler);
         cp.use(filler);
-        cp.activateBuffs();
         cp.use(filler);
         cp.use(ed);
         cp.use(filler);

--- a/src/scripts/sims/sge_sheet_sim_mk2.ts
+++ b/src/scripts/sims/sge_sheet_sim_mk2.ts
@@ -51,14 +51,13 @@ class SgeSimContext {
         cp.use(eDosis);
         cp.use(filler);
         cp.use(filler);
-        cp.activateBuffs();
         cp.use(phlegma);
         cp.use(phlegma);
         cp.useUntil(filler, 30);
         cp.use(eDosis);
         cp.useUntil(filler, 60);
-        cp.use(phlegma);
         cp.use(eDosis);
+        cp.use(phlegma);
         cp.useUntil(filler, 90);
         cp.use(eDosis);
         cp.useUntil(filler, 120);

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -11,17 +11,29 @@ export class CycleProcessor {
     usedAbilities: (UsedAbility | PartiallyUsedAbility)[] = [];
 
     constructor(private cycleTime: number, private allBuffs: Buff[], private stats: ComputedSetStats) {
+        var buffTimes = new Map<Buff, number|null>();
+        this.allBuffs.forEach(function(buff){
+            this.buffTimes.set(buff, buff.startTime);
+        });
     }
 
     /**
      * Get the buffs that would be active right now.
      */
     getActiveBuffs(): Buff[] {
-        return this.allBuffs.filter(buff => (buff.startTime != null) && (this.nextGcdTime > buff.startTime) && (this. nextGcdTime - buff.startTime) < buff.duration);
+        var activeBuffs = new Buff[];
+        this.buffTimes.forEach((buff, time) =>{
+            if (time == null) continue;
+            if (time > this.nextGcdTime) continue;
+            if ((this.nextGcdTime - time) < buff.duration) {
+                this.activeBuffs.push(buff);
+            }
+        });
+        return this.activeBuffs;
     }
 
     activateBuff(buff: Buff) {
-        buff.startTime = this.currentTime;
+        this.buffTimes.set(buff, this.currentTime);
     }
 
     /**

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -1,6 +1,14 @@
 import {ComputedSetStats} from "../geartypes";
 import {applyDhCrit, baseDamage} from "../xivmath";
-import {Ability, Buff, ComputedDamage, GcdAbility, OgcdAbility, PartiallyUsedAbility, UsedAbility} from "./sim_types";
+import {
+    Ability,
+    Buff,
+    ComputedDamage,
+    DamagingAbility,
+    GcdAbility, OgcdAbility,
+    PartiallyUsedAbility,
+    UsedAbility
+} from "./sim_types";
 import {CASTER_TAX, NORMAL_GCD, STANDARD_ANIMATION_LOCK} from "../xivconstants";
 
 export class CycleProcessor {
@@ -8,13 +16,17 @@ export class CycleProcessor {
     nextGcdTime: number = 0;
     currentTime: number = 0;
     gcdBase: number = NORMAL_GCD;
-    usedAbilities: (UsedAbility | PartiallyUsedAbility)[] = [];
-    buffTimes;
+    readonly usedAbilities: (UsedAbility | PartiallyUsedAbility)[] = [];
+    readonly buffTimes = new Map<Buff, number>();
 
-    constructor(private cycleTime: number, private allBuffs: Buff[], private stats: ComputedSetStats) {
-        this.buffTimes = new Map<Buff, number | null>();
-        this.allBuffs.forEach(function(buff){
-            this.buffTimes.set(buff, buff.startTime);
+    constructor(private cycleTime: number, private allBuffs: Buff[], private stats: ComputedSetStats, private manuallyActivatedBuffs?: Buff[]) {
+        this.allBuffs.forEach(buff => {
+            if (manuallyActivatedBuffs && manuallyActivatedBuffs.includes(buff)) {
+                return;
+            }
+            if (buff.startTime !== undefined) {
+                this.buffTimes.set(buff, buff.startTime);
+            }
         });
     }
 
@@ -22,15 +34,18 @@ export class CycleProcessor {
      * Get the buffs that would be active right now.
      */
     getActiveBuffs(): Buff[] {
-        var activeBuffs:Buff[];
-        this.buffTimes.forEach((buff, time) =>{
-            if (time === null) return;
-            if (time > this.nextGcdTime) return;
-            if ((this.currentTime - time) < buff.duration) {
+        const queryTime = this.currentTime;
+        const activeBuffs: Buff[] = [];
+        this.buffTimes.forEach((time, buff) => {
+            if (time === undefined || time > queryTime) {
+                return;
+            }
+            if ((queryTime - time) < buff.duration) {
                 activeBuffs.push(buff);
-            } return;
+            }
+            return;
         });
-    return activeBuffs;
+        return activeBuffs;
     }
 
     activateBuff(buff: Buff) {
@@ -41,92 +56,17 @@ export class CycleProcessor {
      * How many GCDs have been used
      */
     gcdCount() {
-        return this.usedAbilities.length;
+        return this.usedAbilities.filter(used => used.ability['type'] == 'gcd').length;
     }
 
-    use(ability: GcdAbility | OgcdAbility) {
-        const buffs = this.getActiveBuffs();
-        const combinedEffects: CombinedBuffEffect = combineBuffEffects(buffs);
+    use(ability: Ability) {
         // Logic for GCDs
         if (ability.type == "gcd") {
-            if (this.nextGcdTime > this.cycleTime) {
-                // Already over time limit. Ignore completely.
-                return;
-            }
-            const abilityGcd = ability.fixedGcd ? ability.gcd : (this.stats.gcdMag(ability.gcd ?? this.gcdBase, combinedEffects.haste));
-            // When this GCD will end (strictly in terms of GCD. e.g. a BLM spell where cast > recast will still take the cast time. This will be
-            // accounted for later).
-            const gcdFinishedAt = this.nextGcdTime + abilityGcd;
-            // Enough time for entire GCD
-            if (gcdFinishedAt <= this.cycleTime) {
-                this.usedAbilities.push({
-                    ability: ability,
-                    combinedEffects: combinedEffects,
-                    buffs: buffs,
-                    usedAt: this.nextGcdTime,
-                    damage: abilityToDamage(this.stats, ability, combinedEffects),
-                });
-                // Anim lock OR cast time, both effectively block use of skills.
-                // If cast time > GCD recast, then we use that instead. Also factor in caster tax.
-                const animLock = ability.cast ? Math.max(ability.cast + CASTER_TAX, STANDARD_ANIMATION_LOCK) : STANDARD_ANIMATION_LOCK;
-                const animLockFinishedAt = this.nextGcdTime + animLock;
-                this.currentTime = animLockFinishedAt;
-                // If we're casting a long-cast, then the GCD is blocked for more than a GCD.
-                this.nextGcdTime = Math.max(gcdFinishedAt, animLockFinishedAt);
-            }
-            // GCD will only partially fit into remaining time. Pro-rate the damage.
-            else {
-                const remainingTime = this.cycleTime - this.nextGcdTime;
-                const portion = remainingTime / abilityGcd;
-                this.usedAbilities.push({
-                    ability: ability,
-                    buffs: buffs,
-                    combinedEffects: combinedEffects,
-                    usedAt: this.nextGcdTime,
-                    portion: portion,
-                    damage: abilityToDamage(this.stats, ability, combinedEffects, portion),
-                });
-                this.nextGcdTime = this.cycleTime;
-                this.currentTime = this.cycleTime;
-            }
+            this.useGcd(ability);
         }
         // oGCD logic branch
         else if (ability.type == 'ogcd') {
-            if (this.currentTime > this.cycleTime) {
-                // Already over time limit. Ignore completely.
-                return;
-            }
-            // Similar logic to GCDs, but with animation lock alone
-            const animLock = ability.animationLock ?? STANDARD_ANIMATION_LOCK;
-            const animLockFinishedAt = animLock + this.currentTime;
-            // Fits completely
-            if (animLockFinishedAt <= this.cycleTime) {
-                this.usedAbilities.push({
-                    ability: ability,
-                    buffs: buffs,
-                    combinedEffects: combinedEffects,
-                    usedAt: this.currentTime,
-                    damage: abilityToDamage(this.stats, ability, combinedEffects),
-                });
-                this.currentTime = animLockFinishedAt;
-                // Account for potential GCD clipping
-                this.nextGcdTime = Math.max(this.nextGcdTime, animLockFinishedAt);
-            }
-            // fits partially
-            else {
-                const remainingTime = this.cycleTime - this.currentTime;
-                const portion = remainingTime / animLock;
-                this.usedAbilities.push({
-                    ability: ability,
-                    buffs: buffs,
-                    combinedEffects: combinedEffects,
-                    usedAt: this.currentTime,
-                    portion: portion,
-                    damage: abilityToDamage(this.stats, ability, combinedEffects, portion),
-                });
-                this.nextGcdTime = this.cycleTime;
-                this.currentTime = this.cycleTime;
-            }
+            this.useOgcd(ability);
         }
     }
 
@@ -134,6 +74,99 @@ export class CycleProcessor {
         while (this.nextGcdTime < useUntil) {
             this.use(ability);
         }
+    }
+
+    useGcd(ability: GcdAbility) {
+        if (this.nextGcdTime > this.cycleTime) {
+            // Already over time limit. Ignore completely.
+            return;
+        }
+        if (this.nextGcdTime > this.currentTime) {
+            this.currentTime = this.nextGcdTime;
+        }
+        if (ability.activatesBuffs) {
+            ability.activatesBuffs.forEach(buff => this.activateBuff(buff));
+        }
+        const buffs = this.getActiveBuffs();
+        const combinedEffects: CombinedBuffEffect = combineBuffEffects(buffs);
+        const abilityGcd = ability.fixedGcd ? ability.gcd : (this.stats.gcdMag(ability.gcd ?? this.gcdBase, combinedEffects.haste));
+        // When this GCD will end (strictly in terms of GCD. e.g. a BLM spell where cast > recast will still take the cast time. This will be
+        // accounted for later).
+        const gcdFinishedAt = this.currentTime + abilityGcd;
+        // Enough time for entire GCD
+        if (gcdFinishedAt <= this.cycleTime) {
+            this.usedAbilities.push({
+                ability: ability,
+                combinedEffects: combinedEffects,
+                buffs: buffs,
+                usedAt: this.currentTime,
+                damage: abilityToDamage(this.stats, ability, combinedEffects),
+            });
+            // Anim lock OR cast time, both effectively block use of skills.
+            // If cast time > GCD recast, then we use that instead. Also factor in caster tax.
+            const animLock = ability.cast ? Math.max(ability.cast + CASTER_TAX, STANDARD_ANIMATION_LOCK) : STANDARD_ANIMATION_LOCK;
+            const animLockFinishedAt = this.currentTime + animLock;
+            this.currentTime = animLockFinishedAt;
+            // If we're casting a long-cast, then the GCD is blocked for more than a GCD.
+            this.nextGcdTime = Math.max(gcdFinishedAt, animLockFinishedAt);
+        }
+        // GCD will only partially fit into remaining time. Pro-rate the damage.
+        else {
+            const remainingTime = this.cycleTime - this.nextGcdTime;
+            const portion = remainingTime / abilityGcd;
+            this.usedAbilities.push({
+                ability: ability,
+                buffs: buffs,
+                combinedEffects: combinedEffects,
+                usedAt: this.nextGcdTime,
+                portion: portion,
+                damage: abilityToDamage(this.stats, ability, combinedEffects, portion),
+            });
+            this.nextGcdTime = this.cycleTime;
+            this.currentTime = this.cycleTime;
+        }
+
+    }
+
+    useOgcd(ability: OgcdAbility) {
+        if (this.currentTime > this.cycleTime) {
+            // Already over time limit. Ignore completely.
+            return;
+        }
+        const buffs = this.getActiveBuffs();
+        const combinedEffects: CombinedBuffEffect = combineBuffEffects(buffs);
+        // Similar logic to GCDs, but with animation lock alone
+        const animLock = ability.animationLock ?? STANDARD_ANIMATION_LOCK;
+        const animLockFinishedAt = animLock + this.currentTime;
+        // Fits completely
+        if (animLockFinishedAt <= this.cycleTime) {
+            this.usedAbilities.push({
+                ability: ability,
+                buffs: buffs,
+                combinedEffects: combinedEffects,
+                usedAt: this.currentTime,
+                damage: abilityToDamage(this.stats, ability, combinedEffects),
+            });
+            this.currentTime = animLockFinishedAt;
+            // Account for potential GCD clipping
+            this.nextGcdTime = Math.max(this.nextGcdTime, animLockFinishedAt);
+        }
+        // fits partially
+        else {
+            const remainingTime = this.cycleTime - this.currentTime;
+            const portion = remainingTime / animLock;
+            this.usedAbilities.push({
+                ability: ability,
+                buffs: buffs,
+                combinedEffects: combinedEffects,
+                usedAt: this.currentTime,
+                portion: portion,
+                damage: abilityToDamage(this.stats, ability, combinedEffects, portion),
+            });
+            this.nextGcdTime = this.cycleTime;
+            this.currentTime = this.cycleTime;
+        }
+
     }
 }
 
@@ -170,15 +203,24 @@ export function combineBuffEffects(buffs: Buff[]): CombinedBuffEffect {
 
 export function abilityToDamage(stats: ComputedSetStats, ability: Ability, combinedBuffEffects: CombinedBuffEffect, portion: number = 1): ComputedDamage {
     const basePot = ability.potency;
-    const modifiedStats = {...stats};
-    modifiedStats.critChance += combinedBuffEffects.critChanceIncrease;
-    modifiedStats.dhitChance += combinedBuffEffects.dhitChanceIncrease;
-    const nonCritDmg = baseDamage(modifiedStats, basePot, ability.attackType, ability.autoDh ?? false, ability.autoCrit ?? false);
-    const afterCritDh = applyDhCrit(nonCritDmg, modifiedStats);
-    const afterDmgBuff = afterCritDh * combinedBuffEffects.dmgMod;
-    const afterPortion = afterDmgBuff * portion;
-    return {
-        expected: afterPortion,
+    if (!ability.potency) {
+        return {
+            expected: 0
+        }
+    }
+    else if (ability.potency > 0) {
+        // TODO: messy
+        const dmgAbility = ability as DamagingAbility;
+        const modifiedStats = {...stats};
+        modifiedStats.critChance += combinedBuffEffects.critChanceIncrease;
+        modifiedStats.dhitChance += combinedBuffEffects.dhitChanceIncrease;
+        const nonCritDmg = baseDamage(modifiedStats, basePot, dmgAbility.attackType, dmgAbility.autoDh ?? false, dmgAbility.autoCrit ?? false);
+        const afterCritDh = applyDhCrit(nonCritDmg, modifiedStats);
+        const afterDmgBuff = afterCritDh * combinedBuffEffects.dmgMod;
+        const afterPortion = afterDmgBuff * portion;
+        return {
+            expected: afterPortion,
+        }
     }
 
 }

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -7,7 +7,6 @@ export class CycleProcessor {
 
     nextGcdTime: number = 0;
     currentTime: number = 0;
-    startOfBuffs: number | null = null;
     gcdBase: number = NORMAL_GCD;
     usedAbilities: (UsedAbility | PartiallyUsedAbility)[] = [];
 
@@ -18,26 +17,11 @@ export class CycleProcessor {
      * Get the buffs that would be active right now.
      */
     getActiveBuffs(): Buff[] {
-        if (this.startOfBuffs === null) {
-            return [];
-        }
-        return this.getBuffs(this.nextGcdTime - this.startOfBuffs);
+        return this.allBuffs.filter(buff => (buff.startTime != null) && (this.nextGcdTime > buff.startTime) && (this. nextGcdTime - buff.startTime) < buff.duration);
     }
 
-    /**
-     * Get the buffs that would be active `buffRemainingTime` since the start of the buff window.
-     *
-     * i.e. getBuffs(0) should return everything, getBuffs(15) would return 20 sec buffs but not 15, etc
-     */
-    getBuffs(buffRemainingTime: number): Buff[] {
-        return this.allBuffs.filter(buff => buff.duration > buffRemainingTime);
-    }
-
-    /**
-     * Start the raid buffs
-     */
-    activateBuffs() {
-        this.startOfBuffs = this.currentTime;
+    activateBuff(buff: Buff) {
+        buff.startTime = this.currentTime;
     }
 
     /**

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -23,11 +23,12 @@ export class CycleProcessor {
     getActiveBuffs(): Buff[] {
         var activeBuffs = new Buff[];
         this.buffTimes.forEach((buff, time) =>{
-            if (time === null) continue;
-            if (time > this.nextGcdTime) continue;
-            if ((this.nextGcdTime - time) < buff.duration) {
+            if (time === null) return;
+            if (time > this.nextGcdTime) return;
+            if ((this.currentTime - time) < buff.duration) {
                 activeBuffs.push(buff);
             }
+            return;
         });
         return activeBuffs;
     }

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -9,9 +9,10 @@ export class CycleProcessor {
     currentTime: number = 0;
     gcdBase: number = NORMAL_GCD;
     usedAbilities: (UsedAbility | PartiallyUsedAbility)[] = [];
-    buffTimes: Map<Buff, number|null> = [];
+    buffTimes;
 
     constructor(private cycleTime: number, private allBuffs: Buff[], private stats: ComputedSetStats) {
+        this.buffTimes = new Map<Buff, number | null>();
         this.allBuffs.forEach(function(buff){
             this.buffTimes.set(buff, buff.startTime);
         });
@@ -21,16 +22,15 @@ export class CycleProcessor {
      * Get the buffs that would be active right now.
      */
     getActiveBuffs(): Buff[] {
-        var activeBuffs = new Buff[];
+        var activeBuffs:Buff[];
         this.buffTimes.forEach((buff, time) =>{
             if (time === null) return;
             if (time > this.nextGcdTime) return;
             if ((this.currentTime - time) < buff.duration) {
                 activeBuffs.push(buff);
-            }
-            return;
+            } return;
         });
-        return activeBuffs;
+    return activeBuffs;
     }
 
     activateBuff(buff: Buff) {

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -9,9 +9,9 @@ export class CycleProcessor {
     currentTime: number = 0;
     gcdBase: number = NORMAL_GCD;
     usedAbilities: (UsedAbility | PartiallyUsedAbility)[] = [];
+    buffTimes: Map<Buff, number|null> = [];
 
     constructor(private cycleTime: number, private allBuffs: Buff[], private stats: ComputedSetStats) {
-        var buffTimes = new Map<Buff, number|null>();
         this.allBuffs.forEach(function(buff){
             this.buffTimes.set(buff, buff.startTime);
         });
@@ -23,13 +23,13 @@ export class CycleProcessor {
     getActiveBuffs(): Buff[] {
         var activeBuffs = new Buff[];
         this.buffTimes.forEach((buff, time) =>{
-            if (time == null) continue;
+            if (time === null) continue;
             if (time > this.nextGcdTime) continue;
             if ((this.nextGcdTime - time) < buff.duration) {
-                this.activeBuffs.push(buff);
+                activeBuffs.push(buff);
             }
         });
-        return this.activeBuffs;
+        return activeBuffs;
     }
 
     activateBuff(buff: Buff) {

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -69,7 +69,7 @@ export type BuffEffects = {
     haste?: number,
 }
 
-export type Buff = {
+export type Buff = Readonly<{
     // Name of buff
     name: string,
     // Job of buff
@@ -87,4 +87,4 @@ export type Buff = {
     effects: BuffEffects;
     // Time of usage
     startTime: number | null,
-};
+}>;

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -86,5 +86,5 @@ export type Buff = {
     // The effect(s) of the buff
     effects: BuffEffects;
     // Time of usage
-    startTime: number,
+    startTime: number | null,
 };

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -69,7 +69,7 @@ export type BuffEffects = {
     haste?: number,
 }
 
-export type Buff = Readonly<{
+export type Buff = {
     // Name of buff
     name: string,
     // Job of buff
@@ -85,6 +85,6 @@ export type Buff = Readonly<{
     duration: number,
     // The effect(s) of the buff
     effects: BuffEffects;
-    // Time of first usage
+    // Time of usage
     startTime: number,
-}>;
+};

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -85,4 +85,6 @@ export type Buff = Readonly<{
     duration: number,
     // The effect(s) of the buff
     effects: BuffEffects;
+    // Time of first usage
+    startTime: number,
 }>;

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -2,18 +2,25 @@ import {JobName} from "../xivconstants";
 import {AttackType} from "../geartypes";
 import {CombinedBuffEffect} from "./sim_processors";
 
-export type Ability  = {
-    name: string,
+export type NonDamagingAbility = {
+    potency: null,
+}
+export type DamagingAbility = {
     potency: number,
     attackType: AttackType,
     autoCrit?: boolean,
-    autoDh?: boolean
+    autoDh?: boolean,
 }
+
+export type BaseAbility = Readonly<{
+    name: string,
+    activatesBuffs?: readonly Buff[],
+} & (NonDamagingAbility | DamagingAbility)>;
 
 /**
  * Represents an ability you can use
  */
-export type GcdAbility = Ability & {
+export type GcdAbility = BaseAbility & {
     type: 'gcd';
     /**
      * If the ability's GCD can be lowered by sps/sks, put it here.
@@ -31,10 +38,12 @@ export type GcdAbility = Ability & {
     fixedGcd?: boolean,
 }
 
-export type OgcdAbility = Ability & {
+export type OgcdAbility = BaseAbility & Readonly<{
     type: 'ogcd',
     animationLock?: number,
-}
+}>
+
+export type Ability = GcdAbility | OgcdAbility;
 
 export type ComputedDamage = {
     expected: number,
@@ -70,21 +79,23 @@ export type BuffEffects = {
 }
 
 export type Buff = Readonly<{
-    // Name of buff
+    /** Name of buff */
     name: string,
-    // Job of buff
+    /** Job of buff */
     job: JobName,
-    // "Optional" would be things like DNC partner buffs, where merely having the job
-    // in your comp does not mean you would necessarily get the buff.
+    /** "Optional" would be things like DNC partner buffs, where merely having the job
+    // in your comp does not mean you would necessarily get the buff. */
     optional?: boolean,
-    // Can only apply to self - not a party/targeted buff
+    /** Can only apply to self - not a party/targeted buff */
     selfOnly?: boolean,
-    // Cooldown
+    /** Cooldown */
     cooldown: number,
-    // Duration
+    /** Duration */
     duration: number,
-    // The effect(s) of the buff
+    /** The effect(s) of the buff */
     effects: BuffEffects;
-    // Time of usage
-    startTime: number | null,
+    /**
+     * Time of usage - can be omitted for buffs that would only be used by self and never auto-activated
+     */
+    startTime?: number,
 }>;

--- a/src/scripts/sims/whm_new_sheet_sim.ts
+++ b/src/scripts/sims/whm_new_sheet_sim.ts
@@ -3,8 +3,7 @@ import {CharacterGearSet} from "../gear";
 import {ComputedSetStats} from "../geartypes";
 
 import {quickElement} from "../components/util";
-import {CustomTable, HeaderRow} from "../tables";
-import {GcdAbility, Buff, UsedAbility, OgcdAbility} from "./sim_types";
+import {Buff, GcdAbility, OgcdAbility, UsedAbility} from "./sim_types";
 import {CycleProcessor} from "./sim_processors";
 import {sum} from "../util/array_utils";
 import {BuffSettingsArea, BuffSettingsExport, BuffSettingsManager} from "./party_comp_settings";
@@ -35,16 +34,22 @@ const assize: OgcdAbility = {
     attackType: "Ability"
 }
 
-const pom: Buff = {
-    name: "Presence of Mind",
-    job: "WHM",
-    selfOnly: true,
-    duration: 15,
-    cooldown: 0,
-    effects: { 
-        haste: 20,
-    },
-    startTime: null
+const pom: OgcdAbility = {
+    type: 'ogcd',
+    name: 'Presence of Mind',
+    potency: null,
+    activatesBuffs: [
+        {
+            name: "Presence of Mind",
+            job: "WHM",
+            selfOnly: true,
+            duration: 15,
+            cooldown: 120,
+            effects: {
+                haste: 20,
+            },
+        }
+    ]
 }
 
 const misery: GcdAbility = {
@@ -69,11 +74,11 @@ class WhmSimContext {
     }
 
     getResult(): WhmSheetSimResult {
-        const cp = new CycleProcessor(120, [pom, ...this.allBuffs], this.stats);
+        const cp = new CycleProcessor(120, this.allBuffs, this.stats);
         cp.use(dia);
         cp.use(filler);
         cp.use(filler);
-        cp.activateBuff(pom);
+        cp.useOgcd(pom);
         cp.use(filler);
         cp.use(assize);
         cp.use(misery);

--- a/src/scripts/sims/whm_new_sheet_sim.ts
+++ b/src/scripts/sims/whm_new_sheet_sim.ts
@@ -43,7 +43,8 @@ const pom: Buff = {
     cooldown: 0,
     effects: { 
         haste: 20,
-    }
+    },
+    startTime: null
 }
 
 const misery: GcdAbility = {
@@ -72,7 +73,7 @@ class WhmSimContext {
         cp.use(dia);
         cp.use(filler);
         cp.use(filler);
-        cp.activateBuffs();
+        cp.activateBuff(pom);
         cp.use(filler);
         cp.use(assize);
         cp.use(misery);

--- a/src/scripts/simulation.ts
+++ b/src/scripts/simulation.ts
@@ -7,6 +7,7 @@ import {CustomTable} from "./tables";
 import {camel2title} from "./util/strutils";
 import {sgeNewSheetSpec} from "./sims/sge_sheet_sim_mk2";
 import {astNewSheetSpec} from "./sims/ast_sheet_sim";
+import {schNewSheetSpec} from "./sims/sch_sheet_sim";
 
 export interface SimResult {
     mainDpsResult: number;
@@ -183,3 +184,4 @@ registerSim(whmSheetSpec);
 registerSim(sgeSheetSpec);
 registerSim(sgeNewSheetSpec);
 registerSim(astNewSheetSpec);
+registerSim(schNewSheetSpec);

--- a/src/scripts/xivconstants.ts
+++ b/src/scripts/xivconstants.ts
@@ -39,6 +39,8 @@ export const MAX_ILVL = 999;
 export const MATERIA_ACCEPTABLE_OVERCAP_LOSS = 2;
 
 export const STANDARD_ANIMATION_LOCK = 0.6;
+
+export const CAST_SNAPSHOT_PRE = 0.5;
 export const CASTER_TAX = 0.1;
 
 /**

--- a/src/style.less
+++ b/src/style.less
@@ -1743,6 +1743,8 @@ buff-settings-area {
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
+      line-height: 0;
+      height: 20px;
 
       &[col-id='time'] {
         text-align: right;


### PR DESCRIPTION
Builds off of https://github.com/xiv-gear-planner/gear-planner/pull/13

Mayceia reworked the buff processing so that each buff can have a unique activation time, and you no longer need to call `activateBuffs`. This takes that work and adds more handling for buffs being applied by the class being simmed.

Cycle processor abilities can now indicate that they apply a specific buff. This buff can be a pre-existing raid-buff, or a buff unique to that ability (in which case, it can simply be defined inline a la PoM). If it is a normal raid buff (i.e. shows up in the buff picker UI), then it should be passed into the `manuallyActivatedBuffs` parameter of `CycleProcessor`. This will omit them from the normal buff activation. 

This PR also improves behavior with regards to when buffs are checked. For hard-cast abilities, haste buffs must be considered when the cast starts, but everything else must be considered when the ability snapshots (i.e. at the slidecast window).