### PR TITLE
More oneshot buff support

### DIFF
--- a/src/scripts/sims/common/swiftcast.ts
+++ b/src/scripts/sims/common/swiftcast.ts
@@ -1,6 +1,7 @@
 import {Ability, Buff, BuffController, OgcdAbility} from "../sim_types";
 
 export const SwiftcastBuff: Buff = {
+    // TODO: can this field be made optional for buffs that are never automatic?
     cooldown: 60,
     duration: 10,
     effects: {},

--- a/src/scripts/sims/common/utils.ts
+++ b/src/scripts/sims/common/utils.ts
@@ -1,0 +1,5 @@
+import {BuffController} from "../sim_types";
+
+export function removeSelf(controller: BuffController): void {
+    controller.removeSelf();
+}

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -171,10 +171,33 @@ export type FinalizedAbility = {
     buffs: Buff[]
 }
 
+/**
+ * Describes the effects of a buff
+ */
 export type BuffEffects = {
+    /**
+     * Damage increase. e.g. 0.2 = 20% increase
+     */
     dmgIncrease?: number,
+    /**
+     * Crit chance increase, e.g. 0.2 = 20% increase
+     */
     critChanceIncrease?: number,
+    /**
+     * Dhit chance increase, e.g. 0.2 = 20% increase
+     */
     dhitChanceIncrease?: number,
+    /**
+     * Force a crit
+     */
+    forceCrit?: boolean,
+    /**
+     * Force a DH
+     */
+    forceDhit?: boolean,
+    /**
+     * Haste. Expressed as the percentage value, e.g. 20 = 20% faster GCD
+     */
     haste?: number,
 }
 
@@ -183,6 +206,7 @@ export type BuffController = {
     removeSelf(): void;
 }
 
+// TODO: refactor this into Buff and PartyBuff so that the fields used for the party buffs (job, CD) can be untangled
 export type Buff = Readonly<{
     /** Name of buff */
     name: string,
@@ -204,6 +228,13 @@ export type Buff = Readonly<{
      */
     startTime?: number,
     /**
+     * Filter what abilities this buff applies to
+     *
+     * @param ability The ability that is being used
+     * @returns whether this buff should apply to this ability
+     */
+    appliesTo?(ability: Ability): boolean,
+    /**
      * Optional function to run before an ability is used. This can be used for buffs that have special
      * effects which trigger when using an ability, e.g. Swiftcast/Dualcast.
      *
@@ -212,7 +243,7 @@ export type Buff = Readonly<{
      * have already been modified.
      * @returns The ability, if the buff needs to modify some properties of the ability. Null if no modification.
      */
-    beforeAbility?<X extends Ability>(controller: BuffController, ability: X): X | null,
+    beforeAbility?<X extends Ability>(controller: BuffController, ability: X): X | void,
     /**
      * Modify an ability before it snapshots. If the ability is instant, this is not much different from
      * beforeAbility.
@@ -222,7 +253,7 @@ export type Buff = Readonly<{
      * have already been modified.
      * @returns The ability, if the buff needs to modify some properties of the ability. Null if no modification.
      */
-    beforeSnapshot?<X extends Ability>(controller: BuffController, ability: X): X | null,
+    beforeSnapshot?<X extends Ability>(controller: BuffController, ability: X): X | void,
     /**
      * Modify the final damage dealt by an ability.
      *
@@ -232,7 +263,7 @@ export type Buff = Readonly<{
      * @param ability The ability
      * @returns The modified damage, or null if it does not need to be modified
      */
-    modifyDamage?(controller: BuffController, damageResult: DamageResult, ability: Ability): DamageResult | null,
+    modifyDamage?(controller: BuffController, damageResult: DamageResult, ability: Ability): DamageResult | void,
     /**
      * Optional status effect ID. Used to provide an icon.
      */

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -1,6 +1,6 @@
 import {JobName} from "../xivconstants";
 import {AttackType} from "../geartypes";
-import {CombinedBuffEffect} from "./sim_processors";
+import {CombinedBuffEffect, DamageResult} from "./sim_processors";
 
 export type DotInfo = Readonly<{
     duration: number,
@@ -180,6 +180,7 @@ export type BuffEffects = {
 
 export type BuffController = {
     removeStatus(buff: Buff): void;
+    removeSelf(): void;
 }
 
 export type Buff = Readonly<{
@@ -206,9 +207,32 @@ export type Buff = Readonly<{
      * Optional function to run before an ability is used. This can be used for buffs that have special
      * effects which trigger when using an ability, e.g. Swiftcast/Dualcast.
      *
+     * @param controller A controller which lets you perform actions such as removing buffs.
+     * @param ability The original ability, unless it has already been modified by other hooks, in which case it may
+     * have already been modified.
      * @returns The ability, if the buff needs to modify some properties of the ability. Null if no modification.
      */
     beforeAbility?<X extends Ability>(controller: BuffController, ability: X): X | null,
+    /**
+     * Modify an ability before it snapshots. If the ability is instant, this is not much different from
+     * beforeAbility.
+     *
+     * @param controller A controller which lets you perform actions such as removing buffs.
+     * @param ability The original ability, unless it has already been modified by other hooks, in which case it may
+     * have already been modified.
+     * @returns The ability, if the buff needs to modify some properties of the ability. Null if no modification.
+     */
+    beforeSnapshot?<X extends Ability>(controller: BuffController, ability: X): X | null,
+    /**
+     * Modify the final damage dealt by an ability.
+     *
+     * @param controller A controller which lets you perform actions such as removing buffs.
+     * @param damageResult The damage result. May have other status effect modifiers already applied. This is the
+     * post-calculation damage, after gear, plain damage buffs has been considered.
+     * @param ability The ability
+     * @returns The modified damage, or null if it does not need to be modified
+     */
+    modifyDamage?(controller: BuffController, damageResult: DamageResult, ability: Ability): DamageResult | null,
     /**
      * Optional status effect ID. Used to provide an icon.
      */

--- a/src/scripts/test/sim_tests.ts
+++ b/src/scripts/test/sim_tests.ts
@@ -667,7 +667,7 @@ const bristleBuff: Buff = {
     job: 'BLU',
     name: "Bristle",
     beforeSnapshot: removeSelf,
-    appliesTo: ability => ability.attackType === "Spell",
+    appliesTo: ability => ability.attackType === "Spell" && ability.potency !== null,
 }
 
 const bristle: GcdAbility = {
@@ -689,7 +689,7 @@ const bristleBuff2: Buff = {
     job: 'BLU',
     name: "Bristle",
     modifyDamage(buffController: BuffController, damageResult: DamageResult, ability: Ability): DamageResult | void {
-        if (ability.attackType === 'Spell') {
+        if (ability.attackType === 'Spell' && ability.potency !== null) {
             buffController.removeSelf();
             return multiplyDamage(damageResult, 1.5, true, true);
         }


### PR DESCRIPTION
- Adds supports for buffs removing themselves arfter snapshot or damage calc
- Allows buffs to modify final damage
- Adds buffs to filter which abilities they will apply to
- Adds support for buffs forcing a crit or dh

Closes #44 