### PR TITLE
Combo support

### DIFF
--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -347,7 +347,7 @@ class ComboTracker {
     }
 
     set lastComboAbility(value: Ability | null) {
-        console.log(`Combo state: [${this.key}] '${this._lastComboAbility?.name} => ${value?.name}`);
+        // console.log(`Combo state: [${this.key}] '${this._lastComboAbility?.name} => ${value?.name}`);
         this._lastComboAbility = value;
     }
 }

--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -174,9 +174,10 @@ function updateComboTracker(combo: ComboData, ability: Ability, tracker: ComboTr
                 }
                 break;
             }
-        // The the ability does not match, then fall through the the same behavior as 'break'
+        // If the ability does not match, then fall through the same behavior as 'break'
         case "break":
             tracker.lastComboAbility = null;
+            break;
         case "nobreak":
             // Do nothing
             break;
@@ -336,7 +337,19 @@ export type CycleInfo = {
 }
 
 class ComboTracker {
-    lastComboAbility: Ability | null = null;
+    private _lastComboAbility: Ability | null = null;
+
+    constructor(public readonly key: String) {
+    }
+
+    get lastComboAbility(): Ability | null {
+        return this._lastComboAbility;
+    }
+
+    set lastComboAbility(value: Ability | null) {
+        console.log(`Combo state: [${this.key}] '${this._lastComboAbility?.name} => ${value?.name}`);
+        this._lastComboAbility = value;
+    }
 }
 
 
@@ -983,7 +996,7 @@ export class CycleProcessor {
         if (tracker) {
             return tracker;
         }
-        const out = new ComboTracker();
+        const out = new ComboTracker(key);
         this.comboTrackerMap.set(key, out);
         return out;
     }
@@ -1005,13 +1018,13 @@ export class CycleProcessor {
             const key = combo.comboKey;
             seen.push(key);
             const tracker = this.getComboTracker(key);
-            out = updateComboTracker(combo, ability, tracker);
+            out = updateComboTracker(combo, out, tracker);
         }
         for (let entry of this.comboTrackerMap.entries()) {
             const combo = comboData.others;
             if (!seen.includes(entry[0])) {
                 const tracker = entry[1];
-                out = updateComboTracker(combo, ability, tracker);
+                out = updateComboTracker(combo, out, tracker);
             }
         }
         return out;

