### PR TITLE
Split buffs into personal and party types

### DIFF
--- a/src/scripts/sims/ast_sheet_sim.ts
+++ b/src/scripts/sims/ast_sheet_sim.ts
@@ -53,15 +53,12 @@ const astrodyne: OgcdAbility = {
     activatesBuffs: [
         {
             name: "Astrodyne",
-            job: "AST",
             selfOnly: true,
             duration: 15,
-            cooldown: 0,
             effects: { //currently assumes 2 seal dynes, can change dmgIncrease based on frequency of 3 seals
                 // dmgIncrease: 0.00,
                 haste: 10,
             },
-            startTime: null,
         }
     ],
     attackType: "Ability",

--- a/src/scripts/sims/buffs.ts
+++ b/src/scripts/sims/buffs.ts
@@ -1,4 +1,4 @@
-import {Buff} from "./sim_types";
+import {Buff, PartyBuff} from "./sim_types";
 
 
 export const Mug = {
@@ -6,30 +6,33 @@ export const Mug = {
     job: "NIN",
     duration: 20,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.05,
     },
     startTime: 3.5,
     statusId: 3183
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const Litany = {
     name: "Battle Litany",
     job: "DRG",
     duration: 15,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         critChanceIncrease: 0.10
     },
     startTime: 7.5,
     statusId: 786
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const DragonSight = {
     name: "Dragon Sight (Other)",
     job: "DRG",
     duration: 20,
     cooldown: 120,
+    selfOnly: false,
     optional: true,
     effects: {
         dmgIncrease: 0.05
@@ -37,32 +40,34 @@ export const DragonSight = {
     startTime: 5,
     // TODO: there are two of these, 1184 and 1454, one is probably pvp
     statusId: 1184
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const Brotherhood = {
     name: "Brotherhood",
     job: "MNK",
     duration: 15,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.05
     },
     startTime: 7.5,
     // TODO: there are two of these, 1185 and 2174, one is probably pvp
     statusId: 1185
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const ArcaneCircle = {
     name: "Arcane Circle",
     job: "RPR",
     duration: 20,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.03
     },
     startTime: 5,
     statusId: 2599
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const DeathsDesign = {
     name: "Death's Design",
@@ -70,37 +75,40 @@ export const DeathsDesign = {
     duration: 60, // this is a hack to make up for the fact that the duration is stackable.
                   // Needs to be changed if simulating dropping DD is desired.
     cooldown: 0,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.1
     },
     startTime: 0,
     statusId: 2586
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const SearingLight = {
     name: "Searing Light",
     job: "SMN",
     duration: 30,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.03
     },
     startTime: 1.5,
     statusId: 2703
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const Embolden = {
     name: "Embolden",
     job: "RDM",
     duration: 20,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.05
     },
     startTime: 7,
     // This is the party member version of this, not the self version
     statusId: 1297
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const Devilment = {
     name: "Devilment",
@@ -108,13 +116,14 @@ export const Devilment = {
     duration: 20,
     cooldown: 120,
     optional: true,
+    selfOnly: false,
     effects: {
         dhitChanceIncrease: 0.20,
         critChanceIncrease: 0.20
     },
     startTime: 7,
     statusId: 1825
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 /* With how the cycle processer script currently handles buffs, this wouldn't properly work
 export const StandardFinish = {
@@ -127,73 +136,79 @@ export const StandardFinish = {
         dmgIncrease: 0.05,
     }
     startTime: 0,
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 */
 export const TechnicalFinish = {
     name: "Technical Finish",
     job: "DNC",
     duration: 20,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.05,
     },
     startTime: 7,
     statusId: 1822
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const BattleVoice = {
     name: "Battle Voice",
     job: "BRD",
     duration: 15,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dhitChanceIncrease: 0.20,
     },
     startTime: 6,
     statusId: 141
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const RadiantFinale = {
     name: "Radiant Finale",
     job: "BRD",
     duration: 15,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.06
     },
     startTime: 6.7,
     statusId: 2964
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const Chain = {
     name: "Chain",
     job: "SCH",
     duration: 15,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         critChanceIncrease: 0.10
     },
     startTime: 7,
     statusId: 1221
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const Divination = {
     name: "Divination",
     job: "AST",
     duration: 15,
     cooldown: 120,
+    selfOnly: false,
     effects: {
         dmgIncrease: 0.06
     },
     startTime: 7,
     statusId: 1878
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 export const AstCard = {
     name: "Single Target AST Card",
     job: "AST",
     duration: 15,
     cooldown: 30,
+    selfOnly: false,
     optional: true,
     effects: {
         dmgIncrease: 0.06
@@ -201,10 +216,10 @@ export const AstCard = {
     startTime: 4,
     // three IDs for this
     statusId: 829
-} as const satisfies Buff;
+} as const satisfies PartyBuff;
 
 
-export const ALL_BUFFS = [
+export const ALL_BUFFS: readonly PartyBuff[] = [
     Mug, Litany, DragonSight, Brotherhood, ArcaneCircle, SearingLight, Embolden, Devilment, TechnicalFinish, BattleVoice, RadiantFinale, Chain, Divination, AstCard
 ] as const;
 

--- a/src/scripts/sims/common/swiftcast.ts
+++ b/src/scripts/sims/common/swiftcast.ts
@@ -1,15 +1,10 @@
 import {Ability, Buff, BuffController, OgcdAbility} from "../sim_types";
 
 export const SwiftcastBuff: Buff = {
-    // TODO: can this field be made optional for buffs that are never automatic?
-    cooldown: 60,
     duration: 10,
     effects: {},
-    // TODO
-    job: 'WHM',
     name: "Swiftcast",
     selfOnly: true,
-    startTime: 0,
     beforeAbility<X extends Ability>(controller: BuffController, ability: X): X | null {
         if (ability.type === 'gcd' && ability.cast >= 0) {
             controller.removeStatus(SwiftcastBuff);

--- a/src/scripts/sims/party_comp_settings.ts
+++ b/src/scripts/sims/party_comp_settings.ts
@@ -1,5 +1,5 @@
 import {JobName} from "../xivconstants";
-import {Buff} from "./sim_types";
+import {PartyBuff} from "./sim_types";
 import {ALL_BUFFS, BuffName} from "./buffs";
 import {FieldBoundCheckBox, labeledCheckbox} from "../components/util";
 
@@ -29,7 +29,7 @@ class JobSettings {
 }
 
 class BuffSetting {
-    constructor(public readonly buff: Buff, public enabled: boolean) {
+    constructor(public readonly buff: PartyBuff, public enabled: boolean) {
 
     }
 
@@ -46,7 +46,7 @@ export class BuffSettingsManager {
         return new BuffSettingsManager([job]);
     }
 
-    private static makeJobBuffMapping(): { [k in JobName]?: Buff[] } {
+    private static makeJobBuffMapping(): { [k in JobName]?: PartyBuff[] } {
         return ALL_BUFFS.reduce(((map, val) => {
             const job = val.job;
             if (job in map) {

--- a/src/scripts/sims/sim_types.ts
+++ b/src/scripts/sims/sim_types.ts
@@ -207,26 +207,15 @@ export type BuffController = {
 }
 
 // TODO: refactor this into Buff and PartyBuff so that the fields used for the party buffs (job, CD) can be untangled
-export type Buff = Readonly<{
+export type BaseBuff = Readonly<{
     /** Name of buff */
     name: string,
-    /** Job of buff */
-    job: JobName,
-    /** "Optional" would be things like DNC partner buffs, where merely having the job
-     // in your comp does not mean you would necessarily get the buff. */
-    optional?: boolean,
     /** Can only apply to self - not a party/targeted buff */
     selfOnly?: boolean,
-    /** Cooldown */
-    cooldown: number,
     /** Duration */
     duration: number,
     /** The effect(s) of the buff */
     effects: BuffEffects,
-    /**
-     * Time of usage - can be omitted for buffs that would only be used by self and never auto-activated
-     */
-    startTime?: number,
     /**
      * Filter what abilities this buff applies to
      *
@@ -270,3 +259,22 @@ export type Buff = Readonly<{
     statusId?: number
 
 }>;
+
+export type PartyBuff = BaseBuff & Readonly<{
+    /** Job of buff */
+    job: JobName,
+    /** Cooldown */
+    cooldown: number,
+    /** "Optional" would be things like DNC partner buffs, where merely having the job
+     // in your comp does not mean you would necessarily get the buff. */
+    optional?: boolean,
+
+    selfOnly: false
+    /**
+     * Time of usage - can be omitted for buffs that would only be used by self and never auto-activated
+     */
+    startTime?: number,
+
+}>
+
+export type Buff = BaseBuff | PartyBuff;

--- a/src/scripts/sims/whm_new_sheet_sim.ts
+++ b/src/scripts/sims/whm_new_sheet_sim.ts
@@ -39,10 +39,8 @@ const pom: OgcdAbility = {
     activatesBuffs: [
         {
             name: "Presence of Mind",
-            job: "WHM",
             selfOnly: true,
             duration: 15,
-            cooldown: 120,
             effects: {
                 haste: 20,
             },

--- a/src/scripts/test/sim_test_utils.ts
+++ b/src/scripts/test/sim_test_utils.ts
@@ -1,7 +1,6 @@
 import {BaseMultiCycleSim, CycleSimResult, DisplayRecordFinalized} from "../sims/sim_processors";
-import {Buff, FinalizedAbility} from "../sims/sim_types";
+import {FinalizedAbility, PartyBuff} from "../sims/sim_types";
 import {isClose} from "./test_utils";
-import assert from "assert";
 
 /**
  * Type that represents the time, name, and damage of an ability
@@ -20,7 +19,7 @@ export type UseResult = {
  * @param buff The buff to enable
  * @param enabled Whether to enable or disable the buff
  */
-export function setPartyBuffEnabled(sim: BaseMultiCycleSim<any, any>, buff: Buff, enabled: boolean) {
+export function setPartyBuffEnabled(sim: BaseMultiCycleSim<any, any>, buff: PartyBuff, enabled: boolean) {
     const jobSettings = sim.buffManager.allJobs.find(j => j.job === buff.job);
     jobSettings.enabled = true;
     const buffSettings = jobSettings.enabledBuffs.find(b => b.buff.name === buff.name);
@@ -29,7 +28,7 @@ export function setPartyBuffEnabled(sim: BaseMultiCycleSim<any, any>, buff: Buff
 
 export function assertSimAbilityResults(result: CycleSimResult | readonly DisplayRecordFinalized[], expectedAbilities: UseResult[]) {
 
-    const displayRecords: readonly DisplayRecordFinalized[] =  'displayRecords' in result ? result.displayRecords : result;
+    const displayRecords: readonly DisplayRecordFinalized[] = 'displayRecords' in result ? result.displayRecords : result;
     const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
         return 'ability' in record;
     });

--- a/src/scripts/test/sim_tests.ts
+++ b/src/scripts/test/sim_tests.ts
@@ -88,10 +88,8 @@ const pom: OgcdAbility = {
     activatesBuffs: [
         {
             name: "Presence of Mind",
-            job: "WHM",
             selfOnly: true,
             duration: 15,
-            cooldown: 120,
             effects: {
                 haste: 20,
             },

--- a/src/scripts/test/sims/common_values.ts
+++ b/src/scripts/test/sims/common_values.ts
@@ -59,10 +59,8 @@ export const pom: OgcdAbility = {
     activatesBuffs: [
         {
             name: "Presence of Mind",
-            job: "WHM",
             selfOnly: true,
             duration: 15,
-            cooldown: 120,
             effects: {
                 haste: 20,
             },

--- a/src/scripts/test/sims/sim_test_utils.ts
+++ b/src/scripts/test/sims/sim_test_utils.ts
@@ -1,10 +1,6 @@
-import {BaseMultiCycleSim, CycleSimResult, DisplayRecordFinalized} from "../sims/sim_processors";
-import {FinalizedAbility, PartyBuff} from "../sims/sim_types";
-import {isClose} from "./test_utils";
 import {BaseMultiCycleSim, CycleSimResult, DisplayRecordFinalized} from "../../sims/sim_processors";
-import {Buff, FinalizedAbility} from "../../sims/sim_types";
+import {FinalizedAbility, PartyBuff} from "../../sims/sim_types";
 import {isClose} from "../test_utils";
-import assert from "assert";
 
 /**
  * Type that represents the time, name, and damage of an ability


### PR DESCRIPTION
Splits Buffs into BaseBuff and PartyBuff so that personal-only buffs do not need to specify useless fields such as job and CD.

Closes #60 