### PR TITLE
Pot/tincture buffs

### DIFF
--- a/packages/core/src/sims/common/potion.ts
+++ b/packages/core/src/sims/common/potion.ts
@@ -1,0 +1,46 @@
+import {OgcdAbility} from "../sim_types";
+import {fl, mainStatMulti} from "@xivgear/xivmath/xivmath";
+import {RawStatKey} from "@xivgear/xivmath/geartypes";
+import {capitalizeFirstLetter} from "../../util/strutils";
+
+function applyPotionBuff(initialValue: number, bonus: number, cap: number): number {
+    const effectiveBonus = Math.min(fl(initialValue * bonus), cap);
+    return initialValue + effectiveBonus;
+}
+
+function makeTincture(grade: number, stat: RawStatKey, id: number, itemId: number, bonus: number, cap: number): Readonly<OgcdAbility> {
+    const statName = capitalizeFirstLetter(stat);
+    return {
+        name: `Grade ${grade} Tincture of ${statName}`,
+        // TODO: ID is an item, not an ability - can possibily use attackType === item to check
+        // if the icon needs to be an item ability?
+        // For now, going with the same thing you'd see in an ACT log
+        id: id,
+        itemId: itemId,
+        type: 'ogcd',
+        attackType: 'Item',
+        animationLock: 1.5,
+        potency: null,
+        activatesBuffs: [
+            {
+                name: 'Medicated',
+                duration: 30,
+                statusId: 0x31,
+                effects: {
+                    modifyStats: original => {
+                        const stats = {...original};
+                        stats[stat] = applyPotionBuff(stats[stat], bonus, cap);
+                        if (stat === stats.jobStats.mainStat) {
+                            stats.mainStatMulti = mainStatMulti(stats.levelStats, stats.jobStats, stats[stats.jobStats.mainStat]);
+                            stats.aaStatMulti = mainStatMulti(stats.levelStats, stats.jobStats, stats[stats.jobStats.autoAttackStat]);
+                        }
+                        return stats;
+                    }
+                }
+            }
+        ],
+
+    };
+}
+
+export const tincture8mind = makeTincture(8, 'mind', 0x20FCFAB, 39731, 0.08, 209);

--- a/packages/core/src/sims/common/potion.ts
+++ b/packages/core/src/sims/common/potion.ts
@@ -12,8 +12,9 @@ function makeTincture(grade: number, stat: RawStatKey, id: number, itemId: numbe
     const statName = capitalizeFirstLetter(stat);
     return {
         name: `Grade ${grade} Tincture of ${statName}`,
-        // TODO: ID is an item, not an ability - can possibily use attackType === item to check
-        // if the icon needs to be an item ability?
+        // Does it make the most sense to have this be the ability ID + item ID?
+        // From a sim standpoint, there's no reason to care about the potion's action ID, only
+        // the item ID and buff ID.
         // For now, going with the same thing you'd see in an ACT log
         id: id,
         itemId: itemId,

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -641,18 +641,17 @@ export class CycleProcessor {
         const pending = this.pendingPrePullOffset;
         console.log(`Pre-pull adjustment: ${pending}`);
         this.pendingPrePullOffset = 0;
-        // TODO: this will need to be updated to account for pre-pull self-buffs
         if (this.combatStarting) {
+            this.buffHistory.forEach(bh => {
+                bh.start += pending;
+                bh.end += pending;
+            });
             this.settings.allBuffs.forEach(buff => {
                 if (this.isBuffAutomatic(buff)) {
                     if (buff.startTime !== undefined) {
                         this.setBuffStartTime(buff, buff.startTime);
                     }
                 }
-            });
-            this.buffHistory.forEach(bh => {
-                bh.start += pending;
-                bh.end += pending;
             });
             this.combatStarting = false;
         }

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -154,7 +154,7 @@ export const isFinalizedAbilityUse = (record: DisplayRecordFinalized): record is
 
 export interface BuffUsage {
     readonly buff: Buff,
-    readonly start: number,
+    start: number,
     end: number,
     forceEnd: boolean
 }
@@ -638,6 +638,8 @@ export class CycleProcessor {
                 cycle.end += this.pendingPrePullOffset;
             }
         });
+        const pending = this.pendingPrePullOffset;
+        console.log(`Pre-pull adjustment: ${pending}`);
         this.pendingPrePullOffset = 0;
         // TODO: this will need to be updated to account for pre-pull self-buffs
         if (this.combatStarting) {
@@ -647,6 +649,10 @@ export class CycleProcessor {
                         this.setBuffStartTime(buff, buff.startTime);
                     }
                 }
+            });
+            this.buffHistory.forEach(bh => {
+                bh.start += pending;
+                bh.end += pending;
             });
             this.combatStarting = false;
         }

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import {CharacterGearSet} from "../gear";
 import {JobName, SupportedLevel} from "@xivgear/xivmath/xivconstants";