--- a/packages/frontend/src/scripts/sims/sim_types.ts
+++ b/packages/frontend/src/scripts/sims/sim_types.ts
@@ -23,7 +23,7 @@ export type DotInfo = Readonly<{
  * The rest of the object is which fields of {@link DamagingAbility} you would like to override.
  */
 export type ComboData = Readonly<{
-    comboKey?: ComboKey,
+    comboKey?: ComboKeyMatch,
 }> & ({
     comboBehavior: 'start' | 'break' | 'nobreak'
 } | {
@@ -34,6 +34,7 @@ export type ComboData = Readonly<{
 }) & Partial<DamagingAbility>;
 
 export type ComboKey = 'default' | string;
+export type ComboKeyMatch = ComboKey | 'all';
 
 /**
  * Represents a non-damaging action
@@ -51,7 +52,6 @@ export type DamagingAbility = Readonly<{
     autoCrit?: boolean,
     autoDh?: boolean,
     dot?: DotInfo,
-    combos?: readonly ComboData[]
 }>;
 
 /**
@@ -87,7 +87,7 @@ export type BaseAbility = Readonly<{
     /**
      * How this skill contributes to the combo system.
      */
-    combos?: ComboData
+    combos?: readonly ComboData[]
     /**
      * The time that it takes to cast. Do not include caster tax. Defaults to 0.5 (thus 0.6 after adding caster tax)
      * if not specified, i.e. normal animation lock.

--- a/packages/frontend/src/scripts/sims/sim_types.ts
+++ b/packages/frontend/src/scripts/sims/sim_types.ts
@@ -9,7 +9,7 @@ export type DotInfo = Readonly<{
     duration: number,
     tickPotency: number,
     id: number
-}>
+}>;
 
 /**
  * Represents combo-related data.
@@ -22,11 +22,11 @@ export type DotInfo = Readonly<{
  *
  * The rest of the object is which fields of {@link DamagingAbility} you would like to override.
  */
-export type ComboData = Readonly<{
+export type ComboData = ({
     comboKey?: ComboKeyMatch,
-}> & ({
     comboBehavior: 'start' | 'break' | 'nobreak'
 } | {
+    comboKey?: ComboKey,
     comboBehavior: 'continue',
     comboFrom: readonly(Ability & {
         id: number
@@ -61,7 +61,7 @@ export type DamagingAbility = Readonly<{
  * break: cancel any current combo. Default for GCDs.
  * nobreak: no impact on any current combo. Default for non-GCDs.
  */
-export type ComboBehavior = 'start' | 'continue' | 'break' | 'nobreak';
+export type ComboBehavior = ComboData['comboBehavior'];
 
 export type BaseAbility = Readonly<{
     /**

--- a/packages/frontend/src/scripts/sims/sim_types.ts
+++ b/packages/frontend/src/scripts/sims/sim_types.ts
@@ -2,29 +2,92 @@ import {JobName} from "@xivgear/xivmath/xivconstants";
 import {AttackType} from "@xivgear/xivmath/geartypes";
 import {CombinedBuffEffect, DamageResult} from "./sim_processors";
 
+/**
+ * Represents a DoT
+ */
 export type DotInfo = Readonly<{
     duration: number,
     tickPotency: number,
     id: number
 }>
 
+/**
+ * Represents combo-related data.
+ *
+ * comboFrom is a list of abilities that this ability can combo after. e.g. if we have a 1-2-3 combo,
+ * then 1 would not have combo data, while 2 would list 1 as its comboFrom, and 3 would list 2 as its
+ * comboFrom.
+ *
+ * These are keyed on their ID, so they must have an ID.
+ *
+ * The rest of the object is which fields of {@link DamagingAbility} you would like to override.
+ */
+export type ComboData = Readonly<{
+    comboKey?: ComboKey,
+}> & ({
+    comboBehavior: 'start' | 'break' | 'nobreak'
+} | {
+    comboBehavior: 'continue',
+    comboFrom: readonly(Ability & {
+        id: number
+    })[],
+}) & Partial<DamagingAbility>;
+
+export type ComboKey = 'default' | string;
+
+/**
+ * Represents a non-damaging action
+ */
 export type NonDamagingAbility = Readonly<{
     potency: null,
-}>
+}>;
+
+/**
+ * Represents a damaging action
+ */
 export type DamagingAbility = Readonly<{
     potency: number,
     attackType: AttackType,
     autoCrit?: boolean,
     autoDh?: boolean,
-    dot?: DotInfo
-}>
+    dot?: DotInfo,
+    combos?: readonly ComboData[]
+}>;
+
+/**
+ * Combo mode:
+ * start: starts a combo.
+ * continue: continue (or finish) a combo. If there is no combo, then this is treated as 'break'.
+ * break: cancel any current combo. Default for GCDs.
+ * nobreak: no impact on any current combo. Default for non-GCDs.
+ */
+export type ComboBehavior = 'start' | 'continue' | 'break' | 'nobreak';
 
 export type BaseAbility = Readonly<{
+    /**
+     * Name of the ability.
+     */
     name: string,
+    /**
+     * Status effects that are automatically activated by the ability
+     */
     activatesBuffs?: readonly Buff[],
+    /**
+     * The ID of the ability. Used for xivapi lookup for the icon.
+     */
     id?: number,
+    /**
+     * The type of action - Autoattack, Spell, Weaponskill, Ability (oGCD), etc
+     */
     attackType: AttackType,
+    /**
+     * Optional - the cooldown.
+     */
     cooldown?: Cooldown,
+    /**
+     * How this skill contributes to the combo system.
+     */
+    combos?: ComboData
     /**
      * The time that it takes to cast. Do not include caster tax. Defaults to 0.5 (thus 0.6 after adding caster tax)
      * if not specified, i.e. normal animation lock.
@@ -60,7 +123,7 @@ export type Cooldown = Readonly<{
 }>
 
 /**
- * Represents an ability you can use
+ * Represents a GCD action
  */
 export type GcdAbility = BaseAbility & Readonly<{
     type: 'gcd';
@@ -70,14 +133,17 @@ export type GcdAbility = BaseAbility & Readonly<{
     gcd: number,
 }>
 
+/**
+ * Represents an oGCD action
+ */
 export type OgcdAbility = BaseAbility & Readonly<{
     type: 'ogcd',
-}>
+}>;
 
 export type AutoAttack = BaseAbility & DamagingAbility & Readonly<{
     type: 'autoattack',
     // TODO
-}>
+}>;
 
 export type Ability = GcdAbility | OgcdAbility | AutoAttack;
 
@@ -85,11 +151,11 @@ export type DotDamageUnf = {
     fullDurationTicks: number,
     damagePerTick: ComputedDamage,
     actualTickCount?: number
-}
+};
 
 export type ComputedDamage = {
     expected: number,
-}
+};
 
 /**
  * Represents an ability actually being used
@@ -146,7 +212,7 @@ export type UsedAbility = {
      * a cast, this is the cast time + caster tax.
      */
     lockTime: number
-}
+};
 
 /**
  * Represents a pseudo-ability used to round out a cycle to exactly 120s.
@@ -157,7 +223,7 @@ export type UsedAbility = {
  */
 export type PartiallyUsedAbility = UsedAbility & {
     portion: number
-}
+};
 
 export type FinalizedAbility = {
     usedAt: number,
@@ -170,7 +236,7 @@ export type FinalizedAbility = {
     combinedEffects: CombinedBuffEffect,
     ability: Ability,
     buffs: Buff[]
-}
+};
 
 /**
  * Describes the effects of a buff
@@ -200,12 +266,12 @@ export type BuffEffects = {
      * Haste. Expressed as the percentage value, e.g. 20 = 20% faster GCD
      */
     haste?: number,
-}
+};
 
 export type BuffController = {
     removeStatus(buff: Buff): void;
     removeSelf(): void;
-}
+};
 
 // TODO: refactor this into Buff and PartyBuff so that the fields used for the party buffs (job, CD) can be untangled
 export type BaseBuff = Readonly<{
@@ -276,6 +342,6 @@ export type PartyBuff = BaseBuff & Readonly<{
      */
     startTime?: number,
 
-}>
+}>;
 
 export type Buff = BaseBuff | PartyBuff;

