### PR TITLE
Custom cycle processor support

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build": "webpack --mode=development",
     "buildprod": "webpack --mode=production",
     "docs": "typedoc --readme API_DOC.md --out dist/docs --entryPointStrategy expand src/scripts/",
-    "test": "ts-mocha src/scripts/test/*test.ts src/scripts/test/*tests.ts"
+    "test": "ts-mocha src/scripts/test/**/*test.ts src/scripts/test/**/*tests.ts"
   },
   "browser": {
     "[module-name]": false

--- a/src/scripts/sims/sim_processors.ts
+++ b/src/scripts/sims/sim_processors.ts
@@ -3,7 +3,8 @@ import {applyDhCrit, baseDamage} from "../xivmath";
 import {
     Ability,
     AutoAttack,
-    Buff, BuffController,
+    Buff,
+    BuffController,
     ComputedDamage,
     Cooldown,
     DamagingAbility,
@@ -898,12 +899,12 @@ export type ExternalCycleSettings<InternalSettingsType extends SimSettings> = {
     cycleSettings: CycleSettings;
 }
 
-export type Rotation = {
+export type Rotation<CycleProcessorType = CycleProcessor> = {
     readonly cycleTime: number;
-    apply(cp: CycleProcessor);
+    apply(cp: CycleProcessorType): void;
 }
 
-export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, InternalSettingsType extends SimSettings>
+export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, InternalSettingsType extends SimSettings, CycleProcessorType extends CycleProcessor = CycleProcessor>
     implements Simulation<ResultType, InternalSettingsType, ExternalCycleSettings<InternalSettingsType>> {
 
     abstract displayName: string;
@@ -960,14 +961,19 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
         return `DPS: ${result.mainDpsResult}\nUnbuffed PPS: ${result.unbuffedPps}\n`;
     }
 
-    abstract getRotationsToSimulate(): Rotation[];
+    abstract getRotationsToSimulate(): Rotation<CycleProcessorType>[];
+
+    protected createCycleProcessor(settings: MultiCycleSettings): CycleProcessorType {
+        return new CycleProcessor(settings) as CycleProcessorType;
+    };
+
 
     async simulate(set: CharacterGearSet): Promise<ResultType> {
         console.debug("Sim start");
         const allBuffs = this.buffManager.enabledBuffs;
         const rotations = this.getRotationsToSimulate();
         const allResults = rotations.map(rot => {
-            const cp = new CycleProcessor({
+            const cp = this.createCycleProcessor({
                 stats: set.computedStats,
                 totalTime: this.cycleSettings.totalTime,
                 cycleTime: rot.cycleTime,

--- a/src/scripts/test/sims/common_values.ts
+++ b/src/scripts/test/sims/common_values.ts
@@ -1,0 +1,126 @@
+import {GcdAbility, OgcdAbility} from "../../sims/sim_types";
+import {CharacterGearSet} from "../../gear";
+import {makeFakeSet} from "../test_utils";
+import {JobMultipliers} from "../../geartypes";
+import {finalizeStats} from "../../xivstats";
+import {getClassJobStats, getLevelStats} from "../../xivconstants";
+
+export const filler: GcdAbility = {
+    type: 'gcd',
+    name: "Glare",
+    potency: 310,
+    attackType: "Spell",
+    gcd: 2.5,
+    cast: 1.5
+}
+
+export const weaponSkill: GcdAbility = {
+    type: 'gcd',
+    name: "WepSkill",
+    potency: 310,
+    attackType: "Weaponskill",
+    gcd: 2.5,
+    cast: 1.5
+}
+
+export const nop: GcdAbility = {
+    type: 'gcd',
+    name: "NOP",
+    potency: null,
+    attackType: "Spell",
+    gcd: 2.5,
+    cast: 2.0
+}
+
+export const dia: GcdAbility = {
+    type: 'gcd',
+    name: "Dia",
+    potency: 65,
+    dot: {
+        id: 1871,
+        tickPotency: 65,
+        duration: 30
+    },
+    attackType: "Spell",
+    gcd: 2.5,
+}
+
+export const assize: OgcdAbility = {
+    type: 'ogcd',
+    name: "Assize",
+    potency: 400,
+    attackType: "Ability"
+}
+
+export const pom: OgcdAbility = {
+    type: 'ogcd',
+    name: 'Presence of Mind',
+    potency: null,
+    activatesBuffs: [
+        {
+            name: "Presence of Mind",
+            job: "WHM",
+            selfOnly: true,
+            duration: 15,
+            cooldown: 120,
+            effects: {
+                haste: 20,
+            },
+        }
+    ],
+    attackType: "Ability"
+}
+
+export const misery: GcdAbility = {
+    type: 'gcd',
+    name: "Afflatus Misery",
+    potency: 1240,
+    attackType: "Spell",
+    gcd: 2.5,
+}
+
+export const lily: GcdAbility = {
+    type: 'gcd',
+    name: "Afflatus Rapture",
+    potency: 0,
+    attackType: "Spell",
+    gcd: 2.5,
+}
+// Replace data that would normally be loaded from xivapi with fixed data
+const jobStatMultipliers: JobMultipliers = {
+    dexterity: 105,
+    hp: 105,
+    intelligence: 105,
+    mind: 115,
+    strength: 55,
+    vitality: 100
+};
+// Stats from a set. These should be the stats WITH items and race bonus, but WITHOUT party bonus
+const rawStats = {
+    // From https://share.xivgear.app/share/74fb005d-086f-45d3-bee8-9a211559f7df
+    crit: 2287,
+    determination: 1806,
+    dexterity: 409,
+    dhit: 400,
+    hp: 0,
+    intelligence: 409,
+    mind: 3376,
+    piety: 535,
+    skillspeed: 400,
+    spellspeed: 1522,
+    strength: 214,
+    tenacity: 400,
+    vitality: 3321,
+    wdMag: 132,
+    wdPhys: 132,
+    weaponDelay: 3.44
+};
+// Finalize the stats (add class modifiers, party bonus, etc)
+const stats = finalizeStats(rawStats, 90, getLevelStats(90), 'WHM', {
+    ...getClassJobStats('WHM'),
+    jobStatMultipliers: jobStatMultipliers
+}, 5);
+
+// Turn the stats into a fake gear set. This object does not implement all of the methods that a CharacterGearSet
+// should, only the ones that would commonly be used in a simulation.
+export const exampleGearSet: CharacterGearSet = makeFakeSet(stats);

--- a/src/scripts/test/sims/cooldown_tests.ts
+++ b/src/scripts/test/sims/cooldown_tests.ts
@@ -1,6 +1,6 @@
-import {CooldownTracker} from "../sims/common/cooldown_manager";
-import {Ability, GcdAbility, OgcdAbility} from "../sims/sim_types";
-import {Chain} from "../sims/buffs";
+import {CooldownTracker} from "../../sims/common/cooldown_manager";
+import {Ability, GcdAbility, OgcdAbility} from "../../sims/sim_types";
+import {Chain} from "../../sims/buffs";
 import * as assert from "assert";
 
 const chain: OgcdAbility = {

--- a/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/src/scripts/test/sims/cycle_processor_tests.ts
@@ -1,393 +1,12 @@
-// REQUIRED - sets up fake HTML classes
 import 'global-jsdom/register'
+import {Ability, Buff, BuffController, FinalizedAbility, GcdAbility} from "../../sims/sim_types";
 import {it} from "mocha";
-import {SimSettings, SimSpec} from "../simulation";
-import {Ability, Buff, BuffController, FinalizedAbility, GcdAbility, OgcdAbility} from "../sims/sim_types";
-import {CharacterGearSet} from "../gear";
-import {JobMultipliers} from "../geartypes";
-import {finalizeStats} from "../xivstats";
-import {getClassJobStats, getLevelStats} from "../xivconstants";
-
-import {
-    BaseMultiCycleSim,
-    CycleProcessor,
-    CycleSimResult,
-    DamageResult,
-    ExternalCycleSettings,
-    Rotation
-} from "../sims/sim_processors";
-import {assertClose, makeFakeSet} from "./test_utils";
+import {CycleProcessor, DamageResult} from "../../sims/sim_processors";
+import {Swiftcast} from "../../sims/common/swiftcast";
 import * as assert from "assert";
-import {Divination, Litany, Mug} from "../sims/buffs";
-import {assertSimAbilityResults, setPartyBuffEnabled, UseResult} from "./sim_test_utils";
-import {Swiftcast} from "../sims/common/swiftcast";
-import {removeSelf} from "../sims/common/utils";
-
-// Example of end-to-end simulation
-// This one is testing the simulation engine itself, so it copies the full simulation code rather than
-// referencing it. If you wish to test an actual simulation, you would want to reference it directly.
-
-// Set up a simulation
-interface TestSimSettings extends SimSettings {
-}
-
-export interface TestSimSettingsExternal extends ExternalCycleSettings<TestSimSettings> {
-}
-
-const filler: GcdAbility = {
-    type: 'gcd',
-    name: "Glare",
-    potency: 310,
-    attackType: "Spell",
-    gcd: 2.5,
-    cast: 1.5
-}
-
-const weaponSkill: GcdAbility = {
-    type: 'gcd',
-    name: "WepSkill",
-    potency: 310,
-    attackType: "Weaponskill",
-    gcd: 2.5,
-    cast: 1.5
-}
-
-const nop: GcdAbility = {
-    type: 'gcd',
-    name: "NOP",
-    potency: null,
-    attackType: "Spell",
-    gcd: 2.5,
-    cast: 2.0
-}
-
-const dia: GcdAbility = {
-    type: 'gcd',
-    name: "Dia",
-    potency: 65,
-    dot: {
-        id: 1871,
-        tickPotency: 65,
-        duration: 30
-    },
-    attackType: "Spell",
-    gcd: 2.5,
-}
-
-const assize: OgcdAbility = {
-    type: 'ogcd',
-    name: "Assize",
-    potency: 400,
-    attackType: "Ability"
-}
-
-const pom: OgcdAbility = {
-    type: 'ogcd',
-    name: 'Presence of Mind',
-    potency: null,
-    activatesBuffs: [
-        {
-            name: "Presence of Mind",
-            job: "WHM",
-            selfOnly: true,
-            duration: 15,
-            cooldown: 120,
-            effects: {
-                haste: 20,
-            },
-        }
-    ],
-    attackType: "Ability"
-}
-
-const misery: GcdAbility = {
-    type: 'gcd',
-    name: "Afflatus Misery",
-    potency: 1240,
-    attackType: "Spell",
-    gcd: 2.5,
-}
-
-const lily: GcdAbility = {
-    type: 'gcd',
-    name: "Afflatus Rapture",
-    potency: 0,
-    attackType: "Spell",
-    gcd: 2.5,
-}
-
-export const testSimSpec: SimSpec<TestMultiCycleSim, TestSimSettingsExternal> = {
-    displayName: "Test WHM Sim",
-    loadSavedSimInstance(exported: TestSimSettingsExternal) {
-        return new TestMultiCycleSim(exported);
-    },
-    makeNewSimInstance(): TestMultiCycleSim {
-        return new TestMultiCycleSim();
-    },
-    stub: "test-whm-sim",
-    supportedJobs: ['WHM'],
-    isDefaultSim: false
-}
-
-export interface TestSimResult extends CycleSimResult {
-}
-
-class TestMultiCycleSim extends BaseMultiCycleSim<TestSimResult, TestSimSettings> {
-    spec = testSimSpec;
-    displayName = testSimSpec.displayName;
-    shortName = "WHM-new-sheet-sim";
-
-    constructor(settings?: TestSimSettingsExternal) {
-        super('WHM', settings);
-    }
-
-    makeDefaultSettings(): TestSimSettings {
-        return {};
-    }
-
-    getRotationsToSimulate(): Rotation[] {
-        return [{
-            cycleTime: 120,
-            apply(cp: CycleProcessor) {
-                // These should NOT start combat because their damage === null
-                cp.use(nop);
-                cp.use(nop);
-                cp.use(nop);
-                cp.use(filler);
-                cp.remainingCycles(cycle => {
-                    cycle.use(dia);
-                    cycle.use(filler);
-                    cycle.use(filler);
-                    cycle.useOgcd(pom);
-                    cycle.use(filler);
-                    cycle.use(assize);
-                    if (cycle.cycleNumber > 0) {
-                        cycle.use(misery);
-                    }
-                    cycle.useUntil(filler, 30);
-                    cycle.use(dia);
-                    cycle.use(lily); //3 lilys out of buffs to make up for misery in buffs, actual placement isn't specific
-                    cycle.use(lily);
-                    cycle.use(lily);
-                    cycle.useUntil(filler, 50);
-                    cycle.use(assize);
-                    cycle.useUntil(filler, 60);
-                    cycle.use(dia);
-                    cycle.useUntil(filler, 70);
-                    cycle.use(misery);
-                    cycle.useUntil(filler, 90);
-                    cycle.use(dia);
-                    cycle.use(assize);
-                    if (cycle.cycleNumber > 1) {
-                        cycle.use(lily);
-                        cycle.use(lily);
-                        cycle.use(lily);
-                    }
-                    cycle.useUntil(filler, 'end');
-                });
-            }
-
-        }];
-    }
-}
-
-// Replace data that would normally be loaded from xivapi with fixed data
-const jobStatMultipliers: JobMultipliers = {
-    dexterity: 105,
-    hp: 105,
-    intelligence: 105,
-    mind: 115,
-    strength: 55,
-    vitality: 100
-};
-// Stats from a set. These should be the stats WITH items and race bonus, but WITHOUT party bonus
-const rawStats = {
-    // From https://share.xivgear.app/share/74fb005d-086f-45d3-bee8-9a211559f7df
-    crit: 2287,
-    determination: 1806,
-    dexterity: 409,
-    dhit: 400,
-    hp: 0,
-    intelligence: 409,
-    mind: 3376,
-    piety: 535,
-    skillspeed: 400,
-    spellspeed: 1522,
-    strength: 214,
-    tenacity: 400,
-    vitality: 3321,
-    wdMag: 132,
-    wdPhys: 132,
-    weaponDelay: 3.44
-};
-// Finalize the stats (add class modifiers, party bonus, etc)
-const stats = finalizeStats(rawStats, 90, getLevelStats(90), 'WHM', {
-    ...getClassJobStats('WHM'),
-    jobStatMultipliers: jobStatMultipliers
-}, 5);
-
-// Turn the stats into a fake gear set. This object does not implement all of the methods that a CharacterGearSet
-// should, only the ones that would commonly be used in a simulation.
-const set: CharacterGearSet = makeFakeSet(stats);
-
-// Expected sim outcome
-const expectedAbilities: UseResult[] = [
-    {
-        time: -8.41,
-        name: 'NOP',
-        damage: 0
-    },
-    {
-        time: -6.10,
-        name: 'NOP',
-        damage: 0
-    },
-    {
-        time: -3.79,
-        name: 'NOP',
-        damage: 0
-    },
-    {
-        time: -1.48,
-        name: 'Glare',
-        damage: 15078.38
-    },
-    {
-        time: 0,
-        name: 'Auto Attack',
-        damage: 39.04
-    },
-    {
-        time: 0.83,
-        name: 'Dia',
-        damage: 37174.05
-    },
-    {
-        time: 3.14,
-        name: 'Glare',
-        damage: 15832.30
-    },
-    {
-        time: 4.32,
-        name: 'Auto Attack',
-        damage: 40.99
-    },
-    {
-        time: 5.45,
-        name: 'Glare',
-        damage: 15832.30
-    },
-    {
-        time: 6.93,
-        name: 'Presence of Mind',
-        damage: 0
-    },
-    {
-        time: 7.76,
-        name: 'Glare',
-        damage: 17656.20
-    },
-    {
-        time: 8.96,
-        name: "Assize",
-        damage: 22783.24
-    },
-    {
-        time: 9.24,
-        name: "Auto Attack",
-        damage: 45.72
-    },
-    {
-        time: 9.60,
-        name: "Glare",
-        damage: 17656.2
-    },
-    {
-        time: 11.44,
-        name: "Glare",
-        damage: 17656.2
-    },
-    {
-        time: 13.28,
-        name: "Glare",
-        damage: 17656.2
-    },
-    {
-        time: 14.48,
-        name: "Auto Attack",
-        damage: 45.72
-    },
-    {
-        time: 15.12,
-        name: "Glare",
-        damage: 17656.2
-    },
-    {
-        time: 16.96,
-        name: "Glare",
-        damage: 17656.2
-    },
-    {
-        time: 18.80,
-        name: "Glare",
-        damage: 17656.2
-    },
-    {
-        time: 19.72,
-        name: "Auto Attack",
-        damage: 45.72
-    },
-    {
-        time: 20.64,
-        name: "Glare",
-        damage: 17656.2
-    },
-    {
-        time: 22.48,
-        name: "Glare",
-        damage: 15832.3
-    },
-    {
-        time: 24.32,
-        name: "Glare",
-        damage: 15078.38
-    },
-    {
-        time: 25.24,
-        name: "Auto Attack",
-        damage: 39.04
-    },
-    {
-        time: 26.63,
-        name: "Glare",
-        damage: 15078.38
-    },
-    {
-        time: 28.94,
-        name: "Glare",
-        damage: 6919.08
-    },
-]
-
-
-// The test
-describe('Cycle sim processor', () => {
-    // Test the simulation
-    it('produces the correct results', async () => {
-        // Initialize
-        const inst: TestMultiCycleSim = testSimSpec.makeNewSimInstance();
-        inst.cycleSettings.totalTime = 30;
-        // Enable buffs
-        setPartyBuffEnabled(inst, Mug, true);
-        setPartyBuffEnabled(inst, Litany, true);
-        setPartyBuffEnabled(inst, Divination, true);
-        // Run simulation
-        let result = await inst.simulate(set);
-        // Assert correct results
-        assertClose(result.mainDpsResult, 9898.56, 0.01);
-        assertSimAbilityResults(result, expectedAbilities);
-    });
-});
+import {assertClose} from "../test_utils";
+import {removeSelf} from "../../sims/common/utils";
+import {dia, exampleGearSet, filler, weaponSkill} from "./common_values";
 
 const instant: GcdAbility = {
     type: 'gcd',
@@ -416,7 +35,7 @@ describe('Swiftcast', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -462,7 +81,7 @@ describe('Swiftcast', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -498,7 +117,7 @@ describe('Swiftcast', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -540,7 +159,7 @@ describe('Swiftcast', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -614,7 +233,7 @@ describe('Potency Buff Ability', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -712,7 +331,7 @@ describe('Damage Buff Ability', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -742,7 +361,7 @@ describe('Damage Buff Ability', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -771,7 +390,7 @@ describe('Damage Buff Ability', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });
@@ -809,7 +428,7 @@ describe('Damage Buff Ability', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });

--- a/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/src/scripts/test/sims/cycle_processor_tests.ts
@@ -1,16 +1,25 @@
 import 'global-jsdom/register'
-import {Ability, Buff, BuffController, FinalizedAbility, GcdAbility} from "../../sims/sim_types";
+import {Ability, Buff, BuffController, FinalizedAbility, GcdAbility, OgcdAbility} from "../../sims/sim_types";
 import {it} from "mocha";
-import {CycleProcessor, DamageResult} from "../../sims/sim_processors";
-import {Swiftcast} from "../../sims/common/swiftcast";
+import {
+    BaseMultiCycleSim,
+    CycleProcessor,
+    CycleSimResult,
+    DamageResult,
+    ExternalCycleSettings, Rotation
+} from "../../sims/sim_processors";
 import * as assert from "assert";
-import {assertClose} from "../test_utils";
-import {removeSelf} from "../../sims/common/utils";
-import {dia, exampleGearSet, filler, weaponSkill} from "./common_values";
-import {Divination, Litany, Mug} from "../sims/buffs";
+import {assertClose, makeFakeSet} from "../test_utils";
 import {assertSimAbilityResults, setPartyBuffEnabled, UseResult} from "./sim_test_utils";
-import {Swiftcast} from "../sims/common/swiftcast";
-import {removeSelf} from "../sims/common/utils";
+import {SimSettings, SimSpec} from "../../simulation";
+import {JobMultipliers} from "../../geartypes";
+import {finalizeStats} from "../../xivstats";
+import {getClassJobStats, getLevelStats} from "../../xivconstants";
+import {CharacterGearSet} from "../../gear";
+import {Divination, Litany, Mug} from "../../sims/buffs";
+import {exampleGearSet} from "./common_values";
+import {Swiftcast} from "../../sims/common/swiftcast";
+import {removeSelf} from "../../sims/common/utils";
 
 // Example of end-to-end simulation
 // This one is testing the simulation engine itself, so it copies the full simulation code rather than

--- a/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/src/scripts/test/sims/cycle_processor_tests.ts
@@ -465,7 +465,7 @@ describe('Special record', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 30,
-            stats: set.computedStats,
+            stats: exampleGearSet.computedStats,
             totalTime: 120,
             useAutos: false
         });

--- a/src/scripts/test/sims/sim_test_utils.ts
+++ b/src/scripts/test/sims/sim_test_utils.ts
@@ -1,6 +1,6 @@
-import {BaseMultiCycleSim, CycleSimResult, DisplayRecordFinalized} from "../sims/sim_processors";
-import {Buff, FinalizedAbility} from "../sims/sim_types";
-import {isClose} from "./test_utils";
+import {BaseMultiCycleSim, CycleSimResult, DisplayRecordFinalized} from "../../sims/sim_processors";
+import {Buff, FinalizedAbility} from "../../sims/sim_types";
+import {isClose} from "../test_utils";
 import assert from "assert";
 
 /**

--- a/src/scripts/test/sims/sim_tests.ts
+++ b/src/scripts/test/sims/sim_tests.ts
@@ -267,7 +267,7 @@ describe('Cycle sim processor', () => {
 });
 
 class CustomCycleProcessor extends CycleProcessor {
-    fillerCount: number = 0;
+    private fillerCount: number = 0;
 
     use(ability: Ability): AbilityUseResult {
         const out = super.use(ability);
@@ -308,7 +308,7 @@ class TestCustomMultiCycleSim extends BaseMultiCycleSim<TestSimResult, TestSimSe
                 cp.use(filler);
                 cp.use(dia);
                 cp.use(nop);
-                outer.fillerCount = cp.fillerCount;
+                outer.fillerCount = cp.count;
             }
         }];
     }

--- a/src/scripts/test/sims/sim_tests.ts
+++ b/src/scripts/test/sims/sim_tests.ts
@@ -1,0 +1,338 @@
+// REQUIRED - sets up fake HTML classes
+import 'global-jsdom/register'
+import {it} from "mocha";
+import {SimSettings, SimSpec} from "../../simulation";
+
+import {
+    AbilityUseResult,
+    BaseMultiCycleSim,
+    CycleProcessor,
+    CycleSimResult,
+    ExternalCycleSettings,
+    MultiCycleSettings,
+    Rotation
+} from "../../sims/sim_processors";
+import {assertClose} from "../test_utils";
+import {Divination, Litany, Mug} from "../../sims/buffs";
+import {assertSimAbilityResults, setPartyBuffEnabled, UseResult} from "./sim_test_utils";
+import {assize, dia, exampleGearSet, filler, lily, misery, nop, pom} from "./common_values";
+import {Ability} from "../../sims/sim_types";
+import * as assert from "assert";
+
+// Example of end-to-end simulation
+// This one is testing the simulation engine itself, so it copies the full simulation code rather than
+// referencing it. If you wish to test an actual simulation, you would want to reference it directly.
+
+// Set up a simulation
+interface TestSimSettings extends SimSettings {
+}
+
+export interface TestSimSettingsExternal extends ExternalCycleSettings<TestSimSettings> {
+}
+
+
+export const testSimSpec: SimSpec<TestMultiCycleSim, TestSimSettingsExternal> = {
+    displayName: "Test WHM Sim",
+    loadSavedSimInstance(exported: TestSimSettingsExternal) {
+        return new TestMultiCycleSim(exported);
+    },
+    makeNewSimInstance(): TestMultiCycleSim {
+        return new TestMultiCycleSim();
+    },
+    stub: "test-whm-sim",
+    supportedJobs: ['WHM'],
+    isDefaultSim: false
+}
+
+export interface TestSimResult extends CycleSimResult {
+}
+
+class TestMultiCycleSim extends BaseMultiCycleSim<TestSimResult, TestSimSettings> {
+    spec = testSimSpec;
+    displayName = testSimSpec.displayName;
+    shortName = "WHM-new-sheet-sim";
+
+    constructor(settings?: TestSimSettingsExternal) {
+        super('WHM', settings);
+    }
+
+    makeDefaultSettings(): TestSimSettings {
+        return {};
+    }
+
+    getRotationsToSimulate(): Rotation[] {
+        return [{
+            cycleTime: 120,
+            apply(cp: CycleProcessor) {
+                // These should NOT start combat because their damage === null
+                cp.use(nop);
+                cp.use(nop);
+                cp.use(nop);
+                cp.use(filler);
+                cp.remainingCycles(cycle => {
+                    cycle.use(dia);
+                    cycle.use(filler);
+                    cycle.use(filler);
+                    cycle.useOgcd(pom);
+                    cycle.use(filler);
+                    cycle.use(assize);
+                    if (cycle.cycleNumber > 0) {
+                        cycle.use(misery);
+                    }
+                    cycle.useUntil(filler, 30);
+                    cycle.use(dia);
+                    cycle.use(lily); //3 lilys out of buffs to make up for misery in buffs, actual placement isn't specific
+                    cycle.use(lily);
+                    cycle.use(lily);
+                    cycle.useUntil(filler, 50);
+                    cycle.use(assize);
+                    cycle.useUntil(filler, 60);
+                    cycle.use(dia);
+                    cycle.useUntil(filler, 70);
+                    cycle.use(misery);
+                    cycle.useUntil(filler, 90);
+                    cycle.use(dia);
+                    cycle.use(assize);
+                    if (cycle.cycleNumber > 1) {
+                        cycle.use(lily);
+                        cycle.use(lily);
+                        cycle.use(lily);
+                    }
+                    cycle.useUntil(filler, 'end');
+                });
+            }
+
+        }];
+    }
+}
+
+
+// Expected sim outcome
+const expectedAbilities: UseResult[] = [
+    {
+        time: -8.41,
+        name: 'NOP',
+        damage: 0
+    },
+    {
+        time: -6.10,
+        name: 'NOP',
+        damage: 0
+    },
+    {
+        time: -3.79,
+        name: 'NOP',
+        damage: 0
+    },
+    {
+        time: -1.48,
+        name: 'Glare',
+        damage: 15078.38
+    },
+    {
+        time: 0,
+        name: 'Auto Attack',
+        damage: 39.04
+    },
+    {
+        time: 0.83,
+        name: 'Dia',
+        damage: 37174.05
+    },
+    {
+        time: 3.14,
+        name: 'Glare',
+        damage: 15832.30
+    },
+    {
+        time: 4.32,
+        name: 'Auto Attack',
+        damage: 40.99
+    },
+    {
+        time: 5.45,
+        name: 'Glare',
+        damage: 15832.30
+    },
+    {
+        time: 6.93,
+        name: 'Presence of Mind',
+        damage: 0
+    },
+    {
+        time: 7.76,
+        name: 'Glare',
+        damage: 17656.20
+    },
+    {
+        time: 8.96,
+        name: "Assize",
+        damage: 22783.24
+    },
+    {
+        time: 9.24,
+        name: "Auto Attack",
+        damage: 45.72
+    },
+    {
+        time: 9.60,
+        name: "Glare",
+        damage: 17656.2
+    },
+    {
+        time: 11.44,
+        name: "Glare",
+        damage: 17656.2
+    },
+    {
+        time: 13.28,
+        name: "Glare",
+        damage: 17656.2
+    },
+    {
+        time: 14.48,
+        name: "Auto Attack",
+        damage: 45.72
+    },
+    {
+        time: 15.12,
+        name: "Glare",
+        damage: 17656.2
+    },
+    {
+        time: 16.96,
+        name: "Glare",
+        damage: 17656.2
+    },
+    {
+        time: 18.80,
+        name: "Glare",
+        damage: 17656.2
+    },
+    {
+        time: 19.72,
+        name: "Auto Attack",
+        damage: 45.72
+    },
+    {
+        time: 20.64,
+        name: "Glare",
+        damage: 17656.2
+    },
+    {
+        time: 22.48,
+        name: "Glare",
+        damage: 15832.3
+    },
+    {
+        time: 24.32,
+        name: "Glare",
+        damage: 15078.38
+    },
+    {
+        time: 25.24,
+        name: "Auto Attack",
+        damage: 39.04
+    },
+    {
+        time: 26.63,
+        name: "Glare",
+        damage: 15078.38
+    },
+    {
+        time: 28.94,
+        name: "Glare",
+        damage: 6919.08
+    },
+]
+
+
+// The test
+describe('Cycle sim processor', () => {
+    // Test the simulation
+    it('produces the correct results', async () => {
+        // Initialize
+        const inst: TestMultiCycleSim = testSimSpec.makeNewSimInstance();
+        inst.cycleSettings.totalTime = 30;
+        // Enable buffs
+        setPartyBuffEnabled(inst, Mug, true);
+        setPartyBuffEnabled(inst, Litany, true);
+        setPartyBuffEnabled(inst, Divination, true);
+        // Run simulation
+        let result = await inst.simulate(exampleGearSet);
+        // Assert correct results
+        assertClose(result.mainDpsResult, 9898.56, 0.01);
+        assertSimAbilityResults(result, expectedAbilities);
+    });
+});
+
+class CustomCycleProcessor extends CycleProcessor {
+    fillerCount: number = 0;
+
+    use(ability: Ability): AbilityUseResult {
+        const out = super.use(ability);
+        if (ability === filler) {
+            this.fillerCount++;
+        }
+        return out;
+    }
+
+    get count() {
+        return this.fillerCount;
+    }
+}
+
+class TestCustomMultiCycleSim extends BaseMultiCycleSim<TestSimResult, TestSimSettings, CustomCycleProcessor> {
+    spec = testSimSpec;
+    displayName = testSimSpec.displayName;
+    shortName = "WHM-new-sheet-sim";
+    fillerCount: number;
+
+    constructor(settings?: TestSimSettingsExternal) {
+        super('WHM', settings);
+    }
+
+    makeDefaultSettings(): TestSimSettings {
+        return {};
+    }
+
+    protected createCycleProcessor(settings: MultiCycleSettings): CustomCycleProcessor {
+        return new CustomCycleProcessor(settings);
+    }
+
+    getRotationsToSimulate(): Rotation<CustomCycleProcessor>[] {
+        const outer = this;
+        return [{
+            cycleTime: 120,
+            apply(cp: CustomCycleProcessor) {
+                cp.use(filler);
+                cp.use(dia);
+                cp.use(nop);
+                outer.fillerCount = cp.fillerCount;
+            }
+        }];
+    }
+}
+
+export const testCustomSimSpec: SimSpec<TestCustomMultiCycleSim, TestSimSettingsExternal> = {
+    displayName: "Test Custom Sim",
+    loadSavedSimInstance(exported: TestSimSettingsExternal) {
+        return new TestMultiCycleSim(exported);
+    },
+    makeNewSimInstance(): TestCustomMultiCycleSim {
+        return new TestCustomMultiCycleSim();
+    },
+    stub: "test-custom-sim",
+    supportedJobs: ['WHM'],
+    isDefaultSim: false
+}
+describe('Sim with custom cycle processor', () => {
+    // Test the simulation
+    it('can hook, and expose extra methods', async () => {
+        // Initialize
+        const inst: TestCustomMultiCycleSim = testCustomSimSpec.makeNewSimInstance();
+        // Run simulation
+        let result = await inst.simulate(exampleGearSet);
+        assert.equal(inst.fillerCount, 1);
+    });
+});

--- a/src/scripts/test/sims/sim_tests.ts
+++ b/src/scripts/test/sims/sim_tests.ts
@@ -132,7 +132,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 0,
         name: 'Auto Attack',
-        damage: 39.04
+        damage: 33.301
     },
     {
         time: 0.83,
@@ -147,7 +147,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 4.32,
         name: 'Auto Attack',
-        damage: 40.99
+        damage: 34.966
     },
     {
         time: 5.45,
@@ -172,7 +172,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 9.24,
         name: "Auto Attack",
-        damage: 45.72
+        damage: 38.994
     },
     {
         time: 9.60,
@@ -192,7 +192,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 14.48,
         name: "Auto Attack",
-        damage: 45.72
+        damage: 38.994
     },
     {
         time: 15.12,
@@ -212,7 +212,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 19.72,
         name: "Auto Attack",
-        damage: 45.72
+        damage: 38.994
     },
     {
         time: 20.64,
@@ -232,7 +232,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 25.24,
         name: "Auto Attack",
-        damage: 39.04
+        damage: 33.301
     },
     {
         time: 26.63,
@@ -261,7 +261,7 @@ describe('Cycle sim processor', () => {
         // Run simulation
         let result = await inst.simulate(exampleGearSet);
         // Assert correct results
-        assertClose(result.mainDpsResult, 9898.56, 0.01);
+        assertClose(result.mainDpsResult, 9897.32, 0.01);
         assertSimAbilityResults(result, expectedAbilities);
     });
 });
@@ -317,7 +317,7 @@ class TestCustomMultiCycleSim extends BaseMultiCycleSim<TestSimResult, TestSimSe
 export const testCustomSimSpec: SimSpec<TestCustomMultiCycleSim, TestSimSettingsExternal> = {
     displayName: "Test Custom Sim",
     loadSavedSimInstance(exported: TestSimSettingsExternal) {
-        return new TestMultiCycleSim(exported);
+        return new TestCustomMultiCycleSim(exported);
     },
     makeNewSimInstance(): TestCustomMultiCycleSim {
         return new TestCustomMultiCycleSim();


### PR DESCRIPTION
- Adds support for custom subclasses and custom creation of CycleProcessor
- This acts as a convenient place to hold 'rotation state' rather than doing it on the Sim class directly
- Split up sim_tests.ts