### PR TITLE
Fix bug in auto-attack damage calculation

### DIFF
--- a/src/scripts/test/sim_tests.ts
+++ b/src/scripts/test/sim_tests.ts
@@ -255,7 +255,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 0,
         name: 'Auto Attack',
-        damage: 39.04
+        damage: 33.30
     },
     {
         time: 0.83,
@@ -270,7 +270,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 4.32,
         name: 'Auto Attack',
-        damage: 40.99
+        damage: 34.97
     },
     {
         time: 5.45,
@@ -295,7 +295,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 9.24,
         name: "Auto Attack",
-        damage: 45.72
+        damage: 38.99
     },
     {
         time: 9.60,
@@ -315,7 +315,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 14.48,
         name: "Auto Attack",
-        damage: 45.72
+        damage: 38.99
     },
     {
         time: 15.12,
@@ -335,7 +335,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 19.72,
         name: "Auto Attack",
-        damage: 45.72
+        damage: 38.99
     },
     {
         time: 20.64,
@@ -355,7 +355,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 25.24,
         name: "Auto Attack",
-        damage: 39.04
+        damage: 33.30
     },
     {
         time: 26.63,
@@ -384,7 +384,7 @@ describe('Cycle sim processor', () => {
         // Run simulation
         let result = await inst.simulate(set);
         // Assert correct results
-        assertClose(result.mainDpsResult, 9898.56, 0.01);
+        assertClose(result.mainDpsResult, 9897.32, 0.01);
         assertSimAbilityResults(result, expectedAbilities);
     });
 });

--- a/src/scripts/xivmath.ts
+++ b/src/scripts/xivmath.ts
@@ -211,7 +211,7 @@ export function mpTick(levelStats: LevelStats, piety: number) {
  * @param weaponDamage weapon damage
  */
 export function autoAttackModifier(levelStats: LevelStats, jobStats: JobData, weaponDelay: number, weaponDamage: number) {
-    return fl(fl((levelStats.baseMainStat * jobStats.jobStatMultipliers[jobStats.mainStat] / 1000) + weaponDamage) * (weaponDelay * 1000 / 3)) / 1000;
+    return fl(fl((levelStats.baseMainStat * jobStats.jobStatMultipliers[jobStats.autoAttackStat] / 1000) + weaponDamage) * (weaponDelay * 1000 / 3)) / 1000;
 }
 
 /**


### PR DESCRIPTION
`f(AUTO)` should use the appropriate job modifier for auto attacks.