--- a/packages/frontend/src/scripts/test/sims/ability_helpers.ts
+++ b/packages/frontend/src/scripts/test/sims/ability_helpers.ts
@@ -1,0 +1,62 @@
+import {Ability, ComboData, ComboKeyMatch} from "../../sims/sim_types";
+import {STANDARD_APPLICATION_DELAY} from "@xivgear/xivmath/xivconstants";
+
+/**
+ * Returns the application delay of an ability (from time of snapshot to time of damage/effects applying).
+ *
+ * @param ability The ability in question
+ */
+export function appDelay(ability: Ability) {
+    let delay = STANDARD_APPLICATION_DELAY;
+    // TODO: add application delay field to Ability
+    return delay;
+}
+
+function defaultComboData(ability: Ability): ComboData {
+    if (ability.type === 'gcd') {
+        return {
+            comboBehavior: 'break',
+            comboKey: "all"
+        }
+    }
+    else {
+        return {
+            comboBehavior: 'nobreak',
+            comboKey: "all"
+        }
+    }
+}
+
+export type FinalizedComboData = {
+    combos: ComboData[],
+    others: ComboData
+}
+
+/**
+ * Given an ability with 'raw' combo data, complete the data.
+ *
+ * First, if there is not a
+ *
+ * @param ability
+ */
+export function completeComboData(ability: Ability): FinalizedComboData {
+    const all = ability.combos ?? [];
+    const combos = [];
+    let others: ComboData = null;
+    for (let combo of all) {
+        const key = combo.comboKey ?? 'default';
+        if (key === "all") {
+            others = combo;
+        }
+        else {
+            combos.push(combo);
+        }
+    }
+    if (others === null) {
+        others = defaultComboData(ability);
+    }
+    return {
+        combos: combos,
+        others: others,
+    };
+}

