### PR TITLE
Make auto-attacks default based on role

### DIFF
--- a/packages/frontend/src/scripts/sims/blu/blu_common.ts
+++ b/packages/frontend/src/scripts/sims/blu/blu_common.ts
@@ -850,10 +850,6 @@ export abstract class BluSim<_BluCycleSimResult, _BluSimSettings>
         super("BLU", settings);
     }
 
-    get useAutosByDefault(): boolean {
-        return false;
-    }
-
     makeDefaultSettings(): BluSimSettings {
         return {
             dpsMimicryEnabled: true,

--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -1,4 +1,4 @@
-import {JobName} from "@xivgear/xivmath/xivconstants";
+import {JOB_DATA, JobName} from "@xivgear/xivmath/xivconstants";
 import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {cycleSettingsGui} from "./components/cycle_settings_components";
@@ -146,14 +146,12 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
 
     /**
      * Whether or not autoattacks should be enabled by default for ths sim.
+     *
+     * The default implementation returns false for healers and casters, true for everyone else.
      */
     get useAutosByDefault(): boolean {
-        // future TODO: flip this when 7.0 drops.
-        // Not changing now such as to not cause confusion with existing sheets.
-        // Also, this should arguably be added as a property to the job data itself.
-        // const jobData = JOB_DATA[this.job];
-        // return jobData.role !== 'Healer' && jobData.role !== 'Caster';
-        return true;
+        const jobData = JOB_DATA[this.job];
+        return jobData.role !== 'Healer' && jobData.role !== 'Caster';
     }
 
     /**

--- a/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
@@ -392,6 +392,7 @@ describe('Cycle sim processor', () => {
     it('produces the correct results', async () => {
         // Initialize
         const inst: TestMultiCycleSim = testSimSpec.makeNewSimInstance();
+        inst.cycleSettings.useAutos = true;
         inst.cycleSettings.totalTime = 30;
         // Enable buffs
         setPartyBuffEnabled(inst, Dokumori, true);


### PR DESCRIPTION
Auto-attacks will default to on for melee/range/tank, off for healer/caster.