### PR TITLE
Make ability column width smarter

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2517,7 +2517,11 @@ buff-settings-area {
       }
 
       .ability-name {
-
+        overflow-x: hidden;
+        text-overflow: ellipsis;
+        line-height: initial;
+        width: 30px;
+        flex-grow: 1;
       }
     }
 
@@ -2571,8 +2575,8 @@ buff-settings-area {
       }
 
       &[col-id='ability'] {
-        width: 150px;
-        max-width: 150px;
+        min-width: 150px;
+        width: 400px;
       }
 
       &[col-id='unbuffed-pot'] {


### PR DESCRIPTION
Will now correctly ellipsis long names:

![image](https://github.com/xiv-gear-planner/gear-planner/assets/14287379/230d01bf-b548-451d-b50c-cfd681268f9b)

Will also expand/shrink a bit more with the screen width:

![image](https://github.com/xiv-gear-planner/gear-planner/assets/14287379/ee32e79c-6e3e-4034-9a95-a1cf57b9f681)
