### PR TITLE
Rpr support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /build/
 /dist/
 .idea/*.xml
+.vs/

--- a/src/scripts/sims/ast_sheet_sim.ts
+++ b/src/scripts/sims/ast_sheet_sim.ts
@@ -63,7 +63,8 @@ const astrodyne: OgcdAbility = {
             },
             startTime: null,
         }
-    ]
+    ],
+    attackType: "Ability",
 }
 
 export interface AstSheetSimResult extends CycleSimResult {

--- a/src/scripts/sims/buffs.ts
+++ b/src/scripts/sims/buffs.ts
@@ -57,6 +57,18 @@ export const ArcaneCircle = {
     startTime: 5,
 } as const satisfies Buff;
 
+export const DeathsDesign = {
+    name: "Death's Design",
+    job: "RPR",
+    duration: 60, // this is a hack to make up for the fact that the duration is stackable.
+                  // Needs to be changed if simulating dropping DD is desired.
+    cooldown: 0,
+    effects: {
+        dmgIncrease: 0.1
+    },
+    startTime: 0,
+} as const satisfies Buff;
+
 export const SearingLight = {
     name: "Searing Light",
     job: "SMN",

--- a/src/scripts/sims/rpr_sheet_sim.ts
+++ b/src/scripts/sims/rpr_sheet_sim.ts
@@ -1,0 +1,508 @@
+import { updateSourceFile } from "typescript";
+import { Simulation, SimSpec, SimResult, SimSettings } from "../simulation";
+import { JobName, STANDARD_ANIMATION_LOCK } from "../xivconstants";
+import { ArcaneCircle, DeathsDesign } from "./buffs";
+import { BaseMultiCycleSim, CycleSimResult, ExternalCycleSettings, Rotation, CycleProcessor } from "./sim_processors";
+import { BuffEffects, Ability, GcdAbility, OgcdAbility } from "./sim_types";
+
+const slice: GcdAbility = {
+    type: 'gcd',
+    name: "Slice",
+    id: 24373,
+    potency: 320,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
+const waxingSlice: GcdAbility = {
+    type: 'gcd',
+    name: "Waxing Slice",
+    id: 24374,
+    potency: 400,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
+const infernalSlice: GcdAbility = {
+    type: 'gcd',
+    name: "Infernal Slice",
+    id: 24375,
+    potency: 500,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
+const SoD: GcdAbility = {
+    type: 'gcd',
+    name: "Shadow of Death",
+    id: 24378,
+    potency: 300,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0,
+    activatesBuffs: [DeathsDesign]
+}
+const harpe: GcdAbility = {
+    type: 'gcd',
+    name: "Harpe",
+    id: 24386,
+    potency: 300,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 1.3
+}
+const gibbet: GcdAbility = {
+    type: 'gcd',
+    name: "Gibbet",
+    id: 24382,
+    potency: 520,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
+const gallows: GcdAbility = {
+    type: 'gcd',
+    name: "Gallows",
+    id: 24383,
+    potency: 520,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
+const soulSlice: GcdAbility = {
+    type: 'gcd',
+    name: "Soul Slice",
+    id: 24380,
+    potency: 460,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
+const pharvest: GcdAbility = {
+    type: 'gcd',
+    name: "Plentiful Harvest",
+    id: 24385,
+    potency: 1000,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
+const harvestMoon: GcdAbility = {
+    type: 'gcd',
+    name: "Harvest Moon",
+    id: 24388,
+    potency: 600,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0,
+}
+
+const communio: GcdAbility = {
+    type: 'gcd',
+    name: "Communio",
+    id: 24398,
+    potency: 1100,
+    attackType: "Spell",
+    gcd: 2.5,
+    cast: 1.3,
+}
+const voidReaping: GcdAbility = {
+    type: 'gcd',
+    name: "Void Reaping",
+    id: 24395,
+    potency: 520,
+    attackType: "Weaponskill",
+    gcd: 1.5,
+    cast: 0
+}
+const crossReaping: GcdAbility = {
+    type: 'gcd',
+    name: "Cross Reaping",
+    id: 24396,
+    potency: 520,
+    attackType: "Weaponskill",
+    gcd: 1.5,
+    cast: 0
+}
+const gluttony: OgcdAbility = {
+    type: 'ogcd',
+    name: "Gluttony",
+    id: 24393,
+    potency: 520,
+    attackType: "Ability",
+}
+const unveiledGibbet: OgcdAbility = {
+    type: 'ogcd',
+    name: "Unveiled Gibbet",
+    id: 24390,
+    potency: 400,
+    attackType: "Ability",
+}
+const unveiledGallows: OgcdAbility = {
+    type: 'ogcd',
+    name: "Unveiled Gallows",
+    id: 24391,
+    potency: 400,
+    attackType: "Ability",
+}
+const lemuresSlice: OgcdAbility = {
+    type: 'ogcd',
+    name: "Lemure's Slice",
+    id: 24399,
+    potency: 240,
+    attackType: "Ability",
+}
+const arcaneCircle: OgcdAbility = {
+    type: 'ogcd',
+    name: "Arcane Circle",
+    id: 24405,
+    activatesBuffs: [ArcaneCircle],
+    potency: null,
+    attackType: "Ability",
+}
+
+export interface RprSheetSimResult extends CycleSimResult {}
+
+interface RprNewSheetSettings extends SimSettings {
+
+}
+
+export interface RprNewSheetSettingsExternal extends ExternalCycleSettings<RprNewSheetSettings> {}
+
+
+export const rprNewSheetSpec: SimSpec<RprSheetSim, RprNewSheetSettings> = {
+    stub: "rpr-sheet-sim",
+    displayName: "RPR Sim",
+    makeNewSimInstance: function (): RprSheetSim {
+        return new RprSheetSim();
+    },
+    loadSavedSimInstance: function (exported: RprNewSheetSettingsExternal) {
+        return new RprSheetSim(exported);
+    },
+    supportedJobs: ['RPR']
+
+}
+
+class RotationState {
+    private _combo: number = 0;
+    get combo() {return this._combo};
+    set combo(newCombo) {
+        this._combo = newCombo;
+        if (this._combo >= 3) this._combo = 0;
+    }
+
+    private _soulGauge: number = 0;
+    get soulGauge() {return this._soulGauge}
+    set soulGauge(newGauge: number) { this._soulGauge = Math.max(Math.min(newGauge, 100), 0); }
+
+    private _shroudGauge: number = 0;
+    get shroudGauge() {return this._shroudGauge}
+    set shroudGauge(newGauge: number) { this._shroudGauge = Math.max(Math.min(newGauge, 100), 0); }
+
+    oddShroudUsed: boolean = false;
+
+    spendSoul() {
+        if (this.soulGauge >= 50) {
+            this.soulGauge -= 50;
+        }
+
+        this.shroudGauge += 10;
+    }
+
+    // CD/SoD refresh tracking
+    cdTracker: CooldownTracker = new CooldownTracker();
+
+    //We don't refresh SoD going into double enshroud, so we keep track of them
+    // to stop refreshing after the 4th
+    sodNumber = 0;
+
+    nextGibGal = gallows.name;
+
+    gibGalSwap() {
+        if (this.nextGibGal == gallows.name) this.nextGibGal = gibbet.name;
+        else this.nextGibGal = gallows.name;
+    }
+
+    spendSoulThreshold = 100;
+}
+
+class CooldownTracker {
+
+    // Entries have the value [cooldown, timeLastUsed]
+    lastUsedTimes: { [ability: string]: [number, number] } = {
+        "Arcane Circle": [120, 0],
+        "Gluttony": [60, 0],
+        "Soul Slice": [30, 0],
+    }
+
+    sodCoverage: number = 0;
+
+    use(cp: CycleProcessor, ability: Ability) {
+        this.lastUsedTimes[ability.name][1] = cp.currentTime;
+    }
+
+    isOffCD(cp: CycleProcessor, ability: Ability) : boolean {
+        let abilityTime = this.lastUsedTimes[ability.name];
+        return (cp.currentTime - abilityTime[1]) >= abilityTime[0];
+    }
+
+    remainingCd(cp: CycleProcessor, ability: Ability) : number {
+        let abilityTimes = this.lastUsedTimes[ability.name];
+        return abilityTimes[1] + abilityTimes[0] - cp.currentTime;
+    }
+
+    willBeUsableBeforeNextGcd(cp: CycleProcessor, ability: OgcdAbility) : boolean {
+        let abilityTimes = this.lastUsedTimes[ability.name];
+        return (abilityTimes[1] + abilityTimes[0] + (ability.animationLock ?? STANDARD_ANIMATION_LOCK) < cp.nextGcdTime)
+    }
+}
+
+
+export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprNewSheetSettings> {
+    
+    spec = rprNewSheetSpec;
+    shortName: "rpr-sheet-sim";
+    displayName = rprNewSheetSpec.displayName;
+    manuallyActivatedBuffs = [ArcaneCircle];
+
+    rotationState: RotationState = new RotationState();
+    readonly comboActions: GcdAbility[] = [slice, waxingSlice, infernalSlice];
+    
+    constructor(settings?: RprNewSheetSettingsExternal) {
+        super('RPR', settings);
+    }
+
+    makeDefaultSettings(): RprNewSheetSettings {
+        return {};
+    }
+
+
+    useCombo(cp: CycleProcessor) {
+        cp.useGcd(this.comboActions[this.rotationState.combo++])
+        this.rotationState.soulGauge += 10;
+    }
+
+    getGibGal(): [OgcdAbility, GcdAbility] {
+        if (this.rotationState.nextGibGal == gallows.name) return [unveiledGallows, gallows]
+        else return [unveiledGibbet, gibbet];
+    }
+
+    // Needs a weave slot in the gcd
+    useGibGal(cp: CycleProcessor) {
+        
+        if (this.rotationState.soulGauge < 50) {
+            console.error("Tried to use Gibbet/Gallows with <50 soul at " + cp.currentTime);
+            return;
+        }
+
+        let toUse = this.getGibGal();
+        cp.use(toUse[0]);
+        cp.use(toUse[1]);
+
+        this.rotationState.gibGalSwap();
+        this.rotationState.soulGauge -= 50;
+        this.rotationState.shroudGauge += 10;
+    }
+
+    useEnshroud(cp: CycleProcessor) {
+
+        if (this.rotationState.shroudGauge < 50) {
+            console.error("Tried to enter enshroud with < 50 shroud gauge at " + cp.currentTime.toString());
+            return;
+        }
+        this.rotationState.shroudGauge -= 50;
+        cp.useGcd(voidReaping);
+        cp.useGcd(crossReaping);
+        cp.useOgcd(lemuresSlice);
+        cp.useGcd(voidReaping);
+        cp.useGcd(crossReaping);
+        cp.useOgcd(lemuresSlice);
+        cp.useGcd(communio);
+    }
+    
+    useDoubleEnshroudBurst(cp: CycleProcessor) {
+
+        if (this.rotationState.shroudGauge < 50) {
+            console.error("Tried to enter double shroud with < 50 shroud gauge at " + cp.currentTime);
+            return;
+        }
+        this.rotationState.shroudGauge -= 50;
+
+        cp.useGcd(voidReaping);
+        this.useSoD(cp);
+        cp.useGcd(crossReaping);
+        this.useSoD(cp);
+        this.useArcaneCircle(cp);
+        cp.useGcd(voidReaping);
+        cp.useOgcd(lemuresSlice);
+        cp.useGcd(crossReaping);
+        cp.useOgcd(lemuresSlice);
+        cp.useGcd(communio);
+        this.usePlentifulHarvest(cp);
+
+        this.useEnshroud(cp);
+        this.rotationState.sodNumber = 0;
+    }
+
+    useArcaneCircle(cp: CycleProcessor) {
+        
+        cp.useOgcd(arcaneCircle);
+        this.rotationState.cdTracker.use(cp, arcaneCircle);
+    }
+    useSoD(cp: CycleProcessor) {
+        cp.use(SoD);
+        this.rotationState.cdTracker.sodCoverage += 30;
+        this.rotationState.sodNumber++;
+    }
+
+    useGluttony(cp: CycleProcessor) {
+
+        if (this.rotationState.soulGauge < 50) {
+            console.error("Tried to use Gluttony with <50 soul at " + cp.currentTime);
+            return;
+        }
+
+        cp.useOgcd(gluttony);
+        this.rotationState.cdTracker.use(cp, gluttony);
+        this.rotationState.soulGauge -= 50;
+
+        cp.useGcd(this.getGibGal()[1]);
+        this.rotationState.gibGalSwap();
+        cp.useGcd(this.getGibGal()[1]);
+        this.rotationState.gibGalSwap();
+
+        this.rotationState.shroudGauge += 20;
+    }
+    useSoulSlice(cp: CycleProcessor) {
+        cp.useGcd(soulSlice);
+        this.rotationState.cdTracker.lastUsedTimes[soulSlice.name][1] += 30;
+        this.rotationState.soulGauge += 50;
+    }
+
+    usePlentifulHarvest(cp: CycleProcessor) {
+        cp.useGcd(pharvest);
+        this.rotationState.shroudGauge += 50;
+    }
+
+    // This function expects to be called immediately after a gcd is used.
+    // Might not work right if used right after an ogcd
+    useFiller(cp: CycleProcessor) {
+        
+        //This assumes that if we can weave gluttony, it will be the only weave.
+        // If that's not the case then this needs to be revisited
+        if (this.rotationState.cdTracker.willBeUsableBeforeNextGcd(cp, gluttony) &&
+            this.rotationState.soulGauge >= 50) {
+            
+            cp.currentTime += this.rotationState.cdTracker.remainingCd(cp, gluttony);
+            this.useGluttony(cp);
+            this.rotationState.spendSoulThreshold = 150 - this.rotationState.spendSoulThreshold;
+            return;
+        }
+
+        // If SS is available the gcd after next one, use unveiled > gibgal to not overcap
+        if (cp.currentTime + this.rotationState.cdTracker.remainingCd(cp, soulSlice) < cp.nextGcdTime + cp.stats.gcdPhys(cp.gcdBase) &&
+            this.rotationState.soulGauge >= 50) {
+            this.useGibGal(cp); 
+            return;
+        }
+
+        // use SS if its off cd
+        if (this.rotationState.cdTracker.isOffCD(cp, soulSlice)) {
+            this.useSoulSlice(cp);
+            return;
+        }
+
+        // use SoD if off CD
+        if (this.rotationState.cdTracker.sodCoverage - cp.currentTime < 30
+            && this.rotationState.sodNumber <= 3) { // don't refresh SoD before double shroud
+            
+            this.useSoD(cp);
+            return;
+        }
+
+        // use odd enshroud at some point when available
+        if (this.rotationState.shroudGauge >= 50
+            && !this.rotationState.oddShroudUsed
+            && this.rotationState.cdTracker.remainingCd(cp, gluttony) > 8.5 + cp.stats.gcdPhys(cp.gcdBase)) {
+            
+            this.useEnshroud(cp);
+            this.rotationState.oddShroudUsed = true;
+            return;
+        }
+
+        // Spend soul. We spend at 100 before odd gluttony to make sure we have enough gauge,
+        // and then spend at 50 after odd gluttony to make sure we have shroud to do burst
+        if (this.rotationState.soulGauge >= this.rotationState.spendSoulThreshold) {
+            this.useGibGal(cp);
+            return;
+        }
+        
+        this.useCombo(cp);
+    }
+
+
+    getRotationsToSimulate(): Rotation[] {
+        let sim = this;
+        this.rotationState = new RotationState();
+        return [{
+            cycleTime: 120,
+
+            /* I just used the cycle processor instead of doing any cycles, as doing so
+             * would require me to duplicate all of the 'useX(cp)' functions for CycleContext
+             * Is there a better way to do this?
+            */
+            apply(cp: CycleProcessor) {
+
+                console.log("total: " + cp.totalTime);
+                cp.useGcd(harpe);
+
+                //Early shroud opener. Make customizable? (probably not worth unless we wanna sim downtime or very short KTs)
+                //this.useSoD(cp);
+                sim.useSoD(cp);
+                cp.useOgcd(arcaneCircle);
+                cp.useGcd(soulSlice);
+                sim.rotationState.cdTracker.use(cp, soulSlice);
+                sim.rotationState.soulGauge += 50;
+                cp.useGcd(soulSlice);
+                sim.rotationState.soulGauge += 50;
+                sim.usePlentifulHarvest(cp);
+                sim.useEnshroud(cp);
+                sim.useGluttony(cp);
+                sim.useGibGal(cp);
+
+                // 3 + 2*gcd + animlock is (2 reapings) + (gcd before enshroud and first Sod) + (animlock form 2nd SoD)
+                while (sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle) > 9.6) {
+                    sim.useFiller(cp);
+                }
+
+                sim.useCombo(cp);
+                sim.useCombo(cp);
+                
+                while (cp.remainingGcdTime > 0) {
+                    console.log("Double shroud, AC CD: " + sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle));
+                    sim.useDoubleEnshroudBurst(cp);
+                    if (sim.rotationState.combo != 0) {
+                        sim.useCombo(cp);
+                    }
+                    while (cp.remainingGcdTime > 0 &&
+                        sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle) > 9.6) {
+
+                        sim.useFiller(cp);
+                        console.log("AC CD: " + sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle));
+                    }
+                }
+                /*
+                cp.remainingCycles(cycle => {
+                    sim.useDoubleEnshroudBurst(cp);
+
+                    // 3 + 2*gcd + animlock is (2 reapings) + (gcd before enshroud and first Sod) + (animlock form 2nd SoD)
+                    while (sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle) > 3 + 2 * cp.gcdBase + STANDARD_ANIMATION_LOCK) {
+                        sim.useFiller(cp);
+                    }
+                })
+                */
+            }
+
+        }]
+    }
+} 

