### PR TITLE
Implement caster variant of damage formula

### DIFF
--- a/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
@@ -266,7 +266,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 0,
         name: 'Auto Attack',
-        damage: 32.153
+        damage: 33.301
     },
     {
         time: 0.83,
@@ -281,7 +281,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 4.32,
         name: 'Auto Attack',
-        damage: 33.760
+        damage: 34.966
     },
     {
         time: 5.45,
@@ -306,7 +306,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 9.24,
         name: "Auto Attack",
-        damage: 37.649
+        damage: 38.994
     },
     {
         time: 9.60,
@@ -321,7 +321,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 13.192,
         name: "Auto Attack",
-        damage: 37.649
+        damage: 38.994
     },
     {
         time: 13.28,
@@ -341,7 +341,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 17.744,
         name: "Auto Attack",
-        damage: 37.649
+        damage: 38.994
     },
     {
         time: 18.80,
@@ -356,7 +356,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 21.696,
         name: "Auto Attack",
-        damage: 37.649
+        damage: 38.994
     },
     {
         time: 22.48,
@@ -371,7 +371,7 @@ const expectedAbilities: UseResult[] = [
     {
         time: 25.928,
         name: "Auto Attack",
-        damage: 32.1531
+        damage: 33.301
     },
     {
         time: 26.63,
@@ -400,7 +400,7 @@ describe('Cycle sim processor', () => {
         // Run simulation
         const result = await inst.simulate(set);
         // Assert correct results
-        assertClose(result.mainDpsResult, 9896.29, 0.01);
+        assertClose(result.mainDpsResult, 9896.58, 0.01);
         assertSimAbilityResults(result, expectedAbilities);
     });
 });

--- a/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
@@ -14,7 +14,9 @@ import {removeSelf} from "@xivgear/core/sims/common/utils";
 import {finalizeStats} from "@xivgear/xivmath/xivstats";
 import {
     Ability,
-    Buff, BuffController, DamageResult,
+    Buff,
+    BuffController,
+    DamageResult,
     FinalizedAbility,
     GcdAbility,
     OgcdAbility,
@@ -259,32 +261,32 @@ const expectedAbilities: UseResult[] = [
     {
         time: -1.48,
         name: 'Glare',
-        damage: 15078.38
+        damage: 15074.935
     },
     {
         time: 0,
         name: 'Auto Attack',
-        damage: 33.30
+        damage: 32.153
     },
     {
         time: 0.83,
         name: 'Dia',
-        damage: 37174.05
+        damage: 37172.897
     },
     {
         time: 3.14,
         name: 'Glare',
-        damage: 15832.30
+        damage: 15828.682
     },
     {
         time: 4.32,
         name: 'Auto Attack',
-        damage: 34.97
+        damage: 33.760
     },
     {
         time: 5.45,
         name: 'Glare',
-        damage: 15832.30
+        damage: 15828.682
     },
     {
         time: 6.93,
@@ -294,92 +296,92 @@ const expectedAbilities: UseResult[] = [
     {
         time: 7.76,
         name: 'Glare',
-        damage: 17656.20
+        damage: 17652.168
     },
     {
         time: 8.96,
         name: "Assize",
-        damage: 22783.24
+        damage: 22777.859
     },
     {
         time: 9.24,
         name: "Auto Attack",
-        damage: 38.99
+        damage: 37.649
     },
     {
         time: 9.60,
         name: "Glare",
-        damage: 17656.2
+        damage: 17652.168
     },
     {
         time: 11.44,
         name: "Glare",
-        damage: 17656.2
+        damage: 17652.168
     },
     {
         time: 13.192,
         name: "Auto Attack",
-        damage: 38.99
+        damage: 37.649
     },
     {
         time: 13.28,
         name: "Glare",
-        damage: 17656.2
+        damage: 17652.168
     },
     {
         time: 15.12,
         name: "Glare",
-        damage: 17656.2
+        damage: 17652.168
     },
     {
         time: 16.96,
         name: "Glare",
-        damage: 17656.2
+        damage: 17652.168
     },
     {
         time: 17.744,
         name: "Auto Attack",
-        damage: 38.99
+        damage: 37.649
     },
     {
         time: 18.80,
         name: "Glare",
-        damage: 17656.2
+        damage: 17652.168
     },
     {
         time: 20.64,
         name: "Glare",
-        damage: 17656.2
+        damage: 17652.168
     },
     {
         time: 21.696,
         name: "Auto Attack",
-        damage: 38.99
+        damage: 37.649
     },
     {
         time: 22.48,
         name: "Glare",
-        damage: 15832.3
+        damage: 15828.682
     },
     {
         time: 24.32,
         name: "Glare",
-        damage: 15078.38
+        damage: 15074.935
     },
     {
         time: 25.928,
         name: "Auto Attack",
-    damage: 33.301
+        damage: 32.1531
     },
     {
         time: 26.63,
         name: "Glare",
-        damage: 15078.38
+        damage: 15074.935
     },
     {
         time: 28.94,
         name: "Glare",
-        damage: 6919.08
+        damage: 6917.503
     },
 ];
 
@@ -398,7 +400,7 @@ describe('Cycle sim processor', () => {
         // Run simulation
         const result = await inst.simulate(set);
         // Assert correct results
-        assertClose(result.mainDpsResult, 9898.60, 0.01);
+        assertClose(result.mainDpsResult, 9896.29, 0.01);
         assertSimAbilityResults(result, expectedAbilities);
     });
 });
@@ -645,16 +647,16 @@ describe('Potency Buff Ability', () => {
         });
         // Not swifted
         assert.equal(actualAbilities[0].ability.name, "Glare");
-        assertClose(actualAbilities[0].directDamage, 15078, 1);
+        assertClose(actualAbilities[0].directDamage, 15074, 1);
         // Swiftcast
         assert.equal(actualAbilities[1].ability.name, "Pot Buff Ability");
         assertClose(actualAbilities[1].directDamage, 0, 1);
         // Swifted
         assert.equal(actualAbilities[2].ability.name, "Glare");
-        assertClose(actualAbilities[2].directDamage, 15078 * (310 + 100) / 310, 1);
+        assertClose(actualAbilities[2].directDamage, 15074 * (310 + 100) / 310, 2);
         // Not swifted
         assert.equal(actualAbilities[3].ability.name, "Glare");
-        assertClose(actualAbilities[3].directDamage, 15078, 1);
+        assertClose(actualAbilities[3].directDamage, 15074, 1);
 
     });
 });
