### PR TITLE
Further relic stat validation behavior

### DIFF
--- a/src/scripts/datamanager.ts
+++ b/src/scripts/datamanager.ts
@@ -183,7 +183,7 @@ export class DataManager {
                         item.applyIlvlData(native, sync);
                         if (item.isCustomRelic) {
                             console.log('Applying relic model')
-                            item.relicStatModel = getRelicStatModelFor(item, this.baseParams);
+                            item.relicStatModel = getRelicStatModelFor(item, this.baseParams, this.classJob);
                             console.log('Applied', item.relicStatModel)
                         }
                     }));
@@ -193,7 +193,7 @@ export class DataManager {
                         item.applyIlvlData(native);
                         if (item.isCustomRelic) {
                             console.log('Applying relic model')
-                            item.relicStatModel = getRelicStatModelFor(item, this.baseParams);
+                            item.relicStatModel = getRelicStatModelFor(item, this.baseParams, this.classJob);
                             console.log('Applied', item.relicStatModel)
                         }
                     }));

--- a/src/scripts/datamanager.ts
+++ b/src/scripts/datamanager.ts
@@ -21,7 +21,15 @@ export function queryBaseParams() {
     });
 }
 
+/**
+ * Mapping from gear slot to the stat 'weighting' of that gear slot for a particular base param.
+ *
+ * These values are usually between 67 and 140 (excluding shields).
+ */
 export type BaseParamInfo = Record<OccGearSlotKey, number>