-import {AttackType} from "@xivgear/xivmath/geartypes";
+import {AttackType, ComputedSetStats} from "@xivgear/xivmath/geartypes";
 import {ValueWithDev} from "@xivgear/xivmath/deviation";
 
 /**
@@ -244,9 +244,18 @@ export type BaseAbility = Readonly<{
      */
     activatesBuffs?: readonly Buff[],
     /**
-     * The ID of the ability. Used for xivapi lookup for the icon.
+     * The ID of the ability. Used for equality checks, and for xivapi lookup.
      */
-    id?: number,
+    id: number,
+    /**
+     * If the action comes from an item, list the item ID so that it can be used for the
+     * icon.
+     */
+    itemId?: number,
+    /**
+     * Don't display an icon for this ability
+     */
+    noIcon?: boolean,
     /**
      * The type of action - Autoattack, Spell, Weaponskill, Ability (oGCD), etc
      */
@@ -437,6 +446,10 @@ export type BuffEffects = {
      * Haste. Expressed as the percentage value, e.g. 20 = 20% faster GCD
      */
     haste?: number,
+    /**
+     * Modify stats directly
+     */
+    modifyStats?: (stats: ComputedSetStats) => ComputedSetStats;
 };
 
 export type BuffController = {
@@ -557,6 +570,7 @@ export type CombinedBuffEffect = {
     critChanceIncrease: number,
     dhitChanceIncrease: number,
     forceCrit: boolean,
-    forceDhit: boolean
+    forceDhit: boolean,
     haste: number,
+    modifyStats: (stats: ComputedSetStats) => ComputedSetStats,
 }

--- a/packages/core/src/sims/sim_utils.ts
+++ b/packages/core/src/sims/sim_utils.ts
@@ -10,7 +10,6 @@ function dotPotencyToDamage(stats: ComputedSetStats, potency: number, dmgAbility
     // TODO: are there any dots with auto-crit or auto-dh?
     const forceDh = false;
     const forceCrit = false;
-    // TODO: why is autoDH true
     const nonCritDmg = baseDamageFull(modifiedStats, potency, dmgAbility.attackType, forceDh, forceCrit, true);
     const afterCritDh = applyDhCritFull(nonCritDmg, modifiedStats);
     return multiplyFixed(afterCritDh, combinedBuffEffects.dmgMod);
@@ -88,11 +87,8 @@ export function combineBuffEffects(buffs: Buff[]): CombinedBuffEffect {
             const oldFunc = combinedEffects.modifyStats;
             combinedEffects.modifyStats = (stats) => {
                 const before = oldFunc(stats);
-                console.log('Old', stats);
                 const copy = {...before};
-                const modified = effects.modifyStats(copy);
-                console.log('New', modified);
-                return modified;
+                return effects.modifyStats(copy);
             }
         }
     }

--- a/packages/frontend/src/scripts/components/item_icon.ts
+++ b/packages/frontend/src/scripts/components/item_icon.ts
@@ -1,0 +1,31 @@
+import {xivApiSingleCols} from "@xivgear/core/external/xivapi";
+
+export interface XivApiItemData {
+    ID: number,
+    Icon: string
+}
+
+const itemIconMap = new Map<number, Promise<XivApiItemData>>();
+
+// TODO: can this be consolidated with other job loading stuff in DataManager?
+async function getDataFor(itemId: number): Promise<XivApiItemData> {
+    if (itemIconMap.has(itemId)) {
+        return itemIconMap.get(itemId);
+    }
+    else {
+        const out = xivApiSingleCols('Item', itemId, ['ID', 'Icon'] as const) as Promise<XivApiItemData>;
+        itemIconMap.set(itemId, out);
+        return out;
+    }
+}
+
+export class ItemIcon extends HTMLImageElement {
+    constructor(itemId: number) {
+        super();
+        this.classList.add('ffxiv-ability-icon');
+        this.setAttribute('intrinsicsize', '64x64');
+        getDataFor(itemId).then(data => this.src = "https://xivapi.com/" + data.Icon);
+    }
+}
+
+customElements.define("ffxiv-item-icon", ItemIcon, {extends: "img"});

--- a/packages/frontend/src/scripts/sims/components/ability_used_table.ts
+++ b/packages/frontend/src/scripts/sims/components/ability_used_table.ts
@@ -4,6 +4,7 @@ import {AbilityIcon} from "../../components/abilities";
 import {BuffListDisplay} from "./buff_list_display";
 import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {AutoAttack, Buff, CombinedBuffEffect, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
+import {ItemIcon} from "../../components/item_icon";
 
 /**
  * Format a time into the format x:yy.zz
@@ -73,8 +74,13 @@ export class AbilitiesUsedTable extends CustomTable<DisplayRecordFinalized> {
                         else if (ability.type !== "gcd") {
                             out.appendChild(document.createTextNode(' ⤷ '));
                         }
-                        if (ability.id) {
-                            out.appendChild(new AbilityIcon(ability.id));
+                        if (!ability.noIcon) {
+                            if (ability.itemId) {
+                                out.appendChild(new ItemIcon(ability.itemId));
+                            }
+                            else if (ability.id) {
+                                out.appendChild(new AbilityIcon(ability.id));
+                            }
                         }
                         const abilityNameSpan = document.createElement('span');
                         abilityNameSpan.textContent = ability.name;

--- a/packages/frontend/src/scripts/sims/healer/ast_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/healer/ast_sheet_sim.ts
@@ -5,6 +5,7 @@ import {BuffSettingsExport} from "@xivgear/core/sims/common/party_comp_settings"
 
 
 const filler: GcdAbility = {
+    id: 25871,
     type: 'gcd',
     name: "Malefic",
     potency: 250,
@@ -14,6 +15,7 @@ const filler: GcdAbility = {
 };
 
 const combust: GcdAbility = {
+    id: 16554,
     type: 'gcd',
     name: "Combust",
     potency: 0,
@@ -27,6 +29,7 @@ const combust: GcdAbility = {
 };
 
 const star: OgcdAbility = {
+    id: 7439,
     type: 'ogcd',
     name: "Earthly Star",
     potency: 310,
@@ -34,6 +37,7 @@ const star: OgcdAbility = {
 };
 
 const lord: OgcdAbility = {
+    id: 7444,
     type: 'ogcd',
     name: "Lord of Crowns",
     potency: 250,
@@ -41,6 +45,7 @@ const lord: OgcdAbility = {
 };
 
 const astrodyne: OgcdAbility = {
+    id: 25870,
     name: "Astrodyne",
     type: "ogcd",
     potency: null,

--- a/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
+++ b/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
@@ -82,6 +82,7 @@ export class SgeSheetSim extends BaseMultiCycleSim<SgeSheetSimResult, SgeNewShee
     spec = sgeNewSheetSpec;
     displayName = sgeNewSheetSpec.displayName;
     shortName = "sge-new-sheet-sim";
+    usePotion = false;
 
     constructor(settings?: SgeNewSheetSettingsExternal) {
         super('SGE', settings);
@@ -103,7 +104,9 @@ export class SgeSheetSim extends BaseMultiCycleSim<SgeSheetSimResult, SgeNewShee
             cycleTime: 120,
             apply(cp: CycleProcessor) {
                 // TODO: make a setting for this
-                // cp.useOgcd(tincture8mind);
+                if (this.usePotion) {
+                    cp.useOgcd(tincture8mind);
+                }
                 cp.useGcd(filler);
                 cp.remainingCycles(cycle => {
                     cycle.use(eDosis);

--- a/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
+++ b/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
@@ -102,7 +102,8 @@ export class SgeSheetSim extends BaseMultiCycleSim<SgeSheetSimResult, SgeNewShee
         return [{
             cycleTime: 120,
             apply(cp: CycleProcessor) {
-                cp.useOgcd(tincture8mind);
+                // TODO: make a setting for this
+                // cp.useOgcd(tincture8mind);
                 cp.useGcd(filler);
                 cp.remainingCycles(cycle => {
                     cycle.use(eDosis);

--- a/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
+++ b/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
@@ -1,6 +1,7 @@
 import {GcdAbility, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
 import {CycleProcessor, CycleSimResult, ExternalCycleSettings, Rotation} from "@xivgear/core/sims/cycle_sim";
 import {BaseMultiCycleSim} from "../sim_processors";
+import {tincture8mind} from "@xivgear/core/sims/common/potion";
 
 /**
  * Used for all 330p filler abilities
@@ -101,6 +102,7 @@ export class SgeSheetSim extends BaseMultiCycleSim<SgeSheetSimResult, SgeNewShee
         return [{
             cycleTime: 120,
             apply(cp: CycleProcessor) {
+                cp.useOgcd(tincture8mind);
                 cp.useGcd(filler);
                 cp.remainingCycles(cycle => {
                     cycle.use(eDosis);

--- a/packages/frontend/src/scripts/sims/healer/whm_new_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/healer/whm_new_sheet_sim.ts
@@ -4,6 +4,7 @@ import {BaseMultiCycleSim} from "../sim_processors";
 import {BuffSettingsExport} from "@xivgear/core/sims/common/party_comp_settings";
 
 const filler: GcdAbility = {
+    id: 25859,
     type: 'gcd',
     name: "Glare",
     potency: 310,
@@ -13,6 +14,7 @@ const filler: GcdAbility = {
 };
 
 const dia: GcdAbility = {
+    id: 16532,
     type: 'gcd',
     name: "Dia",
     potency: 65,
@@ -26,6 +28,7 @@ const dia: GcdAbility = {
 };
 
 const assize: OgcdAbility = {
+    id: 3571,
     type: 'ogcd',
     name: "Assize",
     potency: 400,
@@ -33,6 +36,7 @@ const assize: OgcdAbility = {
 };
 
 const pom: OgcdAbility = {
+    id: 136,
     type: 'ogcd',
     name: 'Presence of Mind',
     potency: null,
@@ -50,6 +54,7 @@ const pom: OgcdAbility = {
 };
 
 const misery: GcdAbility = {
+    id: 16535,
     type: 'gcd',
     name: "Afflatus Misery",
     potency: 1240,
@@ -58,6 +63,7 @@ const misery: GcdAbility = {
 };
 
 const lily: GcdAbility = {
+    id: 16534,
     type: 'gcd',
     name: "Afflatus Rapture",
     potency: 0,

--- a/packages/frontend/src/scripts/test/sims/common_values.ts
+++ b/packages/frontend/src/scripts/test/sims/common_values.ts
@@ -5,7 +5,10 @@ import {getClassJobStats, getLevelStats} from "@xivgear/xivmath/xivconstants";
 import {finalizeStats} from "@xivgear/xivmath/xivstats";
 import {GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
 
+let fakeId = 0x200_0000;
+
 export const filler: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Glare",
     potency: 310,
@@ -15,6 +18,7 @@ export const filler: GcdAbility = {
 };
 
 export const weaponSkill: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "WepSkill",
     potency: 310,
@@ -24,6 +28,7 @@ export const weaponSkill: GcdAbility = {
 };
 
 export const nop: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "NOP",
     potency: null,
@@ -33,6 +38,7 @@ export const nop: GcdAbility = {
 };
 
 export const dia: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Dia",
     potency: 65,
@@ -46,6 +52,7 @@ export const dia: GcdAbility = {
 };
 
 export const assize: OgcdAbility = {
+    id: fakeId++,
     type: 'ogcd',
     name: "Assize",
     potency: 400,
@@ -53,6 +60,7 @@ export const assize: OgcdAbility = {
 };
 
 export const pom: OgcdAbility = {
+    id: fakeId++,
     type: 'ogcd',
     name: 'Presence of Mind',
     potency: null,
@@ -70,6 +78,7 @@ export const pom: OgcdAbility = {
 };
 
 export const misery: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Afflatus Misery",
     potency: 1240,
@@ -78,6 +87,7 @@ export const misery: GcdAbility = {
 };
 
 export const lily: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Afflatus Rapture",
     potency: 0,

--- a/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
@@ -35,7 +35,10 @@ interface TestSimSettings extends SimSettings {
 interface TestSimSettingsExternal extends ExternalCycleSettings<TestSimSettings> {
 }
 
+let fakeId = 0x100_0000;
+
 const filler: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Glare",
     potency: 310,
@@ -45,6 +48,7 @@ const filler: GcdAbility = {
 };
 
 const weaponSkill: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "WepSkill",
     potency: 310,
@@ -54,6 +58,7 @@ const weaponSkill: GcdAbility = {
 };
 
 const nop: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "NOP",
     potency: null,
@@ -63,6 +68,7 @@ const nop: GcdAbility = {
 };
 
 const dia: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Dia",
     potency: 65,
@@ -76,6 +82,7 @@ const dia: GcdAbility = {
 };
 
 const assize: OgcdAbility = {
+    id: fakeId++,
     type: 'ogcd',
     name: "Assize",
     potency: 400,
@@ -83,6 +90,7 @@ const assize: OgcdAbility = {
 };
 
 const pom: OgcdAbility = {
+    id: fakeId++,
     type: 'ogcd',
     name: 'Presence of Mind',
     potency: null,
@@ -100,6 +108,7 @@ const pom: OgcdAbility = {
 };
 
 const misery: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Afflatus Misery",
     potency: 1240,
@@ -108,6 +117,7 @@ const misery: GcdAbility = {
 };
 
 const lily: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Afflatus Rapture",
     potency: 0,
@@ -394,6 +404,7 @@ describe('Cycle sim processor', () => {
 });
 
 const instant: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Dia",
     potency: 65,
@@ -407,6 +418,7 @@ const instant: GcdAbility = {
 };
 
 const long: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Raise",
     potency: 310,
@@ -604,6 +616,7 @@ const potBuff: Buff = {
 };
 
 const potBuffAbility: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Pot Buff Ability",
     potency: null,
@@ -677,6 +690,7 @@ const bristleBuff: Buff = {
 };
 
 const bristle: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Bristle",
     potency: null,
@@ -703,6 +717,7 @@ const bristleBuff2: Buff = {
 };
 
 const bristle2: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Bristle2",
     potency: null,
@@ -905,6 +920,7 @@ describe('Special record', () => {
 // TODO: another set of test, but with a GCD that doesn't evenly divide the cycle time, so that re-alignment
 // can be checked.
 const fixed: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Fixed",
     potency: 310,
@@ -914,6 +930,7 @@ const fixed: GcdAbility = {
     fixedGcd: true
 };
 const fixedLonger: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Fixed Longer",
     potency: 310,
@@ -1182,6 +1199,7 @@ describe('Cycle processor alignment options', () => {
 
 // GCD that doesn't evenly divide into a 30 second cycle time so that we can test drift behavior
 const fixedOdd: GcdAbility = {
+    id: fakeId++,
     type: 'gcd',
     name: "Fixed Odd",
     potency: 310,
@@ -1403,6 +1421,7 @@ const indefBuff: Buff = {
 };
 
 const indefAb: Ability = {
+    id: fakeId++,
     type: 'gcd',
     name: "Ability that applies Indefinite Buff",
     potency: 310,

--- a/packages/xivmath/src/computed_set_stats.ts
+++ b/packages/xivmath/src/computed_set_stats.ts
@@ -1,0 +1,89 @@
+// import {AttackType, ComputedSetStats, JobData, LevelStats, PartyBonusAmount, RawStats} from "./geartypes";
+// import {JobName, SupportedLevel} from "./xivconstants";
+// import {critChance, sksToGcd, spsToGcd} from "./xivmath";
+//
+// // TODO: replace the interface with this type
+// class ComputedSetStatsImpl implements ComputedSetStats {
+//
+//
+//     readonly raw: RawStats;
+//     readonly buffEffects = {
+//         critChance: 0
+//     };
+//
+//     constructor(
+//         private readonly combinedStats: RawStats,
+//         private readonly level: SupportedLevel,
+//         private readonly levelStats: LevelStats,
+//         private readonly classJob: JobName,
+//         private readonly classJobStats: JobData,
+//         private readonly partyBonus: PartyBonusAmount) {
+//     }
+//
+//     gcdPhys(baseGcd: number, haste?: number): number {
+//         return sksToGcd(baseGcd, this.levelStats, this.skillspeed, haste);
+//     }
+//
+//     gcdMag(baseGcd: number, haste?: number): number {
+//         return spsToGcd(baseGcd, this.levelStats, this.skillspeed, haste);
+//     }
+//
+//     haste(attackType: AttackType): number {
+//         // TODO
+//         return 0;
+//     }
+//
+//     get critChance() {
+//         return critChance(this.levelStats, this.raw.crit + this.buffEffects.critChance);
+//     }
+//
+//     get critChanceBonus() {
+//         return this.buffEffects.critChance;
+//     }
+//
+//     set critChanceBonus(value: number) {
+//         this.buffEffects.critChance = value;
+//     }
+//
+//     critMulti: number;
+//     dhitChance: number;
+//     dhitMulti: number;
+//     detMulti: number;
+//     spsDotMulti: number;
+//     sksDotMulti: number;
+//     tncMulti: number;
+//     wdMulti: number;
+//     mainStatMulti: number;
+//     aaStatMulti: number;
+//
+//     traitMulti(attackType: "Unknown" | "Auto-attack" | "Spell" | "Weaponskill" | "Ability" | "Item"): number {
+//         throw new Error("Method not implemented.");
+//     }
+//
+//     autoDhBonus: number;
+//     mpPerTick: number;
+//     aaMulti: number;
+//     aaDelay: number;
+//     hp: number;
+//     vitality: number;
+//     strength: number;
+//     dexterity: number;
+//     intelligence: number;
+//     mind: number;
+//     piety: number;
+//     crit: number;
+//     dhit: number;
+//     determination: number;
+//     tenacity: number;
+//     spellspeed: number;
+//     skillspeed: number;
+//     wdPhys: number;
+//     wdMag: number;
+//     weaponDelay: number;
+//
+//     get rawStats() {
+//         return this.raw
+//     }
+//
+//
+// }


### PR DESCRIPTION
See `potion.ts` for an example. I've only done grade 8 mind tinc so far for testing.

This PR also makes two wider changes:

- Pre-pull buffs are now timed correctly
- ID is now a required field for abilities. All existing abilities have had their IDs added.