--- a/src/scripts/sims/rpr_sheet_sim.ts
+++ b/src/scripts/sims/rpr_sheet_sim.ts
@@ -51,6 +51,15 @@ const harpe: GcdAbility = {
     gcd: 2.5,
     cast: 1.3
 }
+const unbuffedGallows: GcdAbility = {
+    type: 'gcd',
+    name: "Gallows",
+    id: 24383,
+    potency: 460,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 0
+}
 const gibbet: GcdAbility = {
     type: 'gcd',
     name: "Gibbet",
@@ -105,6 +114,15 @@ const communio: GcdAbility = {
     attackType: "Spell",
     gcd: 2.5,
     cast: 1.3,
+}
+const unbuffedVoidReaping: GcdAbility = {
+    type: 'gcd',
+    name: "Void Reaping",
+    id: 24395,
+    potency: 460,
+    attackType: "Weaponskill",
+    gcd: 1.5,
+    cast: 0
 }
 const voidReaping: GcdAbility = {
     type: 'gcd',
@@ -311,7 +329,7 @@ export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprNewShee
             return;
         }
         this.rotationState.shroudGauge -= 50;
-        cp.useGcd(voidReaping);
+        cp.useGcd(unbuffedVoidReaping);
         cp.useGcd(crossReaping);
         cp.useOgcd(lemuresSlice);
         cp.useGcd(voidReaping);
@@ -328,7 +346,7 @@ export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprNewShee
         }
         this.rotationState.shroudGauge -= 50;
 