--- a/packages/frontend/src/scripts/test/sims/ability_helpers.ts
+++ b/packages/frontend/src/scripts/test/sims/ability_helpers.ts
@@ -45,11 +45,30 @@ export function completeComboData(ability: Ability): FinalizedComboData {
     let others: ComboData = null;
     for (let combo of all) {
         const key = combo.comboKey ?? 'default';
+        // For continuations, validate that they actually continue off of something that
+        // is eligible to start a combo.
+        if (combo.comboBehavior === 'continue') {
+            combo.comboFrom.forEach((from: Ability) => {
+                const found = from.combos?.find(fromCombo => {
+                    const otherKey = fromCombo.comboKey ?? 'default';
+                    if (otherKey === key) {
+                        return fromCombo.comboBehavior === 'start' || fromCombo.comboBehavior === 'continue';
+                    }
+                    return false;
+                });
+                if (!found) {
+                    console.error(`Ability '${ability.name}' wants to continue combo from '${from.name}' for combo key '${key}', but that skill cannot start this combo.`);
+                }
+            });
+        }
         if (key === "all") {
             others = combo;
         }
         else {
-            combos.push(combo);
+            combos.push({
+                ...combo,
+                comboKey: key
+            });
         }
     }
     if (others === null) {

--- a/packages/frontend/src/scripts/test/sims/combo_test.ts
+++ b/packages/frontend/src/scripts/test/sims/combo_test.ts
@@ -4,11 +4,7 @@ import {CycleProcessor} from "../../sims/sim_processors";
 import {exampleGearSet} from "./common_values";
 import assert from "assert";
 
-type IdAb = (Ability & {
-    id: number
-});
-
-const initial1: IdAb = {
+const initial1 = {
     name: "Initial Ability 1",
     id: 100_001,
     attackType: 'Weaponskill',
@@ -18,9 +14,9 @@ const initial1: IdAb = {
     combos: [{
         comboBehavior: "start"
     }]
-}
+} as const satisfies Ability;
 
-const initial2: IdAb = {
+const initial2 = {
     name: "Initial Ability 2",
     id: 100_002,
     attackType: 'Weaponskill',
@@ -30,18 +26,53 @@ const initial2: IdAb = {
     combos: [{
         comboBehavior: "start"
     }]
-}
+} as const satisfies Ability;
 
-const notCombo: Ability = {
+const notCombo = {
     name: "Non-Combo Ability",
     id: 100_003,
     attackType: 'Weaponskill',
     potency: 120,
     type: 'gcd',
     gcd: 2.5
-}
+} as const satisfies Ability;
 
-const cont1: IdAb = {
+const ogcd = {
+    name: "Default oGCD",
+    id: 100_101,
+    attackType: 'Ability',
+    potency: 123,
+    type: 'ogcd',
+} as const satisfies Ability;
+
+const ogcdInterrupt = {
+    name: "oGCD that breaks default combo",
+    id: 100_102,
+    attackType: 'Ability',
+    potency: 124,
+    type: 'ogcd',
+    combos: [{
+        comboBehavior: 'break'
+    }]
+} as const satisfies Ability;
+// TODO: oGCD that breaks all combos
+// TODO: gcd that doesn't break a specific combo
+// TODO: gcd that doesn't break any combo
+
+const ogcdWithOtherInterrupt = {
+    name: "oGCD that breaks other combo",
+    id: 100_103,
+    attackType: 'Ability',
+    potency: 125,
+    type: 'ogcd',
+    combos: [{
+        comboKey: 'side combo',
+        comboBehavior: 'break',
+    }]
+} as const satisfies Ability;
+
+
+const cont1 = {
     name: "Followup Ability",
     id: 100_004,
     attackType: 'Weaponskill',
@@ -51,18 +82,13 @@ const cont1: IdAb = {
     combos: [
         {
             comboBehavior: "continue",
-            comboFrom: [initial1],
+            comboFrom: [initial1, initial2],
             potency: 200
         },
-        {
-            comboBehavior: "continue",
-            comboFrom: [initial2],
-            potency: 300,
-        }
     ]
-}
+} as const satisfies Ability;
 
-const cont2: IdAb = {
+const cont2 = {
     name: "Followup Ability 2",
     id: 100_004,
     attackType: 'Weaponskill',
@@ -76,11 +102,9 @@ const cont2: IdAb = {
             potency: 500
         },
     ]
-}
+} as const satisfies Ability;
 
 /** TODO: test cases
- * - non-combo version of ability
- * - combo versions of ability
  * - combo not interrupted by oGCD by default
  * - combo interrupted by GCD by default
  * - combo not interrupted by GCD which is explicitly not a combo breaker
@@ -122,12 +146,120 @@ describe('sim processor combo support', () => {
         const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
             return 'ability' in record;
         });
-        assert.equal(140, actualAbilities[0].totalPotency);
-        assert.equal(150, actualAbilities[1].totalPotency);
-        assert.equal(100, actualAbilities[2].totalPotency);
-        assert.equal(200, actualAbilities[3].totalPotency);
-        assert.equal(500, actualAbilities[4].totalPotency);
+        assert.equal(actualAbilities[0].totalPotency, cont1.potency);
+        assert.equal(actualAbilities[1].totalPotency, cont2.potency);
+        assert.equal(actualAbilities[2].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[3].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[4].totalPotency, cont2.combos[0].potency);
+        assert.equal(actualAbilities[5].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[6].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[7].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[8].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[9].totalPotency, cont2.combos[0].potency);
+        assert.equal(actualAbilities[10].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[11].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[12].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[13].totalPotency, cont2.potency);
+    });
+    it('unrelated ability should cancel combo', () => {
+        const cp = new CycleProcessor({
+            allBuffs: [],
+            cycleTime: 120,
+            stats: exampleGearSet.computedStats,
+            totalTime: 295,
+            useAutos: false
+        });
+        // Unrelated ability should cancel combo
+        cp.use(initial1);
+        cp.use(notCombo);
+        cp.use(cont1);
+        cp.use(cont2);
+        // Try again, interrupt in different point
+        cp.use(initial1);
+        cp.use(cont1);
+        cp.use(notCombo);
+        cp.use(cont2);
 
+        const displayRecords = cp.finalizedRecords;
+        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
+            return 'ability' in record;
+        });
 
+        assert.equal(actualAbilities[0].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[1].totalPotency, notCombo.potency);
+        assert.equal(actualAbilities[2].totalPotency, cont1.potency);
+        assert.equal(actualAbilities[3].totalPotency, cont2.potency);
+
+        assert.equal(actualAbilities[4].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[5].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[6].totalPotency, notCombo.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont2.potency);
+    });
+    it('should not interrupt a combo when an oGCD is used by default', () => {
+        const cp = new CycleProcessor({
+            allBuffs: [],
+            cycleTime: 120,
+            stats: exampleGearSet.computedStats,
+            totalTime: 295,
+            useAutos: false
+        });
+        // oGCD should not cancel
+        cp.use(initial2);
+        cp.use(ogcd)
+        cp.use(cont1);
+        cp.use(cont2);
+        cp.use(initial2);
+        cp.use(cont1);
+        cp.use(ogcd)
+        cp.use(cont2);
+
+        const displayRecords = cp.finalizedRecords;
+        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
+            return 'ability' in record;
+        });
+
+        assert.equal(actualAbilities[0].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[1].totalPotency, ogcd.potency);
+        assert.equal(actualAbilities[2].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[3].totalPotency, cont2.combos[0].potency);
+
+        assert.equal(actualAbilities[4].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[5].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[6].totalPotency, ogcd.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont2.combos[0].potency);
+    });
+    it('should not interrupt a combo if the oGCD breaks a different combo', () => {
+        const cp = new CycleProcessor({
+            allBuffs: [],
+            cycleTime: 120,
+            stats: exampleGearSet.computedStats,
+            totalTime: 295,
+            useAutos: false
+        });
+        // oGCD should not cancel
+        cp.use(initial2);
+        cp.use(ogcdWithOtherInterrupt)
+        cp.use(cont1);
+        cp.use(cont2);
+
+        cp.use(initial2);
+        cp.use(cont1);
+        cp.use(ogcdWithOtherInterrupt)
+        cp.use(cont2);
+
+        const displayRecords = cp.finalizedRecords;
+        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
+            return 'ability' in record;
+        });
+
+        assert.equal(actualAbilities[0].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[1].totalPotency, ogcdWithOtherInterrupt.potency);
+        assert.equal(actualAbilities[2].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[3].totalPotency, cont2.combos[0].potency);
+
+        assert.equal(actualAbilities[4].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[5].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[6].totalPotency, ogcdWithOtherInterrupt.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont2.combos[0].potency);
     });
 });

--- a/packages/frontend/src/scripts/test/sims/combo_test.ts
+++ b/packages/frontend/src/scripts/test/sims/combo_test.ts
@@ -1,0 +1,92 @@
+import {Ability} from "../../sims/sim_types";
+import {CycleProcessor} from "../../sims/sim_processors";
+import {exampleGearSet} from "./common_values";
+
+type IdAb = (Ability & {
+    id: number
+});
+
+const initial1: IdAb = {
+    name: "Initial Ability 1",
+    id: 100_001,
+    attackType: 'Weaponskill',
+    potency: 100,
+    type: 'gcd',
+    gcd: 2.5
+}
+
+const initial2: IdAb = {
+    name: "Initial Ability 2",
+    id: 100_002,
+    attackType: 'Weaponskill',
+    potency: 110,
+    type: 'gcd',
+    gcd: 2.5
+}
+
+const notCombo: Ability = {
+    name: "Non-Combo Ability",
+    id: 100_003,
+    attackType: 'Weaponskill',
+    potency: 120,
+    type: 'gcd',
+    gcd: 2.5
+}
+
+const cont1: IdAb = {
+    name: "Followup Ability",
+    id: 100_004,
+    attackType: 'Weaponskill',
+    potency: 140,
+    type: 'gcd',
+    gcd: 2.5,
+    combos: [
+        {
+            comboFrom: [initial1],
+            potency: 200
+        },
+        {
+            comboFrom: [initial2],
+            potency: 300
+        }
+    ]
+}
+const cont2: IdAb = {
+    name: "Followup Ability 2",
+    id: 100_004,
+    attackType: 'Weaponskill',
+    potency: 140,
+    type: 'gcd',
+    gcd: 2.5,
+    combos: [
+        {
+            comboFrom: [cont1],
+            potency: 200
+        },
+    ]
+}
+
+/** TODO: test cases
+ * - non-combo version of ability
+ * - combo versions of ability
+ * - combo not interrupted by oGCD by default
+ * - combo interrupted by GCD by default
+ * - combo not interrupted by GCD which is explicitly not a combo breaker
+ * - combo interrupted by oGCD which is explicitly a combo breaker
+ * - GNB-style multiple combos
+ */
+
+describe('sim processor combo support', () => {
+    it('understands combos', () => {
+        const cp = new CycleProcessor({
+            allBuffs: [],
+            cycleTime: 120,
+            stats: exampleGearSet.computedStats,
+            totalTime: 295,
+            useAutos: false
+        });
+        // Use continuation ability initially, should not be a combo
+        cp.use(cont1);
+
+    });
+});

--- a/packages/frontend/src/scripts/test/sims/combo_test.ts
+++ b/packages/frontend/src/scripts/test/sims/combo_test.ts
@@ -1,6 +1,8 @@
-import {Ability} from "../../sims/sim_types";
+import 'global-jsdom/register'
+import {Ability, FinalizedAbility} from "../../sims/sim_types";
 import {CycleProcessor} from "../../sims/sim_processors";
 import {exampleGearSet} from "./common_values";
+import assert from "assert";
 
 type IdAb = (Ability & {
     id: number
@@ -12,7 +14,10 @@ const initial1: IdAb = {
     attackType: 'Weaponskill',
     potency: 100,
     type: 'gcd',
-    gcd: 2.5
+    gcd: 2.5,
+    combos: [{
+        comboBehavior: "start"
+    }]
 }
 
 const initial2: IdAb = {
@@ -21,7 +26,10 @@ const initial2: IdAb = {
     attackType: 'Weaponskill',
     potency: 110,
     type: 'gcd',
-    gcd: 2.5
+    gcd: 2.5,
+    combos: [{
+        comboBehavior: "start"
+    }]
 }
 
 const notCombo: Ability = {
@@ -42,26 +50,30 @@ const cont1: IdAb = {
     gcd: 2.5,
     combos: [
         {
+            comboBehavior: "continue",
             comboFrom: [initial1],
             potency: 200
         },
         {
+            comboBehavior: "continue",
             comboFrom: [initial2],
-            potency: 300
+            potency: 300,
         }
     ]
 }
+
 const cont2: IdAb = {
     name: "Followup Ability 2",
     id: 100_004,
     attackType: 'Weaponskill',
-    potency: 140,
+    potency: 150,
     type: 'gcd',
     gcd: 2.5,
     combos: [
         {
+            comboBehavior: "continue",
             comboFrom: [cont1],
-            potency: 200
+            potency: 500
         },
     ]
 }
@@ -74,10 +86,11 @@ const cont2: IdAb = {
  * - combo not interrupted by GCD which is explicitly not a combo breaker
  * - combo interrupted by oGCD which is explicitly a combo breaker
  * - GNB-style multiple combos
+ *      - including "default" vs "non-default" vs "all" combo keys
  */
 
 describe('sim processor combo support', () => {
-    it('understands combos', () => {
+    it('understands basic combo mechanics', () => {
         const cp = new CycleProcessor({
             allBuffs: [],
             cycleTime: 120,
@@ -87,6 +100,34 @@ describe('sim processor combo support', () => {
         });
         // Use continuation ability initially, should not be a combo
         cp.use(cont1);
+        cp.use(cont2);
+        // Use combo properly
+        cp.use(initial1);
+        cp.use(cont1);
+        cp.use(cont2);
+        // Start combo but interrupt
+        cp.use(initial1);
+        cp.use(cont1);
+        // And then do combo normally
+        cp.use(initial2);
+        cp.use(cont1);
+        cp.use(cont2);
+        // Start combo but interrupt, mess up subsequently
+        cp.use(initial1);
+        cp.use(cont1);
+        cp.use(initial2);
+        cp.use(cont2);
+
+        const displayRecords = cp.finalizedRecords;
+        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
+            return 'ability' in record;
+        });
+        assert.equal(140, actualAbilities[0].totalPotency);
+        assert.equal(150, actualAbilities[1].totalPotency);
+        assert.equal(100, actualAbilities[2].totalPotency);
+        assert.equal(200, actualAbilities[3].totalPotency);
+        assert.equal(500, actualAbilities[4].totalPotency);
+
 
     });
 });

--- a/packages/frontend/src/scripts/test/sims/combo_test.ts
+++ b/packages/frontend/src/scripts/test/sims/combo_test.ts
@@ -71,6 +71,34 @@ const ogcdWithOtherInterrupt = {
     }]
 } as const satisfies Ability;
 
+const ogcdThatBreaksEverything = {
+    name: "Default oGCD",
+    id: 100_104,
+    attackType: 'Ability',
+    potency: 126,
+    type: 'ogcd',
+    combos: [{
+        comboKey: "all",
+        comboBehavior: "break",
+    }]
+} as const satisfies Ability;
+
+const ogcdThatBreaksEverythingButThis = {
+    name: "Default oGCD",
+    id: 100_104,
+    attackType: 'Ability',
+    potency: 127,
+    type: 'ogcd',
+    combos: [
+        {
+            comboBehavior: "nobreak",
+        },
+        {
+            comboKey: "all",
+            comboBehavior: "break",
+        }
+    ]
+} as const satisfies Ability;
 
 const cont1 = {
     name: "Followup Ability",
@@ -79,13 +107,11 @@ const cont1 = {
     potency: 140,
     type: 'gcd',
     gcd: 2.5,
-    combos: [
-        {
-            comboBehavior: "continue",
-            comboFrom: [initial1, initial2],
-            potency: 200
-        },
-    ]
+    combos: [{
+        comboBehavior: "continue",
+        comboFrom: [initial1, initial2],
+        potency: 200
+    }]
 } as const satisfies Ability;
 
 const cont2 = {
@@ -95,56 +121,123 @@ const cont2 = {
     potency: 150,
     type: 'gcd',
     gcd: 2.5,
-    combos: [
-        {
-            comboBehavior: "continue",
-            comboFrom: [cont1],
-            potency: 500
-        },
-    ]
+    combos: [{
+        comboBehavior: "continue",
+        comboFrom: [cont1],
+        potency: 500
+    }]
+} as const satisfies Ability;
+
+const nonBreakingGcd = {
+    name: "GCD that doesn't break combo",
+    id: 100_005,
+    attackType: 'Weaponskill',
+    potency: 152,
+    type: 'gcd',
+    gcd: 2.5,
+    combos: [{
+        comboBehavior: 'nobreak',
+    }],
+} as const satisfies Ability;
+
+const gnashKey = 'gnashingCombo';
+
+const gnbGnash1 = {
+    name: 'Gnashing Fang',
+    id: 101_001,
+    attackType: 'Weaponskill',
+    potency: 380,
+    type: 'gcd',
+    gcd: 2.5,
+    combos: [{
+        comboBehavior: 'nobreak',
+    }, {
+        comboKey: gnashKey,
+        comboBehavior: 'start'
+    }]
+} as const satisfies Ability;
+
+const gnbGnash2 = {
+    name: 'Savage Claw',
+    id: 101_002,
+    attackType: 'Weaponskill',
+    // TODO: need a better "locked out ability" flag
+    potency: 0,
+    type: 'gcd',
+    gcd: 2.5,
+    combos: [{
+        comboBehavior: 'nobreak',
+    }, {
+        comboKey: gnashKey,
+        comboBehavior: 'continue',
+        comboFrom: [gnbGnash1],
+        potency: 460
+    }]
+} as const satisfies Ability;
+
+const gnbGnash3 = {
+    name: 'Wicked Talon',
+    id: 101_003,
+    attackType: 'Weaponskill',
+    potency: 0,
+    type: 'gcd',
+    gcd: 2.5,
+    combos: [{
+        comboBehavior: 'nobreak',
+    }, {
+        comboKey: gnashKey,
+        comboBehavior: 'continue',
+        comboFrom: [gnbGnash2],
+        potency: 540
+    }]
 } as const satisfies Ability;
 
 /** TODO: test cases
- * - combo not interrupted by oGCD by default
  * - combo interrupted by GCD by default
  * - combo not interrupted by GCD which is explicitly not a combo breaker
- * - combo interrupted by oGCD which is explicitly a combo breaker
  * - GNB-style multiple combos
  *      - including "default" vs "non-default" vs "all" combo keys
  */
 
+function quickTest(testCase: (cp: CycleProcessor) => void): FinalizedAbility[] {
+    const cp = new CycleProcessor({
+        allBuffs: [],
+        cycleTime: 120,
+        stats: exampleGearSet.computedStats,
+        totalTime: 295,
+        useAutos: false
+    });
+    testCase(cp);
+    const displayRecords = cp.finalizedRecords;
+    const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
+        return 'ability' in record;
+    });
+    return actualAbilities;
+}
+
 describe('sim processor combo support', () => {
     it('understands basic combo mechanics', () => {
-        const cp = new CycleProcessor({
-            allBuffs: [],
-            cycleTime: 120,
-            stats: exampleGearSet.computedStats,
-            totalTime: 295,
-            useAutos: false
-        });
-        // Use continuation ability initially, should not be a combo
-        cp.use(cont1);
-        cp.use(cont2);
-        // Use combo properly
-        cp.use(initial1);
-        cp.use(cont1);
-        cp.use(cont2);
-        // Start combo but interrupt
-        cp.use(initial1);
-        cp.use(cont1);
-        // And then do combo normally
-        cp.use(initial2);
-        cp.use(cont1);
-        cp.use(cont2);
-        // Start combo but interrupt, mess up subsequently
-        cp.use(initial1);
-        cp.use(cont1);
-        cp.use(initial2);
-        cp.use(cont2);
+        const actualAbilities = quickTest(cp => {
 
-        const displayRecords = cp.finalizedRecords;
-        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
-            return 'ability' in record;
+            // Use continuation ability initially, should not be a combo
+            cp.use(cont1);
+            cp.use(cont2);
+            // Use combo properly
+            cp.use(initial1);
+            cp.use(cont1);
+            cp.use(cont2);
+            // Start combo but interrupt
+            cp.use(initial1);
+            cp.use(cont1);
+            // And then do combo normally
+            cp.use(initial2);
+            cp.use(cont1);
+            cp.use(cont2);
+            // Start combo but interrupt, mess up subsequently
+            cp.use(initial1);
+            cp.use(cont1);
+            cp.use(initial2);
+            cp.use(cont2);
         });
         assert.equal(actualAbilities[0].totalPotency, cont1.potency);
         assert.equal(actualAbilities[1].totalPotency, cont2.potency);
@@ -162,29 +255,18 @@ describe('sim processor combo support', () => {
         assert.equal(actualAbilities[13].totalPotency, cont2.potency);
     });
     it('unrelated ability should cancel combo', () => {
-        const cp = new CycleProcessor({
-            allBuffs: [],
-            cycleTime: 120,
-            stats: exampleGearSet.computedStats,
-            totalTime: 295,
-            useAutos: false
+        const actualAbilities = quickTest(cp => {
+            // Unrelated ability should cancel combo
+            cp.use(initial1);
+            cp.use(notCombo);
+            cp.use(cont1);
+            cp.use(cont2);
+            // Try again, interrupt in different point
+            cp.use(initial1);
+            cp.use(cont1);
+            cp.use(notCombo);
+            cp.use(cont2);
         });
-        // Unrelated ability should cancel combo
-        cp.use(initial1);
-        cp.use(notCombo);
-        cp.use(cont1);
-        cp.use(cont2);
-        // Try again, interrupt in different point
-        cp.use(initial1);
-        cp.use(cont1);
-        cp.use(notCombo);
-        cp.use(cont2);
-
-        const displayRecords = cp.finalizedRecords;
-        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
-            return 'ability' in record;
-        });
-
         assert.equal(actualAbilities[0].totalPotency, initial1.potency);
         assert.equal(actualAbilities[1].totalPotency, notCombo.potency);
         assert.equal(actualAbilities[2].totalPotency, cont1.potency);
@@ -196,27 +278,18 @@ describe('sim processor combo support', () => {
         assert.equal(actualAbilities[7].totalPotency, cont2.potency);
     });
     it('should not interrupt a combo when an oGCD is used by default', () => {
-        const cp = new CycleProcessor({
-            allBuffs: [],
-            cycleTime: 120,
-            stats: exampleGearSet.computedStats,
-            totalTime: 295,
-            useAutos: false
+        const actualAbilities = quickTest(cp => {
+            // oGCD should not cancel
+            cp.use(initial2);
+            cp.use(ogcd)
+            cp.use(cont1);
+            cp.use(cont2);
+            cp.use(initial2);
+            cp.use(cont1);
+            cp.use(ogcd)
+            cp.use(cont2);
         });
-        // oGCD should not cancel
-        cp.use(initial2);
-        cp.use(ogcd)
-        cp.use(cont1);
-        cp.use(cont2);
-        cp.use(initial2);
-        cp.use(cont1);
-        cp.use(ogcd)
-        cp.use(cont2);
 
-        const displayRecords = cp.finalizedRecords;
-        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
-            return 'ability' in record;
-        });
 
         assert.equal(actualAbilities[0].totalPotency, initial2.potency);
         assert.equal(actualAbilities[1].totalPotency, ogcd.potency);
@@ -229,29 +302,18 @@ describe('sim processor combo support', () => {
         assert.equal(actualAbilities[7].totalPotency, cont2.combos[0].potency);
     });
     it('should not interrupt a combo if the oGCD breaks a different combo', () => {
-        const cp = new CycleProcessor({
-            allBuffs: [],
-            cycleTime: 120,
-            stats: exampleGearSet.computedStats,
-            totalTime: 295,
-            useAutos: false
+        const actualAbilities = quickTest(cp => {
+            // oGCD should not cancel
+            cp.use(initial2);
+            cp.use(ogcdWithOtherInterrupt)
+            cp.use(cont1);
+            cp.use(cont2);
+
+            cp.use(initial2);
+            cp.use(cont1);
+            cp.use(ogcdWithOtherInterrupt)
+            cp.use(cont2);
         });
-        // oGCD should not cancel
-        cp.use(initial2);
-        cp.use(ogcdWithOtherInterrupt)
-        cp.use(cont1);
-        cp.use(cont2);
-
-        cp.use(initial2);
-        cp.use(cont1);
-        cp.use(ogcdWithOtherInterrupt)
-        cp.use(cont2);
-
-        const displayRecords = cp.finalizedRecords;
-        const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
-            return 'ability' in record;
-        });
-
         assert.equal(actualAbilities[0].totalPotency, initial2.potency);
         assert.equal(actualAbilities[1].totalPotency, ogcdWithOtherInterrupt.potency);
         assert.equal(actualAbilities[2].totalPotency, cont1.combos[0].potency);
@@ -262,4 +324,126 @@ describe('sim processor combo support', () => {
         assert.equal(actualAbilities[6].totalPotency, ogcdWithOtherInterrupt.potency);
         assert.equal(actualAbilities[7].totalPotency, cont2.combos[0].potency);
     });
+    it('ogcd that breaks combo should break the combo', () => {
+        const actualAbilities = quickTest(cp => {
+            // Unrelated ability should cancel combo
+            cp.use(initial1);
+            cp.use(ogcdInterrupt);
+            cp.use(cont1);
+            cp.use(cont2);
+            // Try again, interrupt in different point
+            cp.use(initial1);
+            cp.use(cont1);
+            cp.use(ogcdInterrupt);
+            cp.use(cont2);
+        });
+        assert.equal(actualAbilities[0].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[1].totalPotency, ogcdInterrupt.potency);
+        assert.equal(actualAbilities[2].totalPotency, cont1.potency);
+        assert.equal(actualAbilities[3].totalPotency, cont2.potency);
+
+        assert.equal(actualAbilities[4].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[5].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[6].totalPotency, ogcdInterrupt.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont2.potency);
+    });
+    it('ogcd that breaks all combos should break the combo', () => {
+        const actualAbilities = quickTest(cp => {
+            // Unrelated ability should cancel combo
+            cp.use(initial1);
+            cp.use(ogcdThatBreaksEverything);
+            cp.use(cont1);
+            cp.use(cont2);
+            // Try again, interrupt in different point
+            cp.use(initial1);
+            cp.use(cont1);
+            cp.use(ogcdThatBreaksEverything);
+            cp.use(cont2);
+        });
+        assert.equal(actualAbilities[0].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[1].totalPotency, ogcdThatBreaksEverything.potency);
+        assert.equal(actualAbilities[2].totalPotency, cont1.potency);
+        assert.equal(actualAbilities[3].totalPotency, cont2.potency);
+
+        assert.equal(actualAbilities[4].totalPotency, initial1.potency);
+        assert.equal(actualAbilities[5].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[6].totalPotency, ogcdThatBreaksEverything.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont2.potency);
+    });
+    it('should not interrupt a combo if the oGCD breaks a different combo', () => {
+        const actualAbilities = quickTest(cp => {
+            cp.use(initial2);
+            cp.use(ogcdThatBreaksEverythingButThis);
+            cp.use(cont1);
+            cp.use(cont2);
+
+            cp.use(initial2);
+            cp.use(cont1);
+            cp.use(ogcdThatBreaksEverythingButThis);
+            cp.use(cont2);
+        });
+        assert.equal(actualAbilities[0].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[1].totalPotency, ogcdThatBreaksEverythingButThis.potency);
+        assert.equal(actualAbilities[2].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[3].totalPotency, cont2.combos[0].potency);
+
+        assert.equal(actualAbilities[4].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[5].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[6].totalPotency, ogcdThatBreaksEverythingButThis.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont2.combos[0].potency);
+    });
+    it('non-breaking GCD', () => {
+        const actualAbilities = quickTest(cp => {
+            cp.use(initial2);
+            cp.use(nonBreakingGcd);
+            cp.use(cont1);
+            cp.use(cont2);
+
+            cp.use(initial2);
+            cp.use(cont1);
+            cp.use(nonBreakingGcd);
+            cp.use(cont2);
+        });
+        assert.equal(actualAbilities[0].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[1].totalPotency, nonBreakingGcd.potency);
+        assert.equal(actualAbilities[2].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[3].totalPotency, cont2.combos[0].potency);
+
+        assert.equal(actualAbilities[4].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[5].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[6].totalPotency, nonBreakingGcd.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont2.combos[0].potency);
+    });
+    it('GNB example', () => {
+        const actualAbilities = quickTest(cp => {
+            // Gnashing combo should not cancel normal combo
+            cp.use(initial2);
+            cp.use(cont1);
+            cp.use(gnbGnash1);
+            cp.use(gnbGnash2);
+            cp.use(gnbGnash3);
+            cp.use(cont2);
+
+            // Normal combo should cancel gnashing combo
+            cp.use(initial2);
+            cp.use(cont1);
+            cp.use(gnbGnash1);
+            cp.use(gnbGnash2);
+            cp.use(cont2);
+            cp.use(gnbGnash3);
+        });
+        assert.equal(actualAbilities[0].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[1].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[2].totalPotency, gnbGnash1.potency);
+        assert.equal(actualAbilities[3].totalPotency, gnbGnash2.combos[1].potency);
+        assert.equal(actualAbilities[4].totalPotency, gnbGnash3.combos[1].potency);
+        assert.equal(actualAbilities[5].totalPotency, cont2.combos[0].potency);
+
+        assert.equal(actualAbilities[6].totalPotency, initial2.potency);
+        assert.equal(actualAbilities[7].totalPotency, cont1.combos[0].potency);
+        assert.equal(actualAbilities[8].totalPotency, gnbGnash1.potency);
+        assert.equal(actualAbilities[9].totalPotency, gnbGnash2.combos[1].potency);
+        assert.equal(actualAbilities[10].totalPotency, cont2.combos[0].potency);
+        assert.equal(actualAbilities[11].totalPotency, gnbGnash3.potency);
+    })
 });


### PR DESCRIPTION
This supports defining multiple sets of combos on an ability, for corner cases like Gnashing Fang where you need to have two "combo" states being tracked at the same time, and have fine-grained control over which combos are canceled by what.