### PR TITLE
Shared cooldown support

### DIFF
--- a/packages/core/src/sims/common/cooldown_manager.ts
+++ b/packages/core/src/sims/common/cooldown_manager.ts
@@ -259,6 +259,7 @@ function cooldownKey(ability: CdAbility): number {
     const seen = [];
     let current = ability;
     let attempts = 10;
+    // This SHOULDN'T happen with the new types, but leaving this check just in case.
     while (--attempts > 0) {
         if (current.cooldown.sharesCooldownWith !== undefined) {
             current = current.cooldown.sharesCooldownWith;

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -301,10 +301,18 @@ export type Cooldown = Readonly<{
      */
     reducedBy?: 'none' | 'spellspeed' | 'skillspeed';
     /**
-     * The number of charges of the ability
+     * The number of charges of the ability.
      */
     charges?: number
+    /**
+     * If the ability shares a cooldown with another ability, specify that ability here.
+     */
+    sharesCooldownWith?: CdAbility
 }>
+
+export type CdAbility = Ability & {
+    cooldown: Cooldown
+}
 
 /**
  * Represents a GCD action

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -291,7 +291,7 @@ export type BaseAbility = Readonly<{
 /**
  * Represents the cooldown of an ability
  */
-export type Cooldown = Readonly<{
+export type BaseCooldown = Readonly<{
     /**
      * The cooldown duration, or the time to regain a single charge
      */
@@ -304,15 +304,34 @@ export type Cooldown = Readonly<{
      * The number of charges of the ability.
      */
     charges?: number
-    /**
-     * If the ability shares a cooldown with another ability, specify that ability here.
-     */
-    sharesCooldownWith?: CdAbility
 }>
 
-export type CdAbility = Ability & {
-    cooldown: Cooldown
+export type OriginCooldown = BaseCooldown & {
+    sharesCooldownWith?: never;
 }
+
+export type SharedCooldown = BaseCooldown & {
+    /**
+     * If the ability shares a cooldown with another ability, specify that ability here.
+     *
+     * When using shared cooldowns, the reference should only be made in one direction. That is,
+     * if A, B, and C share cooldowns, then B and C should set their shared cooldown to A, and A should not have a
+     * shared cooldown.
+     */
+    sharesCooldownWith: Ability & {
+        cooldown: OriginCooldown
+    }
+}
+
+export type Cooldown = OriginCooldown | SharedCooldown;
+export type OriginCdAbility = Ability & {
+    cooldown: OriginCooldown;
+}
+export type SharedCdAbility = Ability & {
+    cooldown: SharedCooldown;
+}
+
+export type CdAbility = OriginCdAbility | SharedCdAbility;
 
 /**
  * Represents a GCD action

--- a/packages/frontend/src/scripts/test/sims/cooldown_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cooldown_tests.ts
@@ -1,9 +1,9 @@
 import {CooldownTracker} from "@xivgear/core/sims/common/cooldown_manager";
 import {Chain} from "@xivgear/core/sims/buffs";
 import * as assert from "assert";
-import {CdAbility, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
+import {GcdAbility, OgcdAbility, OriginCdAbility, SharedCdAbility} from "@xivgear/core/sims/sim_types";
 
-const chain: OgcdAbility & CdAbility = {
+const chain: OgcdAbility & OriginCdAbility = {
     type: 'ogcd',
     name: "Chain",
     id: 7436,
@@ -15,7 +15,7 @@ const chain: OgcdAbility & CdAbility = {
     }
 };
 
-const chainShared: OgcdAbility = {
+const chainShared: OgcdAbility & SharedCdAbility = {
     type: 'ogcd',
     name: 'Chain II',
     id: 100_0001,

--- a/packages/frontend/src/scripts/test/sims/cooldown_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cooldown_tests.ts
@@ -1,9 +1,9 @@
 import {CooldownTracker} from "@xivgear/core/sims/common/cooldown_manager";
 import {Chain} from "@xivgear/core/sims/buffs";
 import * as assert from "assert";
-import {GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
+import {CdAbility, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
 
-const chain: OgcdAbility = {
+const chain: OgcdAbility & CdAbility = {
     type: 'ogcd',
     name: "Chain",
     id: 7436,
@@ -12,6 +12,19 @@ const chain: OgcdAbility = {
     attackType: "Ability",
     cooldown: {
         time: 120
+    }
+};
+
+const chainShared: OgcdAbility = {
+    type: 'ogcd',
+    name: 'Chain II',
+    id: 100_0001,
+    activatesBuffs: [Chain],
+    potency: null,
+    attackType: "Ability",
+    cooldown: {
+        time: 60,
+        sharesCooldownWith: chain
     }
 };
 
@@ -566,5 +579,354 @@ describe('cooldown manager', () => {
             },
             currentCharges: 3,
         });
+    });
+    it('handles shared CDs', () => {
+        const ts = new FakeTimeSource();
+        const tracker = new CooldownTracker(() => ts.time, 'reject');
+        const ability = chain;
+        const ability2 = chainShared;
+        // Validate initial state
+        const e1 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 0,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 0,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e1);
+        assert.deepEqual(tracker.statusOf(ability2), e1);
+        // Use first ability
+        tracker.useAbility(ability);
+        const e2 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 120,
+                relative: 120
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 120,
+                relative: 120
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e2);
+        assert.deepEqual(tracker.statusOf(ability2), e2);
+        ts.time = 30;
+        const e3 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 120,
+                relative: 90
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 120,
+                relative: 90
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e3);
+        assert.deepEqual(tracker.statusOf(ability2), e3);
+
+        // Move to 90s
+        ts.time = 90;
+        const e4 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 120,
+                relative: 30
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 120,
+                relative: 30
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e4);
+        assert.deepEqual(tracker.statusOf(ability2), e4);
+
+        ts.time = 120;
+        const e5 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 120,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 120,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e5);
+        assert.deepEqual(tracker.statusOf(ability2), e5);
+
+        ts.time = 150;
+        const e6 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 150,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 150,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e6);
+        assert.deepEqual(tracker.statusOf(ability2), e6);
+
+        tracker.useAbility(ability2);
+        const e7 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 210,
+                relative: 60
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 210,
+                relative: 60
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e7);
+        assert.deepEqual(tracker.statusOf(ability2), e7);
+
+        ts.time = 180;
+        const e8 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 210,
+                relative: 30
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 210,
+                relative: 30
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e8);
+        assert.deepEqual(tracker.statusOf(ability2), e8);
+
+        ts.time = 210;
+        const e9 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 210,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 210,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e9);
+        assert.deepEqual(tracker.statusOf(ability2), e9);
+
+        ts.time = 240;
+        const e10 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 240,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 240,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e10);
+        assert.deepEqual(tracker.statusOf(ability2), e10);
+    });
+    it('handles shared CDs when the shared CD is used first', () => {
+        const ts = new FakeTimeSource();
+        const tracker = new CooldownTracker(() => ts.time, 'reject');
+        const ability = chain;
+        const ability2 = chainShared;
+        // Validate initial state
+        const e1 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 0,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 0,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e1);
+        assert.deepEqual(tracker.statusOf(ability2), e1);
+        // Use first ability
+        tracker.useAbility(ability2);
+        const e2 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 60,
+                relative: 60
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 60,
+                relative: 60
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e2);
+        assert.deepEqual(tracker.statusOf(ability2), e2);
+        ts.time = 20;
+        const e3 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 60,
+                relative: 40
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 60,
+                relative: 40
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e3);
+        assert.deepEqual(tracker.statusOf(ability2), e3);
+
+        ts.time = 60;
+        const e4 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 60,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 60,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e4);
+        assert.deepEqual(tracker.statusOf(ability2), e4);
+
+        ts.time = 120;
+        const e5 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 120,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 120,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e5);
+        assert.deepEqual(tracker.statusOf(ability2), e5);
+
+        ts.time = 90;
+        const e6 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 90,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 90,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e6);
+        assert.deepEqual(tracker.statusOf(ability2), e6);
+
+        tracker.useAbility(ability);
+        const e7 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 210,
+                relative: 120
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 210,
+                relative: 120
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e7);
+        assert.deepEqual(tracker.statusOf(ability2), e7);
+
+        ts.time = 180;
+        const e8 = {
+            readyToUse: false,
+            readyAt: {
+                absolute: 210,
+                relative: 30
+            },
+            capped: false,
+            cappedAt: {
+                absolute: 210,
+                relative: 30
+            },
+            currentCharges: 0,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e8);
+        assert.deepEqual(tracker.statusOf(ability2), e8);
+
+        ts.time = 210;
+        const e9 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 210,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 210,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e9);
+        assert.deepEqual(tracker.statusOf(ability2), e9);
+
+        ts.time = 240;
+        const e10 = {
+            readyToUse: true,
+            readyAt: {
+                absolute: 240,
+                relative: 0
+            },
+            capped: true,
+            cappedAt: {
+                absolute: 240,
+                relative: 0
+            },
+            currentCharges: 1,
+        };
+        assert.deepEqual(tracker.statusOf(ability), e10);
+        assert.deepEqual(tracker.statusOf(ability2), e10);
     });
 });


### PR DESCRIPTION
Adds `sharesCooldownWith` field to `Cooldown`. If you want A, B, C, and D to have shared cooldowns, then B/C/D should have `sharesCooldownWith: A`.

The source and target cooldowns can have different CDs. If one has a 60s CD, and one has a 120s CD, then the cooldown time will be derived from whichever you actually use. That is, using the first skill would block both skills for 60s, and using the second would block both skills for 120s.

Behavior is undefined for abilities with more than one charge.