-        cp.useGcd(voidReaping);
+        cp.useGcd(unbuffedVoidReaping);
         this.useSoD(cp);
         cp.useGcd(crossReaping);
         this.useSoD(cp);
@@ -342,6 +360,7 @@ export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprNewShee
 
         this.useEnshroud(cp);
         this.rotationState.sodNumber = 0;
+        this.rotationState.oddShroudUsed = false;
     }
 
     useArcaneCircle(cp: CycleProcessor) {
@@ -467,11 +486,20 @@ export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprNewShee
                 sim.rotationState.soulGauge += 50;
                 sim.usePlentifulHarvest(cp);
                 sim.useEnshroud(cp);
-                sim.useGluttony(cp);
+                
+                // Do gluttony manually to insert the unbuffed gallows
+                cp.use(gluttony);
+                cp.use(unbuffedGallows);
+                cp.use(gibbet);
+                sim.rotationState.soulGauge -= 50;
+                sim.rotationState.shroudGauge += 20;
+                
                 sim.useGibGal(cp);
 
                 // 3 + 2*gcd + animlock is (2 reapings) + (gcd before enshroud and first Sod) + (animlock form 2nd SoD)
-                while (sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle) > 9.6) {
+                while (cp.remainingGcdTime > 0 &&
+                    sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle) > 9.6) {
+
                     sim.useFiller(cp);
                 }
 
