### PR TITLE
Adjust `CooldownTracker` state map

### DIFF
--- a/src/scripts/sims/common/cooldown_manager.ts
+++ b/src/scripts/sims/common/cooldown_manager.ts
@@ -47,7 +47,7 @@ class InternalState {
 export class CooldownTracker {
 
 
-    private readonly currentState: Map<Ability, InternalState> = new Map();
+    private readonly currentState: Map<string, InternalState> = new Map();
     public mode: CooldownMode = 'warn';
 
     public constructor(private timeSource: () => number, mode: CooldownMode = 'warn') {
@@ -89,7 +89,7 @@ export class CooldownTracker {
         // seconds. The trivial case is the ability is capped 'now' and you use it (works for charge based and normal).
         const newCappedAt = status.cappedAt.absolute + cdTime;
         const state = new InternalState(newCappedAt);
-        this.currentState.set(ability, state);
+        this.currentState.set(ability.name, state);
     }
 
     public canUse(ability: Ability, when?: number): boolean {
@@ -121,7 +121,7 @@ export class CooldownTracker {
         if (!ability.cooldown) {
             return defaultStatus(ability, desiredTime);
         }
-        const existing = this.currentState.get(ability);
+        const existing = this.currentState.get(ability.name);
         // Have existing state
         if (existing) {
             const cappedAt = existing.cappedAt;


### PR DESCRIPTION
Changes `CooldownTracker`'s `currentState` map to use ability name as the key, instead of the entire ability object.  This solves an issue where using a buff, such as Swiftcast, which creates a new ability object before passing it to the `CooldownTracker`, causes additional entries for the same ability in the `currentState` map, since the ability object of the non-Swiftcasted ability and Swiftcasted ability are no longer equal.  This prevents the `CooldownTracker` from properly tracking the cooldown state of an ability that is used with Swiftcast, or any other buff that creates a modified ability object before being passed to the `CooldownTracker`.