### PR TITLE
Property to allow autoattacks to be disabled by default in a cycle sim

### DIFF
--- a/packages/frontend/src/scripts/sims/blu/blu_common.ts
+++ b/packages/frontend/src/scripts/sims/blu/blu_common.ts
@@ -854,6 +854,10 @@ export abstract class BluSim<_BluCycleSimResult, _BluSimSettings>
         super("BLU", settings);
     }
 
+    get useAutosByDefault(): boolean {
+        return false;
+    }
+
     makeDefaultSettings(): BluSimSettings {
         return {
             dpsMimicryEnabled: true,

--- a/packages/frontend/src/scripts/sims/cycle_settings.ts
+++ b/packages/frontend/src/scripts/sims/cycle_settings.ts
@@ -5,18 +5,3 @@ export type CycleSettings = {
     which: 'totalTime' | 'cycles',
     useAutos: boolean
 }
-
-export function defaultCycleSettings(): CycleSettings {
-    return {
-        cycles: 6,
-        totalTime: 6 * 120,
-        which: 'totalTime',
-        useAutos: true
-    }
-}
-
-export function rehydrate(imported: Partial<CycleSettings>): CycleSettings {
-    const out = defaultCycleSettings();
-    Object.assign(out, imported);
-    return out;
-}

--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -22,13 +22,14 @@ import {
     AUTOATTACK_APPLICATION_DELAY,
     CAST_SNAPSHOT_PRE,
     CASTER_TAX,
+    JOB_DATA,
     JobName,
     NORMAL_GCD,
     STANDARD_ANIMATION_LOCK
 } from "@xivgear/xivmath/xivconstants";
 import {simpleAutoResultTable, SimResult, SimSettings, SimSpec, Simulation} from "../simulation";
 import {BuffSettingsArea, BuffSettingsExport, BuffSettingsManager} from "./party_comp_settings";
-import {CycleSettings, defaultCycleSettings, rehydrate} from "./cycle_settings";
+import {CycleSettings} from "./cycle_settings";
 import {CharacterGearSet} from "../gear";
 import {cycleSettingsGui} from "./components/cycle_settings_components";
 import {writeProxy} from "../util/proxies";
@@ -1086,15 +1087,15 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
     readonly cycleSettings: CycleSettings;
     readonly manualRun = false;
 
-    protected constructor(job: JobName, settings?: ExternalCycleSettings<InternalSettingsType>) {
+    protected constructor(public readonly job: JobName, settings?: ExternalCycleSettings<InternalSettingsType>) {
         this.settings = this.makeDefaultSettings();
         if (settings !== undefined) {
             Object.assign(this.settings, settings.customSettings ?? settings);
             this.buffManager = BuffSettingsManager.fromSaved(settings.buffConfig);
-            this.cycleSettings = rehydrate(settings.cycleSettings);
+            this.cycleSettings = this.rehydrateCycleSettings(settings.cycleSettings);
         }
         else {
-            this.cycleSettings = defaultCycleSettings();
+            this.cycleSettings = this.defaultCycleSettings();
             this.buffManager = BuffSettingsManager.defaultForJob(job);
         }
     }
@@ -1129,6 +1130,30 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
 
     makeToolTip(result: ResultType): string {
         return `DPS: ${result.mainDpsResult}\nUnbuffed PPS: ${result.unbuffedPps}\n`;
+    }
+
+    get useAutosByDefault(): boolean {
+        // future TODO: flip this when 7.0 drops.
+        // Not changing now such as to not cause confusion with existing sheets.
+        // Also, this should arguably be added as a property to the job data itself.
+        // const jobData = JOB_DATA[this.job];
+        // return jobData.role !== 'Healer' && jobData.role !== 'Caster';
+        return true;
+    }
+
+    defaultCycleSettings(): CycleSettings {
+        return {
+            cycles: 6,
+            totalTime: 6 * 120,
+            which: 'totalTime',
+            useAutos: this.useAutosByDefault,
+        }
+    }
+
+    rehydrateCycleSettings(imported: Partial<CycleSettings>): CycleSettings {
+        const out = this.defaultCycleSettings();
+        Object.assign(out, imported);
+        return out;
     }
 
     abstract getRotationsToSimulate(): Rotation<CycleProcessorType>[];


### PR DESCRIPTION
Closes #100 

Override `get useAutosByDefault()` to control behavior.

In a future version, it could automatically disable for all healers and casters.