+/**
+ * Mapping for BaseParam to BaseParamInfo.
+ */
 export type BaseParamMap = { [rawStat in RawStatKey]?: BaseParamInfo }
 
 export class DataManager {

--- a/src/scripts/geartypes.ts
+++ b/src/scripts/geartypes.ts
@@ -412,17 +412,50 @@ export type Mainstat = typeof MAIN_STATS[number];
 export type Substat = (typeof FAKE_MAIN_STATS[number] | typeof SPECIAL_SUB_STATS[number]);
 
 export interface JobDataConst {
+    /**
+     * The role of the job
+     */
     readonly role: RoleKey,
+    /**
+     * The primary stat
+     */
     readonly mainStat: Mainstat;
+    /**
+     * The primary stat as used for auto-attack calculations specifically
+     */
     readonly autoAttackStat: Mainstat;
+    /**
+     * Optional function to apply a damage multiplication trait.
+     */
     readonly traitMulti?: (level: number, attackType: AttackType) => number;
+    /**
+     * Optional list of stat-modifying traits
+     */
     readonly traits?: readonly JobTrait[];
+    /**
+     * Substats which are completely irrelevant to this class, e.g. TNC on non-tanks
+     */
     readonly irrelevantSubstats?: readonly Substat[];
+    /**
+     * True if this class uses 1H+Offhand rather than 2H weapons
+     */
     readonly offhand?: boolean;
+    /**
+     * Stat cap multipliers. e.g. Healers have a 10% VIT penalty, so it would be {'Vitality': 0.90}
+     */
     readonly itemStatCapMultipliers?: {
         [K in RawStatKey]?: number
     };
-    readonly aaPotency: number
+    /**
+     * Auto-attack potency amount
+     */
+    readonly aaPotency: number;
+    /**
+     * Substats which are NOT already in {@link irrelevantSubstats}, but which cannot be put onto custom relics.
+     *
+     * e.g. Healers and Tanks cannot put DHit on their custom relics.
+     */
+    readonly excludedRelicSubstats: readonly Substat[]
 }
 
 export type JobMultipliers = {

--- a/src/scripts/relicstats/relicstats.ts
+++ b/src/scripts/relicstats/relicstats.ts
@@ -2,7 +2,7 @@ import {GearItem, Substat} from "../geartypes";
 import {BaseParamMap} from "../datamanager";
 import {CharacterGearSet, EquippedItem} from "../gear";
 import {FieldBoundDataSelect, FieldBoundIntField} from "../components/util";
-import {ALL_SUB_STATS, STAT_ABBREVIATIONS} from "../xivconstants";
+import {ALL_SUB_STATS, getClassJobStats, JobName, STAT_ABBREVIATIONS, STAT_FULL_NAMES} from "../xivconstants";
 
 type BaseRelicStatModel = {
     /**
@@ -33,7 +33,11 @@ type UnknownRelicStatModel = BaseRelicStatModel & {
     type: 'unknown'
 }
 
-export type RelicStatModel = EwRelicStatModel | CustomRelicStatModel | UnknownRelicStatModel
+type PartialRelicStatModel = EwRelicStatModel | CustomRelicStatModel | UnknownRelicStatModel
+
+export type RelicStatModel = PartialRelicStatModel & {
+    excludedStats: readonly Substat[]
+}
 
 
 function ewRelic(large: number, small: number): EwRelicStatModel {
@@ -133,8 +137,38 @@ function customRelic(total: number): CustomRelicStatModel {
     }
 }
 
-// TODO: you need to not be able to edit certain stats, like DH for healers
-export function getRelicStatModelFor(gearItem: GearItem, baseParams: BaseParamMap): RelicStatModel | null {
+export function getRelicStatModelFor(gearItem: GearItem, baseParams: BaseParamMap, job: JobName): RelicStatModel | null {
+    const partial = getRelicStatModelForPartial(gearItem, baseParams);
+    if (partial === null) {
+        return null;
+    }
+    else {
+        const jobData = getClassJobStats(job);
+        return {
+            excludedStats: jobData.excludedRelicSubstats,
+            ...partial,
+            validate(item: EquippedItem, statToReport?: Substat): string[] {
+                const failures = [...partial.validate(item, statToReport)];
+                const relicStats = item.relicStats;
+                if (statToReport) {
+                    if (relicStats[statToReport] && jobData.excludedRelicSubstats.includes(statToReport)) {
+                        failures.push(`${STAT_FULL_NAMES[statToReport]} is not available on ${jobData.role.toLowerCase()} relics.`);
+                    }
+                }
+                else {
+                    for (let entry of Object.entries(relicStats)) {
+                        const stat = entry[0] as Substat;
+                        if (entry[1] && jobData.excludedRelicSubstats.includes(stat)) {
+                            failures.push(`Stat ${STAT_FULL_NAMES[stat]} is not available on ${jobData.role.toLowerCase()} relics.`);
+                        }
+                    }
+                }
+                return failures;
+            }
+        }
+    }
+}
+function getRelicStatModelForPartial(gearItem: GearItem, baseParams: BaseParamMap): PartialRelicStatModel | null {
     if (!gearItem.isCustomRelic) {
         return null;
     }
@@ -172,7 +206,15 @@ export function getRelicStatModelFor(gearItem: GearItem, baseParams: BaseParamMa
 
 export function makeRelicStatEditor(equipment: EquippedItem, stat: Substat, set: CharacterGearSet): HTMLElement {
     const gearItem = equipment.gearItem;
-    if (gearItem.relicStatModel.type === 'unknown' || gearItem.relicStatModel.type === 'customrelic') {
+    // If the stat is excluded, disable editing ONLY if the user had not already entered a value. Otherwise, they'd be
+    // stuck with a value that they can't clear.
+    if (gearItem.relicStatModel.type && gearItem.relicStatModel.excludedStats.includes(stat) && !equipment.relicStats[stat]) {
+        const div = document.createElement('div');
+        div.classList.add('relic-stat-excluded');
+        div.title = 'You cannot use this relic stat on this class';
+        return div;
+    }
+    else if (gearItem.relicStatModel.type === 'unknown' || gearItem.relicStatModel.type === 'customrelic') {
         const inputSubstatCap = gearItem.unsyncedVersion.statCaps[stat] ?? 1000;
         const input = new FieldBoundIntField(equipment.relicStats, stat, {
             postValidators: [ctx => {

--- a/src/scripts/relicstats/relicstats.ts
+++ b/src/scripts/relicstats/relicstats.ts
@@ -16,25 +16,55 @@ type BaseRelicStatModel = {
     validate(item: EquippedItem, statToReport?: Substat): string[]
 }
 
+/**
+ * Relic stat model for Endwalker-style relics, where you have X 'large' stats, and Y 'small' stats.
+ */
 type EwRelicStatModel = BaseRelicStatModel & {
     type: 'ewrelic'
-    smallValue: number
+    /**
+     * The stat value of the 'large' stats (typically the stat cap).
+     */
     largeValue: number
+    /**
+     * The stat value of the 'small' stats.
+     */
+    smallValue: number
+    /**
+     * The maximum number of large stats.
+     */
     numLarge: number
+    /**
+     * The maximum number of small stats.
+     */
     numSmall: number
 }
 
+/**
+ * Relic stat model for pre-EW relics, where you get to allocate stats as you wish as
+ * long as the total remains below a cap, and no individual stat goes over the normal
+ * stat cap.
+ */
 type CustomRelicStatModel = BaseRelicStatModel & {
     type: 'customrelic'
+    /**
+     * The cap for total stats.
+     */
     totalCap: number
 }
 
+/**
+ * Generic model for all unknown relics. The only validation performed is that no individual stat
+ * is over the stat cap.
+ */
 type UnknownRelicStatModel = BaseRelicStatModel & {
     type: 'unknown'
 }
 
 type PartialRelicStatModel = EwRelicStatModel | CustomRelicStatModel | UnknownRelicStatModel
 
+/**
+ * Final type for relic stat models.
+ */
 export type RelicStatModel = PartialRelicStatModel & {
     excludedStats: readonly Substat[]
 }
@@ -137,6 +167,13 @@ function customRelic(total: number): CustomRelicStatModel {
     }
 }
 
+/**
+ * Get a relic stat model for an item
+ *
+ * @param gearItem The item
+ * @param baseParams Data for BaseParams
+ * @param job The job
+ */
 export function getRelicStatModelFor(gearItem: GearItem, baseParams: BaseParamMap, job: JobName): RelicStatModel | null {
     const partial = getRelicStatModelForPartial(gearItem, baseParams);
     if (partial === null) {

--- a/src/scripts/xivconstants.ts
+++ b/src/scripts/xivconstants.ts
@@ -109,7 +109,8 @@ const STANDARD_HEALER: JobDataConst = {
     itemStatCapMultipliers: {
         'vitality': 0.90
     },
-    aaPotency: MELEE_AUTO_POTENCY
+    aaPotency: MELEE_AUTO_POTENCY,
+    excludedRelicSubstats: ['dhit'],
 } as const;
 
 const STANDARD_TANK: JobDataConst = {
@@ -118,7 +119,8 @@ const STANDARD_TANK: JobDataConst = {
     autoAttackStat: 'strength',
     irrelevantSubstats: ['spellspeed', 'piety'],
     // traitMulti: TODO: Tank Mastery?
-    aaPotency: MELEE_AUTO_POTENCY
+    aaPotency: MELEE_AUTO_POTENCY,
+    excludedRelicSubstats: ['dhit'],
 } as const;
 
 const STANDARD_MELEE: JobDataConst = {
@@ -126,7 +128,8 @@ const STANDARD_MELEE: JobDataConst = {
     mainStat: 'strength',
     autoAttackStat: 'strength',
     irrelevantSubstats: ['spellspeed', 'tenacity', 'piety'],
-    aaPotency: MELEE_AUTO_POTENCY
+    aaPotency: MELEE_AUTO_POTENCY,
+    excludedRelicSubstats: [],
 } as const;
 
 const STANDARD_RANGED: JobDataConst = {
@@ -135,7 +138,8 @@ const STANDARD_RANGED: JobDataConst = {
     autoAttackStat: 'dexterity',
     irrelevantSubstats: ['spellspeed', 'tenacity', 'piety'],
     traitMulti: (level, attackType) => attackType === 'Auto-attack' ? 1.0 :  1.2, // Increased Action Damage II
-    aaPotency: RANGE_AUTO_POTENCY
+    aaPotency: RANGE_AUTO_POTENCY,
+    excludedRelicSubstats: [],
 } as const;
 
 const STANDARD_CASTER: JobDataConst = {
@@ -147,7 +151,8 @@ const STANDARD_CASTER: JobDataConst = {
     itemStatCapMultipliers: {
         'vitality': 0.90
     },
-    aaPotency: MELEE_AUTO_POTENCY
+    aaPotency: MELEE_AUTO_POTENCY,
+    excludedRelicSubstats: [],
 } as const;
 
 

--- a/src/style.less
+++ b/src/style.less
@@ -2538,3 +2538,8 @@ rename-dialog {
   outline: initial;
   box-shadow: 0 0 2px 2px var(--table-selected-outline-color);
 }
+
+.relic-stat-excluded {
+  width: 100%;
+  height: 100%;
+}

--- a/src/style.less
+++ b/src/style.less
@@ -2539,6 +2539,7 @@ rename-dialog {
   box-shadow: 0 0 2px 2px var(--table-selected-outline-color);
 }
 
+// Cell for when a relic row is selected, but the cell's stat is "excluded" i.e. dhit on tank/healer
 .relic-stat-excluded {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
Prohibits putting invalid stats (i.e. dhit on tank/healer) on relics. 

Closes #41 