@@ -479,7 +507,6 @@ export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprNewShee
                 sim.useCombo(cp);
                 
                 while (cp.remainingGcdTime > 0) {
-                    console.log("Double shroud, AC CD: " + sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle));
                     sim.useDoubleEnshroudBurst(cp);
                     if (sim.rotationState.combo != 0) {
                         sim.useCombo(cp);
@@ -488,19 +515,8 @@ export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprNewShee
                         sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle) > 9.6) {
 
                         sim.useFiller(cp);
-                        console.log("AC CD: " + sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle));
                     }
                 }
-                /*
-                cp.remainingCycles(cycle => {
-                    sim.useDoubleEnshroudBurst(cp);
-
-                    // 3 + 2*gcd + animlock is (2 reapings) + (gcd before enshroud and first Sod) + (animlock form 2nd SoD)
-                    while (sim.rotationState.cdTracker.remainingCd(cp, arcaneCircle) > 3 + 2 * cp.gcdBase + STANDARD_ANIMATION_LOCK) {
-                        sim.useFiller(cp);
-                    }
-                })
-                */
             }
 
         }]

--- a/src/scripts/sims/sch_sheet_sim.ts
+++ b/src/scripts/sims/sch_sheet_sim.ts
@@ -25,7 +25,8 @@ const chain: OgcdAbility = {
     name: "Chain",
     id: 7436,
     activatesBuffs: [Chain],
-    potency: null
+    potency: null,
+    attackType: "Ability",
 }
 
 const r2: GcdAbility = {

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -353,7 +353,10 @@ export class CycleProcessor {
         const gcdStartsAt = this.currentTime;
         const preBuffs = this.getActiveBuffs();
         const preCombinedEffects: CombinedBuffEffect = combineBuffEffects(preBuffs);
-        const abilityGcd = ability.fixedGcd ? ability.gcd : (this.stats.gcdMag(ability.gcd ?? this.gcdBase, preCombinedEffects.haste));
+        const abilityGcd = ability.fixedGcd ? ability.gcd :
+            (ability.attackType == "Spell") ? 
+                (this.stats.gcdMag(ability.gcd ?? this.gcdBase, preCombinedEffects.haste)) :
+                (this.stats.gcdPhys(ability.gcd ?? this.gcdBase, preCombinedEffects.haste));
         const snapshotsAt = ability.cast ? Math.max(this.currentTime, this.currentTime + ability.cast - CAST_SNAPSHOT_PRE) : this.currentTime;
         // When this GCD will end (strictly in terms of GCD. e.g. a BLM spell where cast > recast will still take the cast time. This will be
         // accounted for later).

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -23,6 +23,7 @@ export type BaseAbility = Readonly<{
     name: string,
     activatesBuffs?: readonly Buff[],
     id?: number
+    attackType: AttackType,
 } & (NonDamagingAbility | DamagingAbility)>;
 
 /**

--- a/src/scripts/sims/whm_new_sheet_sim.ts
+++ b/src/scripts/sims/whm_new_sheet_sim.ts
@@ -48,7 +48,8 @@ const pom: OgcdAbility = {
                 haste: 20,
             },
         }
-    ]
+    ],
+    attackType: "Ability"
 }
 
 const misery: GcdAbility = {

--- a/src/scripts/simulation.ts
+++ b/src/scripts/simulation.ts
@@ -9,6 +9,7 @@ import {sgeNewSheetSpec} from "./sims/sge_sheet_sim_mk2";
 import {astNewSheetSpec} from "./sims/ast_sheet_sim";
 import {schNewSheetSpec} from "./sims/sch_sheet_sim";
 import {whmNewSheetSpec} from "./sims/whm_new_sheet_sim";
+import { rprNewSheetSpec } from "./sims/rpr_sheet_sim";
 
 export interface SimResult {
     mainDpsResult: number;
@@ -190,3 +191,4 @@ registerSim(sgeNewSheetSpec);
 registerSim(astNewSheetSpec);
 registerSim(schNewSheetSpec);
 registerSim(whmNewSheetSpec);
+registerSim(rprNewSheetSpec);


### PR DESCRIPTION
Initial support for reaper.

uses the Multicycle class to simulate the rotation

This includes a change to how `CycleProcessor.useGcd` calculates the gcd, because it previously just used `stats.gcdMag`. This required adding `attackType` to `Ability`, in addition to just `DamagingAbility`, because not all gcds are damaging (e.g. Healing spells, Form shift, NIN mudras, Dances). There's probably a much better way to implement it than duplicating the field in `Ability` that i'd be down to implement, i'd just need a bit of guidance on how to do so. I modified the other sim sheets to include the new field.

Death's design was also added as a buff. i gave it a 1min duration for the time being because it shakes out the same and not mattering as long as the rotation is done right. I'm not sure if this was the best way to implement this, but I am not certain how to handle the buff being 30s, with the duration stacking up to 60s 