@@ -747,16 +749,16 @@ describe('Damage Buff Ability', () => {
         });
         // Not buffed
         assert.equal(actualAbilities[0].ability.name, "Glare");
-        assertClose(actualAbilities[0].directDamage, 15078, 1);
+        assertClose(actualAbilities[0].directDamage, 15074, 1);
         // Buff
         assert.equal(actualAbilities[1].ability.name, "Bristle");
         assertClose(actualAbilities[1].directDamage, 0, 1);
         // Buffed
         assert.equal(actualAbilities[2].ability.name, "Glare");
-        assertClose(actualAbilities[2].directDamage, 15078 * 1.5, 1);
+        assertClose(actualAbilities[2].directDamage, 15074 * 1.5, 2);
         // Not buffed
         assert.equal(actualAbilities[3].ability.name, "Glare");
-        assertClose(actualAbilities[3].directDamage, 15078, 1);
+        assertClose(actualAbilities[3].directDamage, 15074, 1);
 
     });
     it('should increase the damage once, other style', () => {
@@ -777,16 +779,16 @@ describe('Damage Buff Ability', () => {
         });
         // Not buffed
         assert.equal(actualAbilities[0].ability.name, "Glare");
-        assertClose(actualAbilities[0].directDamage, 15078, 1);
+        assertClose(actualAbilities[0].directDamage, 15074, 2);
         // Buff
         assert.equal(actualAbilities[1].ability.name, "Bristle2");
         assertClose(actualAbilities[1].directDamage, 0, 1);
         // Buffed
         assert.equal(actualAbilities[2].ability.name, "Glare");
-        assertClose(actualAbilities[2].directDamage, 15078 * 1.5, 1);
+        assertClose(actualAbilities[2].directDamage, 15074 * 1.5, 2);
         // Not Buffed
         assert.equal(actualAbilities[3].ability.name, "Glare");
-        assertClose(actualAbilities[3].directDamage, 15078, 1);
+        assertClose(actualAbilities[3].directDamage, 15074, 1);
     });
     it('should multiply direct damage and dots by default', () => {
         const cp = new CycleProcessor({
@@ -811,20 +813,20 @@ describe('Damage Buff Ability', () => {
         });
         // Not buffed
         assert.equal(actualAbilities[0].ability.name, "Dia");
-        assertClose(actualAbilities[0].directDamage, 3161.5, 1);
-        assertClose(actualAbilities[0].totalDamage, 37174, 1);
+        assertClose(actualAbilities[0].directDamage, 3160.1, 1);
+        assertClose(actualAbilities[0].totalDamage, 37172.9, 1);
         // Buff
         assert.equal(actualAbilities[1].ability.name, "Bristle");
         assertClose(actualAbilities[1].directDamage, 0, 1);
         assertClose(actualAbilities[1].totalDamage, 0, 1);
         // Buffed
         assert.equal(actualAbilities[2].ability.name, "Dia");
-        assertClose(actualAbilities[2].directDamage, 3161.5 * 1.5, 1);
-        assertClose(actualAbilities[2].totalDamage, 37174 * 1.5, 1);
+        assertClose(actualAbilities[2].directDamage, 3160.1 * 1.5, 1);
+        assertClose(actualAbilities[2].totalDamage, 37172.9 * 1.5, 1);
         // Not Buffed
         assert.equal(actualAbilities[3].ability.name, "Dia");
-        assertClose(actualAbilities[3].directDamage, 3161.5, 1);
-        assertClose(actualAbilities[3].totalDamage, 37174, 1);
+        assertClose(actualAbilities[3].directDamage, 3160.1, 1);
+        assertClose(actualAbilities[3].totalDamage, 37172.9, 1);
     });
     it('should filter abilities correctly', () => {
         const cp = new CycleProcessor({
@@ -846,19 +848,19 @@ describe('Damage Buff Ability', () => {
         });
         // Not buffed
         assert.equal(actualAbilities[0].ability.name, "Glare");
-        assertClose(actualAbilities[0].directDamage, 15078, 1);
+        assertClose(actualAbilities[0].directDamage, 15074, 1);
         // Buff
         assert.equal(actualAbilities[1].ability.name, "Bristle");
         assertClose(actualAbilities[1].directDamage, 0, 1);
         // Filtered, not buffed
         assert.equal(actualAbilities[2].ability.name, "WepSkill");
-        assertClose(actualAbilities[2].directDamage, 15078, 1);
+        assertClose(actualAbilities[2].directDamage, 15074, 1);
         // Buffed
         assert.equal(actualAbilities[3].ability.name, "Glare");
-        assertClose(actualAbilities[3].directDamage, 15078 * 1.5, 1);
+        assertClose(actualAbilities[3].directDamage, 15074 * 1.5, 2);
         // Not buffed
         assert.equal(actualAbilities[4].ability.name, "Glare");
-        assertClose(actualAbilities[4].directDamage, 15078, 1);
+        assertClose(actualAbilities[4].directDamage, 15074, 1);
     });
 });
 
@@ -1512,7 +1514,7 @@ describe('application delay', () => {
         assert.equal(actualAbilities[0].original.appDelay, STANDARD_APPLICATION_DELAY);
         assert.equal(actualAbilities[0].original.appDelayFromStart, STANDARD_APPLICATION_DELAY + actualAbilities[0].original.snapshotTimeFromStart);
         // Test that application delay correctly affects pre-pull timing
-        assert.equal(actualAbilities[0].original.usedAt,  -1 * (STANDARD_APPLICATION_DELAY + actualAbilities[0].original.snapshotTimeFromStart));
+        assert.equal(actualAbilities[0].original.usedAt, -1 * (STANDARD_APPLICATION_DELAY + actualAbilities[0].original.snapshotTimeFromStart));
 
         assert.equal(actualAbilities[1].original.appDelay, STANDARD_APPLICATION_DELAY);
         assert.equal(actualAbilities[1].original.appDelayFromStart, STANDARD_APPLICATION_DELAY + actualAbilities[0].original.snapshotTimeFromStart);
@@ -1536,7 +1538,7 @@ describe('application delay', () => {
         assert.equal(actualAbilities[0].original.appDelay, delay);
         assert.equal(actualAbilities[0].original.appDelayFromStart, delay + actualAbilities[0].original.snapshotTimeFromStart);
         // Test that application delay correctly affects pre-pull timing
-        assert.equal(actualAbilities[0].original.usedAt,  -1 * (delay + actualAbilities[0].original.snapshotTimeFromStart));
+        assert.equal(actualAbilities[0].original.usedAt, -1 * (delay + actualAbilities[0].original.snapshotTimeFromStart));
 
         assert.equal(actualAbilities[1].original.appDelay, delay);
         assert.equal(actualAbilities[1].original.appDelayFromStart, delay + actualAbilities[0].original.snapshotTimeFromStart);

--- a/packages/math-frontend/src/scripts/mathpage/math_ui.ts
+++ b/packages/math-frontend/src/scripts/mathpage/math_ui.ts
@@ -353,6 +353,17 @@ export class MathArea extends HTMLElement {
                     languages: ['js']
                 });
                 hljs.highlightElement(codeArea);
+                codeArea.querySelectorAll('span.hljs-title')
+                    .forEach(element => {
+                        switch (element.textContent) {
+                            case 'fl':
+                                element.setAttribute('title', 'Floor to integer');
+                                break;
+                            case 'flp':
+                                element.setAttribute('title', 'Floor to specified number of decimal places');
+                                break;
+                        }
+                    });
                 const codeOuter = quickElement('div', ['code-outer'], [codeArea]);
                 const formulaText = quickElement('div', ['function-code-area'], [codeOuter]);
                 return quickElement('div', [], [heading, formulaText]);

--- a/packages/xivmath/src/xivmath.ts
+++ b/packages/xivmath/src/xivmath.ts
@@ -240,10 +240,12 @@ export function baseDamage(...args: Parameters<typeof baseDamageFull>): number {
 /**
  * Determines whether the caster variant of the damage formula should be used instead of the normal variant.
  *
- * @param stats The set stats
+ * @param stats The set stats.
+ * @param attackType The type of attack.
  */
-function usesCasterDamageFormula(stats: ComputedSetStats): boolean {
-    return stats.jobStats.role === 'Caster' || stats.jobStats.role === 'Healer';
+function usesCasterDamageFormula(stats: ComputedSetStats, attackType: AttackType): boolean {
+    return (stats.jobStats.role === 'Caster' || stats.jobStats.role === 'Healer')
+        && attackType !== 'Auto-attack';
 }
 
 /**
@@ -297,7 +299,7 @@ export function baseDamageFull(stats: ComputedSetStats, potency: number, attackT
     // Mahdi:
     // Caster Damage has potency multiplied into weapon damage and then truncated
     // to an integer as opposed to into ap and truncated to 2 decimal.
-    if (usesCasterDamageFormula(stats)) {
+    if (usesCasterDamageFormula(stats, attackType)) {
         // https://github.com/Amarantine-xiv/Amas-FF14-Combat-Sim_source/blob/main/ama_xiv_combat_sim/simulator/calcs/compute_damage_utils.py#L130
         const apDet = flp(2, mainStatMulti * effectiveDetMulti);
         const basePotency = fl(apDet * flp(2, wdMulti * potency));

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -61,7 +61,7 @@ export function finalizeStats(
         detMulti: detDmg(levelStats, combinedStats.determination),
         spsDotMulti: spsTickMulti(levelStats, combinedStats.spellspeed),
         sksDotMulti: sksTickMulti(levelStats, combinedStats.skillspeed),
-        tncMulti: tenacityDmg(levelStats, combinedStats.tenacity),
+        tncMulti: classJobStats.role === 'Tank' ? tenacityDmg(levelStats, combinedStats.tenacity) : 1,
         // TODO: does this need to be phys/magic split?
         wdMulti: wdMulti(levelStats, classJobStats, wdEffective),
         mainStatMulti: mainStatMulti(levelStats, classJobStats, mainStat),


### PR DESCRIPTION
Also updates tests, and implements the 'flp' function that floors to a certain precision. 

e.g. `flp(3, value)` will floor to 3 places, i.e. the equivalent of `fl(value * 1000) / 1000`.