### PR TITLE
Paladin Skill Speed Simulator

### DIFF
--- a/packages/frontend/src/scripts/sims/default_sims.ts
+++ b/packages/frontend/src/scripts/sims/default_sims.ts
@@ -1,4 +1,5 @@
 import {pldUsageSimSpec} from "./tank/pld/pld_usage_sim_no_sks"
+import {pldSKSSheetSpec} from "./tank/pld/pldsks_sim";
 import {whmSheetSpec} from "./healer/whm_sheet_sim";
 import {sgeSheetSpec} from "./healer/sge_sheet_sim";
 import {sgeNewSheetSpec} from "./healer/sge_sheet_sim_mk2";
@@ -20,6 +21,7 @@ import {dncDtSheetSpec} from "./ranged/dnc_sim";
 export function registerDefaultSims() {
     registerSim(potRatioSimSpec);
     registerSim(pldUsageSimSpec);
+    registerSim(pldSKSSheetSpec);
     registerSim(whmSheetSpec);
     registerSim(sgeSheetSpec);
     registerSim(sgeNewSheetSpec);

--- a/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
@@ -1,0 +1,211 @@
+import {AtonementReadyBuff, SupplicationReadyBuff, SepulchreReadyBuff, DivineMightBuff, BladeOfHonorReadyBuff, RequiescatBuff, FightOrFlightBuff, GoringBladeReadyBuff} from './pld_buffs';
+import {Ability, GcdAbility, OgcdAbility, OriginCdAbility, SharedCdAbility} from "@xivgear/core/sims/sim_types";
+
+/**
+ * Paladin GCD Actions
+ */
+
+export const FastBlade: GcdAbility = {
+    type: 'gcd',
+    name: "Fast Blade",
+    id: 9,
+    attackType: "Weaponskill",
+    potency: 220,
+    gcd: 2.5,
+    cast: 0
+};
+export const RiotBlade: GcdAbility = {
+    type: 'gcd',
+    name: "Riot Blade",
+    id: 15,
+    attackType: "Weaponskill",
+    potency: 330,
+    gcd: 2.5,
+    cast: 0
+};
+export const RoyalAuthority: GcdAbility = {
+    type: 'gcd',
+    name: "Royal Authority",
+    id: 3539,
+    attackType: "Weaponskill",
+    potency: 440,
+    gcd: 2.5,
+    cast: 0,
+    activatesBuffs: [AtonementReadyBuff, DivineMightBuff]
+};
+
+export const Atonement: GcdAbility = {
+    type: 'gcd',
+    name: "Atonement",
+    id: 16460,
+    attackType: "Weaponskill",
+    potency: 440,
+    gcd: 2.5,
+    cast: 0,
+    activatesBuffs: [SupplicationReadyBuff]
+}
+export const Supplication: GcdAbility = {
+    type: 'gcd',
+    name: "Supplication",
+    // todo update dawntrail
+    id: 36918,
+    attackType: "Weaponskill",
+    potency: 440,
+    gcd: 2.5,
+    cast: 0,
+    activatesBuffs: [SepulchreReadyBuff]
+}
+export const Sepulchre: GcdAbility = {
+    type: 'gcd',
+    name: "Sepulchre",
+    // todo update dawntrail
+    id: 36919,
+    attackType: "Weaponskill",
+    potency: 440,
+    gcd: 2.5,
+    cast: 0
+}
+
+export const HolySpirit: GcdAbility = {
+    type: 'gcd',
+    name: "Holy Spirit",
+    id: 7384,
+    attackType: "Spell",
+    potency: 470,
+    gcd: 2.5,
+    cast: 0
+}
+export const HolySpiritHardcast: GcdAbility = {
+    type: 'gcd',
+    name: "Holy Spirit (hard cast)",
+    id: 7384,
+    attackType: "Spell",
+    potency: 370,
+    gcd: 2.5,
+    cast: 1.5
+}
+
+export const GoringBlade: GcdAbility = {
+    type: 'gcd',
+    name: "Goring Blade",
+    id: 3538,
+    attackType: "Weaponskill",
+    potency: 700,
+    gcd: 2.5,
+    cast: 0
+}
+
+export const Confiteor: GcdAbility = {
+    type: 'gcd',
+    name: "Confiteor",
+    id: 16459,
+    attackType: "Spell",
+    potency: 940,
+    gcd: 2.5,
+    cast: 0
+}
+export const BladeOfFaith: GcdAbility = {
+    type: 'gcd',
+    name: "Blade of Faith",
+    id: 25748,
+    attackType: "Spell",
+    potency: 740,
+    gcd: 2.5,
+    cast: 0
+}
+export const BladeOfTruth: GcdAbility = {
+    type: 'gcd',
+    name: "Blade of Truth",
+    id: 25749,
+    attackType: "Spell",
+    potency: 840,
+    gcd: 2.5,
+    cast: 0
+}
+export const BladeOfValor: GcdAbility = {
+    type: 'gcd',
+    name: "Blade of Valor",
+    id: 25750,
+    attackType: "Spell",
+    potency: 940,
+    gcd: 2.5,
+    cast: 0,
+    activatesBuffs: [BladeOfHonorReadyBuff]
+}
+
+
+
+
+
+
+
+export const FightOrFlight: OgcdAbility = {
+    type: 'ogcd',
+    name: "Fight or Flight",
+    id: 20,
+    attackType: "Ability",
+    potency: null,
+    cooldown: {
+        time: 60
+    },
+    activatesBuffs: [FightOrFlightBuff, GoringBladeReadyBuff]
+}
+export const Imperator: OgcdAbility = {
+    type: 'ogcd',
+    name: "Imperator",
+    id: 36921,
+    attackType: "Ability",
+    potency: 580,
+    cooldown: {
+        time: 60
+    },
+    activatesBuffs: [RequiescatBuff]
+}
+export const BladeOfHonor: OgcdAbility = {
+    type: 'ogcd',
+    name: "Blade of Honor",
+    // todo update dawntrail
+    id: 36922,
+    attackType: "Ability",
+    potency: 1000,
+    cooldown: {
+        time: 1
+    }
+}
+
+export const Intervene: OgcdAbility = {
+    type: 'ogcd',
+    name: "Intervene",
+    id: 16461,
+    attackType: "Ability",
+    potency: 150,
+    cooldown: {
+        time: 30,
+        charges: 2
+    }
+}
+export const Expiacion: OgcdAbility = {
+    type: 'ogcd',
+    name: "Expiacion",
+    id: 25747,
+    attackType: "Ability",
+    potency: null,
+    cooldown: {
+        time: 30
+    }
+}
+export const CircleOfScorn: OgcdAbility = {
+    type: 'ogcd',
+    name: "Circle of Scorn",
+    id: 23,
+    attackType: "Ability",
+    potency: 140,
+    dot: {
+        id: 248,
+        tickPotency: 30,
+        duration: 15
+    },
+    cooldown: {
+        time: 30
+    }
+}

--- a/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
@@ -189,7 +189,7 @@ export const Expiacion: OgcdAbility = {
     name: "Expiacion",
     id: 25747,
     attackType: "Ability",
-    potency: null,
+    potency: 450,
     cooldown: {
         time: 30
     }

--- a/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
@@ -50,7 +50,7 @@ export const Supplication: GcdAbility = {
     // todo update dawntrail
     id: 36918,
     attackType: "Weaponskill",
-    potency: 440,
+    potency: 460,
     gcd: 2.5,
     cast: 0,
     activatesBuffs: [SepulchreReadyBuff]
@@ -61,7 +61,7 @@ export const Sepulchre: GcdAbility = {
     // todo update dawntrail
     id: 36919,
     attackType: "Weaponskill",
-    potency: 440,
+    potency: 480,
     gcd: 2.5,
     cast: 0
 }

--- a/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pld_actions.ts
@@ -1,5 +1,5 @@
 import {AtonementReadyBuff, SupplicationReadyBuff, SepulchreReadyBuff, DivineMightBuff, BladeOfHonorReadyBuff, RequiescatBuff, FightOrFlightBuff, GoringBladeReadyBuff} from './pld_buffs';
-import {Ability, GcdAbility, OgcdAbility, OriginCdAbility, SharedCdAbility} from "@xivgear/core/sims/sim_types";
+import {GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
 
 /**
  * Paladin GCD Actions

--- a/packages/frontend/src/scripts/sims/tank/pld/pld_buffs.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pld_buffs.ts
@@ -1,0 +1,105 @@
+import {Buff, Ability, BuffController} from "@xivgear/core/sims/sim_types";
+import {removeSelf} from "@xivgear/core/sims/common/utils";
+
+// Add a simple function to remove a single stack of a buff, for use with Req:
+export function subtractStackSelf(controller: BuffController): void {
+    controller.subtractStacksSelf(1);
+}
+
+/**
+ * Paladin-specific Buffs
+ */
+
+export const FightOrFlightBuff: Buff = {
+    name: "Fight or Flight",
+    selfOnly: true,
+    effects: {
+        dmgIncrease: 0.25
+    },
+    duration: 19.96, // Not actually 20s, per nikroulah
+    statusId: 76
+};
+export const RequiescatBuff: Buff = {
+    name: "Requiescat",
+    selfOnly: true,
+    effects: {
+        // Buffs PLD Spell Combo but at the level we're considering this
+        // Isn't important for us.
+    },
+    duration: 30,
+    statusId: 1368,
+    stacks: 4,
+    appliesTo: ability => ability.attackType === "Spell",
+    beforeSnapshot: subtractStackSelf
+};
+export const GoringBladeReadyBuff: Buff = {
+    name: "Goring Blade Ready",
+    selfOnly: true,
+    effects: {
+        // Let's us Goring Blade
+    },
+    duration: 30,
+    statusId: 3847,
+    appliesTo: ability => ability.name === "Goring Blade",
+    beforeSnapshot: removeSelf
+}
+
+export const AtonementReadyBuff: Buff = {
+    name: "Atonement Ready",
+    selfOnly: true,
+    effects: {
+        // Just lets us use Atonement
+    },
+    appliesTo: ability => ability.name === "Atonement",
+    beforeSnapshot: removeSelf,
+    duration: 30,
+    statusId: 1902
+};
+
+export const SupplicationReadyBuff: Buff = {
+    name: "Supplication Ready",
+    selfOnly: true,
+    effects: {
+        // Just lets us use Supplication
+    },
+    appliesTo: ability => ability.name === "Supplication",
+    beforeSnapshot: removeSelf,
+    duration: 30,
+    statusId: 3827
+};
+
+export const SepulchreReadyBuff: Buff = {
+    name: "Sepulchre Ready",
+    selfOnly: true,
+    effects: {
+        // Just lets us use Sepulchre
+    },
+    appliesTo: ability => ability.name === "Sepulchre",
+    beforeSnapshot: removeSelf,
+    duration: 30,
+    statusId: 3828
+};
+
+export const DivineMightBuff: Buff = {
+    name: "Divine Might",
+    selfOnly: true,
+    effects: {
+        // Just lets us use Insta Cast Holy Spirit
+    },
+    appliesTo: ability => ability.name === "Holy Spirit",
+    beforeSnapshot: removeSelf,
+    duration: 30,
+    statusId: 2673
+}
+
+export const BladeOfHonorReadyBuff: Buff = {
+    name: "Blade of Honor Ready",
+    selfOnly: true,
+    effects: {
+        // Just lets us use Blade of Honor
+    },
+    appliesTo: ability => ability.name === "Blade of Honor",
+    beforeSnapshot: removeSelf,
+    duration: 30,
+    statusId: 3831
+}

--- a/packages/frontend/src/scripts/sims/tank/pld/pld_buffs.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pld_buffs.ts
@@ -1,4 +1,4 @@
-import {Buff, Ability, BuffController} from "@xivgear/core/sims/sim_types";
+import {Buff, BuffController} from "@xivgear/core/sims/sim_types";
 import {removeSelf} from "@xivgear/core/sims/common/utils";
 
 // Add a simple function to remove a single stack of a buff, for use with Req:

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -661,7 +661,8 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 						{
 							safety++;
 							// Note the current status:
-							cp.addSpecialRow(`FOF: ${fof_remaining}, melee+1? ${enough_time_if_melee}`); 
+							if (!strategy_250)
+								cp.addSpecialRow(`FOF: ${fof_remaining}, melee+1? ${enough_time_if_melee}`); 
 							// Use a burst GCD
 							cp.useBurstFiller(prioritise_melee);
 							// Use any remaining oGCDs:
@@ -672,7 +673,8 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 							fof_remaining = cp.getFOFRemaining().toFixed(2);
 						}
 
-						cp.addSpecialRow(`FOF: ${fof_remaining}, melee+1? ${enough_time_if_melee}`);
+						if (!strategy_250)
+							cp.addSpecialRow(`FOF: ${fof_remaining}, melee+1? ${enough_time_if_melee}`);
 						cp.addSpecialRow(`Final burst GCD:`);
 						cp.useBurstFiller(false);
 

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -97,6 +97,7 @@ export interface PldSKSSheetSettings extends SimSettings {
 	acknowledgeSKS: boolean,
 	attempt9GCDAbove247: boolean,
 	alwaysLateWeave: boolean,
+	hardcastopener: boolean,
 }
 
 export interface PldSKSSheetSettingsExternal extends ExternalCycleSettings<PldSKSSheetSettings> {
@@ -278,7 +279,8 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
         return {
         	acknowledgeSKS: true,
         	attempt9GCDAbove247: false,
-        	alwaysLateWeave: false
+        	alwaysLateWeave: false,
+        	hardcastopener: true
         };
     };
 
@@ -303,6 +305,8 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
         checkboxesDiv.appendChild(labeledCheckbox('Force trying for 9/8 at 2.47+', tryCheck));
         const lateCheck = new FieldBoundCheckBox<PldSKSSheetSettings>(settings, 'alwaysLateWeave', {id: 'late-checkbox'});
         checkboxesDiv.appendChild(labeledCheckbox('Force always Late FOF at 2.43+', lateCheck));
+        const hcOpenCheck = new FieldBoundCheckBox<PldSKSSheetSettings>(settings, 'hardcastopener', {id: 'hc-checkbox'});
+        checkboxesDiv.appendChild(labeledCheckbox('Include a hardcast HS in the opener', hcOpenCheck));
 
         outerDiv.appendChild(checkboxesDiv);
 
@@ -458,7 +462,8 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 				// and juse use things as early as possible after the '3rd' GCD
 
             	// Standard opener:
-				//cp.useGcd(Actions.HolySpiritHardcast);
+            	if (sim.settings.hardcastopener)
+					cp.useGcd(Actions.HolySpiritHardcast);
 				cp.useGcd(Actions.FastBlade);
 				cp.useGcd(Actions.RiotBlade);
 				cp.useGcd(Actions.RoyalAuthority);

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -213,7 +213,7 @@ class PldSKSCycleProcessor extends CycleProcessor {
 		this.useGcd(chosen_ability);
     }
 
-    useBurstFiller(prioritise_melee: boolean, replace_12_w_hc?: boolean) {
+    useBurstFiller(prioritise_melee: boolean, replace_1_w_hc?: boolean) {
 		let chosen_ability = Actions.FastBlade;
 
 		// We always Sepulchre if we have it:
@@ -234,10 +234,10 @@ class PldSKSCycleProcessor extends CycleProcessor {
 		{
 			if (this.MyState.combo_state == 3)
 				chosen_ability = Actions.RoyalAuthority;
-            else if (replace_12_w_hc)
-                chosen_ability = Actions.HolySpiritHardcast;
 			else if (this.MyState.combo_state == 2)
 				chosen_ability = Actions.RiotBlade;
+            else if (replace_1_w_hc)
+                chosen_ability = Actions.HolySpiritHardcast;
 		}
 
     	this.useGcd(chosen_ability);
@@ -756,14 +756,14 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
                     {
                         cp.addSpecialRow("Less than 20s remain on sim!");
                         cp.addSpecialRow("Will now burn GCD resources.");
-                        cp.addSpecialRow("Replace Fast+Riot w/HS in last 3 GCDs");
+                        cp.addSpecialRow("Replace new combo w/HS in last 3 GCDs");
                         end_of_time_burn = true;
                     }
 
 					// This is the bit where we just use filler:
                     if (end_of_time_burn)
                     {
-                        // we also replace 1/2 with hardcasts under 3 phys GCDs
+                        // we also replace 1s with hardcasts under 3 phys GCDs, preventing a new combo starting
                         cp.useBurstFiller(false, cp.remainingGcdTime < (physGCD * 3));
                     }
                     else

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -142,7 +142,7 @@ class PldSKSCycleProcessor extends CycleProcessor {
     }
 
     fofIsActive(atTime: number): boolean {
-    	let fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
+    	const fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
     	if (fofData == null)
     		return false;
 
@@ -153,7 +153,7 @@ class PldSKSCycleProcessor extends CycleProcessor {
     }
 
     getFOFRemaining(): number {
-    	let fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
+    	const fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
     	if (fofData == null)
     		return 0;
     	return fofData.end - this.nextGcdTime;
@@ -354,15 +354,15 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 
             apply(cp: PldSKSCycleProcessor) {
 
-            	let physGCD = cp.stats.gcdPhys(2.5);
-            	let magicGCD = cp.stats.gcdMag(2.5);
+            	const physGCD = cp.stats.gcdPhys(2.5);
+            	const magicGCD = cp.stats.gcdMag(2.5);
 
             	let strategy_250 = false;
             	let strategy_98_alt = false;
             	let strategy_98_force = false;
             	let strategy_always9 = false;
             	let strategy_minimise = false;
-            	let strategy_hubris = (sim.settings.acknowledgeSKS == false);
+            	const strategy_hubris = (sim.settings.acknowledgeSKS == false);
 
             	// Let's assume that we are going to do a fixed time window
             	// optimisation, so, let's have an actual opener
@@ -615,16 +615,16 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 							// if we are on an even minute, and we're 98ing
 							if ((strategy_98_alt && even_minute) || strategy_always9)
 							{
-                                let readyAt = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.absolute;
+                                const readyAt = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.absolute;
 								cp.addSpecialRow(`>> Late Weaving FOF!`);
 								// if force is on, we are here because we are clipping our GCD:
 								if (strategy_98_force)
 								{
 									if (!cp.canUseWithoutClipping(Actions.FightOrFlight))
 									{
-										let beforeGCD = cp.nextGcdTime;
+										const beforeGCD = cp.nextGcdTime;
 										cp.delayForOgcd(Actions.FightOrFlight);
-                                        let clip_amount = cp.nextGcdTime - beforeGCD;
+                                        const clip_amount = cp.nextGcdTime - beforeGCD;
 										cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
                                         clip_total_time += clip_amount;
 									}
@@ -674,7 +674,7 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 							if (strategy_hubris)
 							{
 								let is_gonna_clip = false;
-								let beforeGCD = cp.nextGcdTime;
+								const beforeGCD = cp.nextGcdTime;
 								// If we're specifically pretending SKS doesn't exist, delay for Req+
 								if (!cp.canUseWithoutClipping(Actions.Imperator))
 									is_gonna_clip = true;
@@ -683,7 +683,7 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 
 								if (is_gonna_clip)
                                 {
-                                    let clip_amount = cp.nextGcdTime - beforeGCD;
+                                    const clip_amount = cp.nextGcdTime - beforeGCD;
 									cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
                                     clip_total_time += clip_amount;
                                 }
@@ -818,11 +818,11 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
                         only_cos_once_in_filler = false;
 		    			if (strategy_hubris)
 		    			{
-							let beforeGCD = cp.nextGcdTime;
+							const beforeGCD = cp.nextGcdTime;
 		    				cp.delayForOgcd(Actions.Expiacion);
 		    				if ((cp.nextGcdTime - beforeGCD) > 0)
                             {
-                                let clip_amount = cp.nextGcdTime - beforeGCD;
+                                const clip_amount = cp.nextGcdTime - beforeGCD;
 		    					cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
                                 clip_total_time += clip_amount;
                             }
@@ -836,8 +836,8 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 		    		}
                 }
 
-                let fof_delta = (time_of_last_fof - time_of_first_fof) - ((fofs_used - 1) * 60);
-                let avg_delay_fof = fof_delta / fofs_used;
+                const fof_delta = (time_of_last_fof - time_of_first_fof) - ((fofs_used - 1) * 60);
+                const avg_delay_fof = fof_delta / fofs_used;
 
                 cp.addSpecialRow(">> Summaries:");
 
@@ -846,7 +846,7 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
                 cp.addSpecialRow("Average delay: " + avg_delay_fof.toFixed(2));
                 if (avg_delay_fof > 0.01)
                 {
-                    let three_gcd_delay = 7.5 / avg_delay_fof;
+                    const three_gcd_delay = 7.5 / avg_delay_fof;
                     cp.addSpecialRow("Burst hits 7.5s delay @ ~" + three_gcd_delay.toFixed(0) + "m");
                     cp.addSpecialRow("Delay interacts with Party Buffs.");
                 }

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -1,103 +1,97 @@
-import {Ability, GcdAbility, OgcdAbility, Buff, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
+import {GcdAbility, OgcdAbility, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
 import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, 
-		AbilityUseResult, Rotation, AbilityUseRecordUnf, BuffUsage} from "@xivgear/core/sims/cycle_sim";
-import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
+        AbilityUseResult, Rotation} from "@xivgear/core/sims/cycle_sim";
 import {STANDARD_ANIMATION_LOCK} from "@xivgear/xivmath/xivconstants";
 import {BaseMultiCycleSim} from "../../sim_processors";
-import {AbilitiesUsedTable} from "../../components/ability_used_table";
-import {CharacterGearSet} from "@xivgear/core/gear";
-import {ComputedSetStats} from "@xivgear/xivmath/geartypes";
 import * as Actions from './pld_actions';
 import * as Buffs from './pld_buffs';
 import {
     FieldBoundCheckBox,
-    FieldBoundFloatField,
-    labeledCheckbox, labelFor,
-    positiveValuesOnly, quickElement
+    labeledCheckbox
 } from "@xivgear/common-ui/components/util";
 
 
 
 class PaladinStateSystem {
-	// This simple class accepts the GCD that we performed
-	// and updates the state of our filler
-	A1Ready: number = 0b0001;
-	A2Ready: number = 0b0010;
-	A3Ready: number = 0b0100;
+    // This simple class accepts the GCD that we performed
+    // and updates the state of our filler
+    A1Ready: number = 0b0001;
+    A2Ready: number = 0b0010;
+    A3Ready: number = 0b0100;
 
-	combo_state: number = 1;
-	sword_oath: number = 0;
-	divine_might: boolean = false;
+    combo_state: number = 1;
+    sword_oath: number = 0;
+    divine_might: boolean = false;
 
-	perform_action(GCDused: GcdAbility)
-	{
-		if (GCDused == Actions.FastBlade)
-		{
-			this.combo_state = 2;
-		}
-		else if (GCDused == Actions.RiotBlade)
-		{
-			if (this.combo_state == 2)
-				this.combo_state = 3;
-			else
-				this.combo_state = 0;
-		}
-		else if (GCDused == Actions.RoyalAuthority)
-		{
-			if (this.combo_state == 3)
-			{
-				this.combo_state = 1;
-				this.divine_might = true;
-				this.sword_oath = this.sword_oath | this.A1Ready
-			}
-			else
-				this.combo_state = 0;
-		}
-		else if (GCDused == Actions.HolySpirit)
-		{
-			// Consume Divine Might:
-			this.divine_might = false;
-		}
-		else if (GCDused == Actions.Atonement)
-		{
-			if (this.sword_oath & this.A1Ready)
-			{
-				// Remove AtonementReady, Add Supplication Ready
-				this.sword_oath = (this.sword_oath & ~this.A1Ready) | this.A2Ready;
-			}
-		}
-		else if (GCDused == Actions.Supplication)
-		{
-			if (this.sword_oath & this.A2Ready)
-			{
-				// Remove Supplication Ready, Add Sepulchre Ready
-				this.sword_oath = (this.sword_oath & ~this.A2Ready) | this.A3Ready;
-			}
-		}
-		else if (GCDused == Actions.Sepulchre)
-		{
-			if (this.sword_oath & this.A3Ready)
-			{
-				// Remove Sepulchre
-				this.sword_oath = (this.sword_oath & (~this.A3Ready));
-			}
-		}
-	}
+    perform_action(GCDused: GcdAbility)
+    {
+        if (GCDused == Actions.FastBlade)
+        {
+            this.combo_state = 2;
+        }
+        else if (GCDused == Actions.RiotBlade)
+        {
+            if (this.combo_state == 2)
+                this.combo_state = 3;
+            else
+                this.combo_state = 0;
+        }
+        else if (GCDused == Actions.RoyalAuthority)
+        {
+            if (this.combo_state == 3)
+            {
+                this.combo_state = 1;
+                this.divine_might = true;
+                this.sword_oath = this.sword_oath | this.A1Ready
+            }
+            else
+                this.combo_state = 0;
+        }
+        else if (GCDused == Actions.HolySpirit)
+        {
+            // Consume Divine Might:
+            this.divine_might = false;
+        }
+        else if (GCDused == Actions.Atonement)
+        {
+            if (this.sword_oath & this.A1Ready)
+            {
+                // Remove AtonementReady, Add Supplication Ready
+                this.sword_oath = (this.sword_oath & ~this.A1Ready) | this.A2Ready;
+            }
+        }
+        else if (GCDused == Actions.Supplication)
+        {
+            if (this.sword_oath & this.A2Ready)
+            {
+                // Remove Supplication Ready, Add Sepulchre Ready
+                this.sword_oath = (this.sword_oath & ~this.A2Ready) | this.A3Ready;
+            }
+        }
+        else if (GCDused == Actions.Sepulchre)
+        {
+            if (this.sword_oath & this.A3Ready)
+            {
+                // Remove Sepulchre
+                this.sword_oath = (this.sword_oath & (~this.A3Ready));
+            }
+        }
+    }
 
-	
-	debugState() {
-		console.log( [ this.combo_state , this.sword_oath , this.divine_might ].toString() );
-	}
+    
+    debugState() {
+        console.log( [ this.combo_state , this.sword_oath , this.divine_might ].toString() );
+    }
 }
 
 export interface PldSKSSheetSimResult extends CycleSimResult {
 }
 
 export interface PldSKSSheetSettings extends SimSettings {
-	acknowledgeSKS: boolean,
-	attempt9GCDAbove247: boolean,
-	alwaysLateWeave: boolean,
-	hardcastopener: boolean,
+    acknowledgeSKS: boolean,
+    attempt9GCDAbove247: boolean,
+    alwaysLateWeave: boolean,
+    hardcastopener: boolean,
     burstOneGCDEarlier: boolean,
     disableBurnDown: boolean,
     perform12312OldPrio: boolean,
@@ -128,11 +122,11 @@ export const pldSKSSheetSpec: SimSpec<PldSKSSheetSim, PldSKSSheetSettingsExterna
 };
 
 class PldSKSCycleProcessor extends CycleProcessor {
-	MyState: PaladinStateSystem;
-	MySettings: PldSKSSheetSettings;
+    MyState: PaladinStateSystem;
+    MySettings: PldSKSSheetSettings;
 
-	teeny_tiny_safety_margin: number = 0.001
-	// stats: ComputedSetStats;
+    teeny_tiny_safety_margin: number = 0.001
+    // stats: ComputedSetStats;
 
     constructor(settings: MultiCycleSettings) {
         super(settings);
@@ -142,117 +136,117 @@ class PldSKSCycleProcessor extends CycleProcessor {
     }
 
     fofIsActive(atTime: number): boolean {
-    	const fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
-    	if (fofData == null)
-    		return false;
+        const fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
+        if (fofData == null)
+            return false;
 
-    	if (fofData.end > atTime)
-    		return true;
-    	else
-    		return false;
+        if (fofData.end > atTime)
+            return true;
+        else
+            return false;
     }
 
     getFOFRemaining(): number {
-    	const fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
-    	if (fofData == null)
-    		return 0;
-    	return fofData.end - this.nextGcdTime;
+        const fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
+        if (fofData == null)
+            return 0;
+        return fofData.end - this.nextGcdTime;
     }
 
     useOgcdInOrder(order: OgcdAbility[], idx: number): number {
-    	if (idx < order.length) {
-    		if (this.canUseWithoutClipping(order[idx]))
-    		{
-    			this.useOgcd(order[idx]);
-    			idx++;
-    		}
-    	}
-    	if (idx < order.length) {
-			if (this.canUseWithoutClipping(order[idx]))
-    		{
-    			this.useOgcd(order[idx]);
-    			idx++;
-    		}
-    	}
-    	return idx;
+        if (idx < order.length) {
+            if (this.canUseWithoutClipping(order[idx]))
+            {
+                this.useOgcd(order[idx]);
+                idx++;
+            }
+        }
+        if (idx < order.length) {
+            if (this.canUseWithoutClipping(order[idx]))
+            {
+                this.useOgcd(order[idx]);
+                idx++;
+            }
+        }
+        return idx;
     }
 
     useFiller(even_minute: boolean, use_old_priority?: boolean) {
-    	// During regular filler, we will always use a specific GCD based on our state
-    	let chosen_ability = Actions.FastBlade;
+        // During regular filler, we will always use a specific GCD based on our state
+        let chosen_ability = Actions.FastBlade;
 
-    	// if we are atonement ready, become supplication ready:
-    	// This top If statement is what optimises us for 3 GCDs in FOF
-    	// When we have SKS and expect a 9 GCD FOF, we will skip this aspect
-    	// The parameter, even_minute, will be true when we are approaching an even minute burst
+        // if we are atonement ready, become supplication ready:
+        // This top If statement is what optimises us for 3 GCDs in FOF
+        // When we have SKS and expect a 9 GCD FOF, we will skip this aspect
+        // The parameter, even_minute, will be true when we are approaching an even minute burst
 
-    	if (this.MyState.sword_oath == this.MyState.A1Ready && even_minute == false && !use_old_priority)
-    	{
-    		chosen_ability = Actions.Atonement;
-    	}
-    	else if (this.MyState.combo_state != 3)
-    	{
-    		if (this.MyState.combo_state == 2)
-    			chosen_ability = Actions.RiotBlade;
-    		else
-    			chosen_ability = Actions.FastBlade;
-    	}
-    	else
-    	{
-    		// If we are royal ready:
-			if (this.MyState.sword_oath == this.MyState.A1Ready)
-    			chosen_ability = Actions.Atonement;
-    		else if (this.MyState.sword_oath == this.MyState.A2Ready)
-    			chosen_ability = Actions.Supplication;
-    		else if (this.MyState.divine_might == true && !use_old_priority)
-    			chosen_ability = Actions.HolySpirit;
-    		else if (this.MyState.sword_oath == this.MyState.A3Ready)
-    			chosen_ability = Actions.Sepulchre;
+        if (this.MyState.sword_oath == this.MyState.A1Ready && even_minute == false && !use_old_priority)
+        {
+            chosen_ability = Actions.Atonement;
+        }
+        else if (this.MyState.combo_state != 3)
+        {
+            if (this.MyState.combo_state == 2)
+                chosen_ability = Actions.RiotBlade;
+            else
+                chosen_ability = Actions.FastBlade;
+        }
+        else
+        {
+            // If we are royal ready:
+            if (this.MyState.sword_oath == this.MyState.A1Ready)
+                chosen_ability = Actions.Atonement;
+            else if (this.MyState.sword_oath == this.MyState.A2Ready)
+                chosen_ability = Actions.Supplication;
+            else if (this.MyState.divine_might == true && !use_old_priority)
+                chosen_ability = Actions.HolySpirit;
+            else if (this.MyState.sword_oath == this.MyState.A3Ready)
+                chosen_ability = Actions.Sepulchre;
             else if (this.MyState.divine_might == true && use_old_priority)
                 chosen_ability = Actions.HolySpirit;
-    		else if (this.MyState.sword_oath == 0 && this.MyState.divine_might == false)
-    			chosen_ability = Actions.RoyalAuthority;
-    	}
+            else if (this.MyState.sword_oath == 0 && this.MyState.divine_might == false)
+                chosen_ability = Actions.RoyalAuthority;
+        }
 
-		this.useGcd(chosen_ability);
+        this.useGcd(chosen_ability);
     }
 
     useBurstFiller(prioritise_melee: boolean, replace_1_w_hc?: boolean) {
-		let chosen_ability = Actions.FastBlade;
+        let chosen_ability = Actions.FastBlade;
 
-		// We always Sepulchre if we have it:
-		if (this.MyState.sword_oath == this.MyState.A3Ready)
-			chosen_ability = Actions.Sepulchre;
+        // We always Sepulchre if we have it:
+        if (this.MyState.sword_oath == this.MyState.A3Ready)
+            chosen_ability = Actions.Sepulchre;
 
-		// prioritise_melee blocks this check:
-		else if (this.MyState.divine_might == true && !prioritise_melee)
-			chosen_ability = Actions.HolySpirit;
-		else if (this.MyState.sword_oath == this.MyState.A1Ready)
-			chosen_ability = Actions.Atonement;
-		else if (this.MyState.sword_oath == this.MyState.A2Ready)
-			chosen_ability = Actions.Supplication;
-		// When we prioritise_melee, only use HS if it is our last option
-		else if (this.MyState.divine_might == true)
-			chosen_ability = Actions.HolySpirit;
-		else if (this.MyState.sword_oath == 0 && this.MyState.divine_might == false)
-		{
-			if (this.MyState.combo_state == 3)
-				chosen_ability = Actions.RoyalAuthority;
-			else if (this.MyState.combo_state == 2)
-				chosen_ability = Actions.RiotBlade;
+        // prioritise_melee blocks this check:
+        else if (this.MyState.divine_might == true && !prioritise_melee)
+            chosen_ability = Actions.HolySpirit;
+        else if (this.MyState.sword_oath == this.MyState.A1Ready)
+            chosen_ability = Actions.Atonement;
+        else if (this.MyState.sword_oath == this.MyState.A2Ready)
+            chosen_ability = Actions.Supplication;
+        // When we prioritise_melee, only use HS if it is our last option
+        else if (this.MyState.divine_might == true)
+            chosen_ability = Actions.HolySpirit;
+        else if (this.MyState.sword_oath == 0 && this.MyState.divine_might == false)
+        {
+            if (this.MyState.combo_state == 3)
+                chosen_ability = Actions.RoyalAuthority;
+            else if (this.MyState.combo_state == 2)
+                chosen_ability = Actions.RiotBlade;
             else if (replace_1_w_hc)
                 chosen_ability = Actions.HolySpiritHardcast;
-		}
+        }
 
-    	this.useGcd(chosen_ability);
+        this.useGcd(chosen_ability);
     }
 
     useOgcdLateWeave(ability: OgcdAbility): AbilityUseResult {
-    	this.advanceTo(this.nextGcdTime - (STANDARD_ANIMATION_LOCK) - this.teeny_tiny_safety_margin);
-    	return this.useOgcd(ability);
+        this.advanceTo(this.nextGcdTime - (STANDARD_ANIMATION_LOCK) - this.teeny_tiny_safety_margin);
+        return this.useOgcd(ability);
     }
 
-	override useGcd(ability: GcdAbility): AbilityUseResult {
+    override useGcd(ability: GcdAbility): AbilityUseResult {
         // Automatically update our state when we use a GCD:
         this.MyState.perform_action(ability);
         //this.MyState.debugState();
@@ -261,7 +255,7 @@ class PldSKSCycleProcessor extends CycleProcessor {
 
     // Stolen from Ninja sim
     // Effectively just delays us to the time we can actually use our oGCD at the earliest in the window
-	override useOgcd(ability: OgcdAbility): AbilityUseResult {
+    override useOgcd(ability: OgcdAbility): AbilityUseResult {
         // If an Ogcd isn't ready yet, but it can still be used without clipping, advance time until ready.
         if (this.canUseWithoutClipping(ability)) {
             const readyAt = this.cdTracker.statusOf(ability).readyAt.absolute;
@@ -274,8 +268,8 @@ class PldSKSCycleProcessor extends CycleProcessor {
     }
 
     delayForOgcd(ability: OgcdAbility) : AbilityUseResult {
-    	// Here we insist upon using it:
-    	const readyAt = this.cdTracker.statusOf(ability).readyAt.absolute;
+        // Here we insist upon using it:
+        const readyAt = this.cdTracker.statusOf(ability).readyAt.absolute;
         if (this.totalTime > readyAt) {
             this.advanceTo(readyAt);
         }
@@ -288,27 +282,27 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 
     makeDefaultSettings(): PldSKSSheetSettings {
         return {
-        	acknowledgeSKS: true,
-        	attempt9GCDAbove247: false,
-        	alwaysLateWeave: false,
-        	hardcastopener: true,
+            acknowledgeSKS: true,
+            attempt9GCDAbove247: false,
+            alwaysLateWeave: false,
+            hardcastopener: true,
             burstOneGCDEarlier: false,
             disableBurnDown: false,
             perform12312OldPrio: false,
         };
     };
 
-	spec = pldSKSSheetSpec;
-	shortName = "pld-sheet-sim";
-	displayName = pldSKSSheetSpec.displayName;
+    spec = pldSKSSheetSpec;
+    shortName = "pld-sheet-sim";
+    displayName = pldSKSSheetSpec.displayName;
 
-	constructor(settings?: PldSKSSheetSettingsExternal) {
+    constructor(settings?: PldSKSSheetSettingsExternal) {
         super('PLD', settings);
 
     }
 
 
-	override makeCustomConfigInterface(settings: PldSKSSheetSettings): HTMLElement {
+    override makeCustomConfigInterface(settings: PldSKSSheetSettings): HTMLElement {
 
         const outerDiv = document.createElement("div");
         const checkboxesDiv = document.createElement("div");
@@ -341,148 +335,148 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
         });
     }
 
-	getRotationsToSimulate(): Rotation[] {
+    getRotationsToSimulate(): Rotation[] {
         const sim = this;
 
         //nb I stole most of this from the RPR sim
 
         return [{
-        	// Technically our lowest common cycle time for strategies that we would actually cycle
-        	// are like 14 minutes, lol:
+            // Technically our lowest common cycle time for strategies that we would actually cycle
+            // are like 14 minutes, lol:
             cycleTime: 60 * 14,
 
 
             apply(cp: PldSKSCycleProcessor) {
 
-            	const physGCD = cp.stats.gcdPhys(2.5);
-            	const magicGCD = cp.stats.gcdMag(2.5);
+                const physGCD = cp.stats.gcdPhys(2.5);
+                const magicGCD = cp.stats.gcdMag(2.5);
 
-            	let strategy_250 = false;
-            	let strategy_98_alt = false;
-            	let strategy_98_force = false;
-            	let strategy_always9 = false;
-            	let strategy_minimise = false;
-            	const strategy_hubris = (sim.settings.acknowledgeSKS == false);
+                let strategy_250 = false;
+                let strategy_98_alt = false;
+                let strategy_98_force = false;
+                let strategy_always9 = false;
+                let strategy_minimise = false;
+                const strategy_hubris = (sim.settings.acknowledgeSKS == false);
 
-            	// Let's assume that we are going to do a fixed time window
-            	// optimisation, so, let's have an actual opener
+                // Let's assume that we are going to do a fixed time window
+                // optimisation, so, let's have an actual opener
 
-            	// A fixed time window is favourable to the perception of SKS
-            	// as even minimal delays to burst on an *infinite* dummy translate
-            	// to DPS losses that kinda do not exist in situations where you never
-            	// actually lose a usage: over *infinte* time, even a 0.1s delay
-            	// means you *eventually* lose a usage.
+                // A fixed time window is favourable to the perception of SKS
+                // as even minimal delays to burst on an *infinite* dummy translate
+                // to DPS losses that kinda do not exist in situations where you never
+                // actually lose a usage: over *infinte* time, even a 0.1s delay
+                // means you *eventually* lose a usage.
 
-				cp.addSpecialRow(`Phys GCD is: ${physGCD}`);
-            	cp.addSpecialRow(`Magic GCD is: ${magicGCD}`);
+                cp.addSpecialRow(`Phys GCD is: ${physGCD}`);
+                cp.addSpecialRow(`Magic GCD is: ${magicGCD}`);
 
-				// However, if we are going to pretend SKS does not exist
-				// (or, SKS does in fact not exist), we don't need this:
-				if (physGCD > 2.49)
-				{
-					cp.addSpecialRow(`No SKS to consider due to 2.5 GCD`);
-					strategy_250 = true;
-				}
-				else if (strategy_hubris)
-				{
+                // However, if we are going to pretend SKS does not exist
+                // (or, SKS does in fact not exist), we don't need this:
+                if (physGCD > 2.49)
+                {
+                    cp.addSpecialRow(`No SKS to consider due to 2.5 GCD`);
+                    strategy_250 = true;
+                }
+                else if (strategy_hubris)
+                {
                     cp.addSpecialRow(``);
-					cp.addSpecialRow(`SKS Acknowledgement is disabled.`);
-					cp.addSpecialRow(`Sim will DELIBERATELY CLIP GCD`);
+                    cp.addSpecialRow(`SKS Acknowledgement is disabled.`);
+                    cp.addSpecialRow(`Sim will DELIBERATELY CLIP GCD`);
                     cp.addSpecialRow(`due intentionally playing as though 2.5`);
                     cp.addSpecialRow(``);
                     cp.addSpecialRow(`Gives a baseline for when no sks opti`);
                     cp.addSpecialRow(`is performed.`);
                     cp.addSpecialRow(``);
-					strategy_250 = true;
-				}
-				// We then have a variety of things to consider.
-				// at 2.47 and above, PLD is unlikely to achieve a 9 GCD FOF
-				// So we don't try, and instead aim to minimise buff drift
-				else if (physGCD > 2.46) 
-				{
-					// However we have setting over rides to force our hand:
+                    strategy_250 = true;
+                }
+                // We then have a variety of things to consider.
+                // at 2.47 and above, PLD is unlikely to achieve a 9 GCD FOF
+                // So we don't try, and instead aim to minimise buff drift
+                else if (physGCD > 2.46) 
+                {
+                    // However we have setting over rides to force our hand:
                     if (sim.settings.alwaysLateWeave == true)
                     {
                         cp.addSpecialRow(`Late FOF w/2.43+ GCD (Override)`);
                         strategy_always9 = true;
                     }
-					else if (sim.settings.attempt9GCDAbove247 == true)
-					{
-						cp.addSpecialRow(`9/8 FOF w/2.47+ GCD (Override)`);
-						strategy_98_alt = true;
-					}
-					else
-					{
-						cp.addSpecialRow(`2.47+ GCD, aim to minimise drift`);
-						strategy_minimise = true;
-					}
-				}
-				// At 2.43 to 2.46, it should be possible to alternate a 9 GCD and an 8 GCD
-				// FOF to minimise drift, and just get a little extra from party buffs
-				// It's so, so little though, lol.
-				else if (physGCD > 2.42)
-				{
-					// 2.43 specifically is cursed:
-					if (physGCD < 2.44)
-					{
-						cp.addSpecialRow(`2.43 Phys GCD is particularly challenging.`);
-						cp.addSpecialRow(`It either delays fof significantly`);
-						cp.addSpecialRow(`or risks clipping it's GCD to do 9/8`);
+                    else if (sim.settings.attempt9GCDAbove247 == true)
+                    {
+                        cp.addSpecialRow(`9/8 FOF w/2.47+ GCD (Override)`);
+                        strategy_98_alt = true;
+                    }
+                    else
+                    {
+                        cp.addSpecialRow(`2.47+ GCD, aim to minimise drift`);
+                        strategy_minimise = true;
+                    }
+                }
+                // At 2.43 to 2.46, it should be possible to alternate a 9 GCD and an 8 GCD
+                // FOF to minimise drift, and just get a little extra from party buffs
+                // It's so, so little though, lol.
+                else if (physGCD > 2.42)
+                {
+                    // 2.43 specifically is cursed:
+                    if (physGCD < 2.44)
+                    {
+                        cp.addSpecialRow(`2.43 Phys GCD is particularly challenging.`);
+                        cp.addSpecialRow(`It either delays fof significantly`);
+                        cp.addSpecialRow(`or risks clipping it's GCD to do 9/8`);
 
-						if (sim.settings.alwaysLateWeave)
-						{
-							strategy_always9 = true;
-							cp.addSpecialRow(`Late FOF w/2.43 GCD (Override)`);
-						}
-						else
-						{
-							strategy_98_alt = true;
-							strategy_98_force = true;
-							cp.addSpecialRow(`Presenting CLIP GCD strat`);
-							cp.addSpecialRow(`(consider always late weave option)`);
-						}
-					}
-					else
-					{
-						// If we're 2.44 - 2.46
-						if (sim.settings.alwaysLateWeave == true)
-						{
-							cp.addSpecialRow(`Late FOF w/2.43+ GCD (Override)`);
-							strategy_always9 = true;
-						}
-						else
-						{
-							cp.addSpecialRow(`2.44-2.46 GCD, alternating 9/8 FOFs`);
-							strategy_98_alt = true;
-						}
-					}
-				}
-				// Otherwise, if our GCD is 2.37 - 2.42 We will always late weave FOF:
-				else if (physGCD > 2.36)
-				{
-					cp.addSpecialRow(`Always Late FOF at 2.37+ GCD`);
-					strategy_always9 = true;
-				}
-				// Below that, things get weird, so let's just rely on the sim's override options:
-				else
-				{
-					cp.addSpecialRow(`Phys GCD very low! Use Overrides to trial behavior:`);
+                        if (sim.settings.alwaysLateWeave)
+                        {
+                            strategy_always9 = true;
+                            cp.addSpecialRow(`Late FOF w/2.43 GCD (Override)`);
+                        }
+                        else
+                        {
+                            strategy_98_alt = true;
+                            strategy_98_force = true;
+                            cp.addSpecialRow(`Presenting CLIP GCD strat`);
+                            cp.addSpecialRow(`(consider always late weave option)`);
+                        }
+                    }
+                    else
+                    {
+                        // If we're 2.44 - 2.46
+                        if (sim.settings.alwaysLateWeave == true)
+                        {
+                            cp.addSpecialRow(`Late FOF w/2.43+ GCD (Override)`);
+                            strategy_always9 = true;
+                        }
+                        else
+                        {
+                            cp.addSpecialRow(`2.44-2.46 GCD, alternating 9/8 FOFs`);
+                            strategy_98_alt = true;
+                        }
+                    }
+                }
+                // Otherwise, if our GCD is 2.37 - 2.42 We will always late weave FOF:
+                else if (physGCD > 2.36)
+                {
+                    cp.addSpecialRow(`Always Late FOF at 2.37+ GCD`);
+                    strategy_always9 = true;
+                }
+                // Below that, things get weird, so let's just rely on the sim's override options:
+                else
+                {
+                    cp.addSpecialRow(`Phys GCD very low! Use Overrides to trial behavior:`);
                     if (sim.settings.alwaysLateWeave == true)
                     {
                         cp.addSpecialRow(`Always late override, Late FOFs`);
                         strategy_always9 = true;
                     }
-					else if (sim.settings.attempt9GCDAbove247 == true)
-					{
-						cp.addSpecialRow(`9/8 Override, will late weave evens`);
-						strategy_98_alt = true;
-					}
-					else
-					{
-						cp.addSpecialRow(`No Overrides, Minimizing Drift`);
-						strategy_minimise = true;
-					}
-				}
+                    else if (sim.settings.attempt9GCDAbove247 == true)
+                    {
+                        cp.addSpecialRow(`9/8 Override, will late weave evens`);
+                        strategy_98_alt = true;
+                    }
+                    else
+                    {
+                        cp.addSpecialRow(`No Overrides, Minimizing Drift`);
+                        strategy_minimise = true;
+                    }
+                }
 
                 if (sim.settings.perform12312OldPrio)
                 {
@@ -512,26 +506,26 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
                 {
                     cp.addSpecialRow(`>> Always 9 GCD FOF: Hold Atonement`);
                 }
-				// We will not set our loop up to attempt a special first burst
-				// and juse use things as early as possible after the '3rd' GCD
+                // We will not set our loop up to attempt a special first burst
+                // and juse use things as early as possible after the '3rd' GCD
 
-            	// Standard opener:
-            	if (sim.settings.hardcastopener)
-					cp.useGcd(Actions.HolySpiritHardcast);
-				cp.useGcd(Actions.FastBlade);
-				cp.useGcd(Actions.RiotBlade);
+                // Standard opener:
+                if (sim.settings.hardcastopener)
+                    cp.useGcd(Actions.HolySpiritHardcast);
+                cp.useGcd(Actions.FastBlade);
+                cp.useGcd(Actions.RiotBlade);
                 if (!sim.settings.burstOneGCDEarlier)
                 {
-				    cp.useGcd(Actions.RoyalAuthority);
+                    cp.useGcd(Actions.RoyalAuthority);
                 }
                 else
                 {
                     cp.addSpecialRow(">> Override: Bursting 1 GCD earlier")
                 }
 
-				let safety = 0;
-				let even_minute = true;
-				let force_next_burst = false;
+                let safety = 0;
+                let even_minute = true;
+                let force_next_burst = false;
 
                 let only_cos_once_in_filler = true;
                 let only_exp_once_in_filler = true;
@@ -544,110 +538,110 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 
                 let clip_total_time = 0;
 
-				while ((cp.remainingGcdTime > 0) && (safety < 100000) ) {
-					// While loops with no safety clause!
-					safety++;
+                while ((cp.remainingGcdTime > 0) && (safety < 100000) ) {
+                    // While loops with no safety clause!
+                    safety++;
 
-					//console.log( [ cp.nextGcdTime - cp.currentTime , cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.relative , cp.canUseWithoutClipping(Actions.FightOrFlight) ].toString() );
+                    //console.log( [ cp.nextGcdTime - cp.currentTime , cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.relative , cp.canUseWithoutClipping(Actions.FightOrFlight) ].toString() );
 
-					if (strategy_minimise || strategy_98_alt || strategy_hubris)
-					{
-						// if we are forcing 9/8s, we can't rely on canUseWithoutClipping
-						// this is because: we will clip, lol.
-						// We also want to provide feedback on if we delayed FOF across a GCD
-						
-				        let readyAt = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.absolute;
-				        let next_early = cp.nextGcdTime + STANDARD_ANIMATION_LOCK;
-				        // note that this is the going to delay up to the earliest weave after the next GCD:
-				    	if (readyAt > cp.currentTime && readyAt < ( next_early ))
-				    	{
-				    		// If this is going to collide with the next GCD, we want to know about it
+                    if (strategy_minimise || strategy_98_alt || strategy_hubris)
+                    {
+                        // if we are forcing 9/8s, we can't rely on canUseWithoutClipping
+                        // this is because: we will clip, lol.
+                        // We also want to provide feedback on if we delayed FOF across a GCD
+                        
+                        const readyAt = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.absolute;
+                        const next_early = cp.nextGcdTime + STANDARD_ANIMATION_LOCK;
+                        // note that this is the going to delay up to the earliest weave after the next GCD:
+                        if (readyAt > cp.currentTime && readyAt < ( next_early ))
+                        {
+                            // If this is going to collide with the next GCD, we want to know about it
 
-				    		// If we are forcing 98s and this is an even minute, we will get our awareness
-				    		// elsewhere:
-				    		if ((strategy_98_force && even_minute))
-				    			force_next_burst = true;
-				    		else
-				    		{
-				    			let is_after_late_weave_limit = (readyAt > (cp.nextGcdTime - STANDARD_ANIMATION_LOCK));
-				    			let is_after_next_gcd = readyAt > cp.nextGcdTime;
-				    			// Otherwise, add to the log what we are doing:
-								if (is_after_late_weave_limit)
-								{
-									if (strategy_hubris)
-									{
-										cp.addSpecialRow(">> FOF comes up in " + (readyAt - cp.currentTime).toFixed(2) + "s");
-										if (is_after_next_gcd)
-										{
-											cp.addSpecialRow(">> This is after the next GCD.");
-											cp.addSpecialRow(">> A non-sks inclined player likely uses the GCD");
-											cp.addSpecialRow(">> Delaying FOF by " + (next_early - readyAt).toFixed(2) + "s");
-										}
-										else
-										{
-											cp.addSpecialRow(">> Delaying until available!");
-											cp.advanceTo(readyAt);
-											force_next_burst = true;
-										}
-									}
-									else
-					    				cp.addSpecialRow(">> Delaying FOF " + (next_early - readyAt).toFixed(2) +  "s across GCD...");
-								}
-					    	}
-				    	}
-					}
+                            // If we are forcing 98s and this is an even minute, we will get our awareness
+                            // elsewhere:
+                            if ((strategy_98_force && even_minute))
+                                force_next_burst = true;
+                            else
+                            {
+                                const is_after_late_weave_limit = (readyAt > (cp.nextGcdTime - STANDARD_ANIMATION_LOCK));
+                                const is_after_next_gcd = readyAt > cp.nextGcdTime;
+                                // Otherwise, add to the log what we are doing:
+                                if (is_after_late_weave_limit)
+                                {
+                                    if (strategy_hubris)
+                                    {
+                                        cp.addSpecialRow(">> FOF comes up in " + (readyAt - cp.currentTime).toFixed(2) + "s");
+                                        if (is_after_next_gcd)
+                                        {
+                                            cp.addSpecialRow(">> This is after the next GCD.");
+                                            cp.addSpecialRow(">> A non-sks inclined player likely uses the GCD");
+                                            cp.addSpecialRow(">> Delaying FOF by " + (next_early - readyAt).toFixed(2) + "s");
+                                        }
+                                        else
+                                        {
+                                            cp.addSpecialRow(">> Delaying until available!");
+                                            cp.advanceTo(readyAt);
+                                            force_next_burst = true;
+                                        }
+                                    }
+                                    else
+                                        cp.addSpecialRow(">> Delaying FOF " + (next_early - readyAt).toFixed(2) +  "s across GCD...");
+                                }
+                            }
+                        }
+                    }
 
-					if (cp.canUseWithoutClipping(Actions.FightOrFlight) || force_next_burst)
-					{
+                    if (cp.canUseWithoutClipping(Actions.FightOrFlight) || force_next_burst)
+                    {
 
-						if (strategy_250 || strategy_minimise)
-						{
-							if (strategy_minimise)
-								cp.addSpecialRow(`>> Using FOF ASAP`);
-							cp.useOgcd(Actions.FightOrFlight);
-						}
-						else
-						{
-							// Should we try to late weave?
-							// DANGER DANGER: Magic number:
-							//let fof_is_not_early = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.relative > 1.0;
+                        if (strategy_250 || strategy_minimise)
+                        {
+                            if (strategy_minimise)
+                                cp.addSpecialRow(`>> Using FOF ASAP`);
+                            cp.useOgcd(Actions.FightOrFlight);
+                        }
+                        else
+                        {
+                            // Should we try to late weave?
+                            // DANGER DANGER: Magic number:
+                            //let fof_is_not_early = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.relative > 1.0;
 
-							// if we are on an even minute, and we're 98ing
-							if ((strategy_98_alt && even_minute) || strategy_always9)
-							{
+                            // if we are on an even minute, and we're 98ing
+                            if ((strategy_98_alt && even_minute) || strategy_always9)
+                            {
                                 const readyAt = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.absolute;
-								cp.addSpecialRow(`>> Late Weaving FOF!`);
-								// if force is on, we are here because we are clipping our GCD:
-								if (strategy_98_force)
-								{
-									if (!cp.canUseWithoutClipping(Actions.FightOrFlight))
-									{
-										const beforeGCD = cp.nextGcdTime;
-										cp.delayForOgcd(Actions.FightOrFlight);
+                                cp.addSpecialRow(`>> Late Weaving FOF!`);
+                                // if force is on, we are here because we are clipping our GCD:
+                                if (strategy_98_force)
+                                {
+                                    if (!cp.canUseWithoutClipping(Actions.FightOrFlight))
+                                    {
+                                        const beforeGCD = cp.nextGcdTime;
+                                        cp.delayForOgcd(Actions.FightOrFlight);
                                         const clip_amount = cp.nextGcdTime - beforeGCD;
-										cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
+                                        cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
                                         clip_total_time += clip_amount;
-									}
-									else
-									{
-										cp.useOgcdLateWeave(Actions.FightOrFlight);
-									}
+                                    }
+                                    else
+                                    {
+                                        cp.useOgcdLateWeave(Actions.FightOrFlight);
+                                    }
 
-								}
-								else
-								{
-									// a normal late weave is fine:
-									cp.useOgcdLateWeave(Actions.FightOrFlight);
-								}
+                                }
+                                else
+                                {
+                                    // a normal late weave is fine:
+                                    cp.useOgcdLateWeave(Actions.FightOrFlight);
+                                }
                                 if (fofs_used != 0)
                                     cp.addSpecialRow(`>> Delay to FOF: ` + (cp.currentTime - readyAt).toFixed(2) + "s");
-							}
-							else
-							{
-								cp.addSpecialRow(`Using FOF ASAP`);
-								cp.useOgcd(Actions.FightOrFlight);
-							}
-						}
+                            }
+                            else
+                            {
+                                cp.addSpecialRow(`Using FOF ASAP`);
+                                cp.useOgcd(Actions.FightOrFlight);
+                            }
+                        }
 
                         if (fofs_used == 0)
                             time_of_first_fof = cp.currentTime;
@@ -655,141 +649,141 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
                             time_of_last_fof = cp.currentTime;
 
 
-						let oGCDcounter = 0;
+                        let oGCDcounter = 0;
 
-						// TODO: Intervene will be available earlier than other other oGCDs after a certain point:
-						const ogcdOrder = [Actions.Imperator, Actions.CircleOfScorn, Actions.Expiacion,
-						Actions.Intervene,Actions.Intervene];
+                        // TODO: Intervene will be available earlier than other other oGCDs after a certain point:
+                        const ogcdOrder = [Actions.Imperator, Actions.CircleOfScorn, Actions.Expiacion,
+                        Actions.Intervene,Actions.Intervene];
 
-						/////////////////
-						// We have now entered burst: perform all burst actions:
+                        /////////////////
+                        // We have now entered burst: perform all burst actions:
 
-						// Sks Pattern Detection:
-						if (strategy_250 || strategy_hubris || cp.canUseWithoutClipping(Actions.Imperator))
-						{
-							// In this case, we definitely haven't late weaved
-							// Set counter to 1, as we will have already used our burst first oGCD
-							oGCDcounter = 1;
+                        // Sks Pattern Detection:
+                        if (strategy_250 || strategy_hubris || cp.canUseWithoutClipping(Actions.Imperator))
+                        {
+                            // In this case, we definitely haven't late weaved
+                            // Set counter to 1, as we will have already used our burst first oGCD
+                            oGCDcounter = 1;
 
-							if (strategy_hubris)
-							{
-								let is_gonna_clip = false;
-								const beforeGCD = cp.nextGcdTime;
-								// If we're specifically pretending SKS doesn't exist, delay for Req+
-								if (!cp.canUseWithoutClipping(Actions.Imperator))
-									is_gonna_clip = true;
+                            if (strategy_hubris)
+                            {
+                                let is_gonna_clip = false;
+                                const beforeGCD = cp.nextGcdTime;
+                                // If we're specifically pretending SKS doesn't exist, delay for Req+
+                                if (!cp.canUseWithoutClipping(Actions.Imperator))
+                                    is_gonna_clip = true;
 
-								cp.delayForOgcd(Actions.Imperator);
+                                cp.delayForOgcd(Actions.Imperator);
 
-								if (is_gonna_clip)
+                                if (is_gonna_clip)
                                 {
                                     const clip_amount = cp.nextGcdTime - beforeGCD;
-									cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
+                                    cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
                                     clip_total_time += clip_amount;
                                 }
-								
-							}
-							else
-							{
-								cp.useOgcd(Actions.Imperator);
-							}
-						}
-						else
-						{
-							// we could not use imperator before, so we must melee first GCD
-							// The easiest way to check this is simply, is oGCDcounter 1 or not?
-						}
+                                
+                            }
+                            else
+                            {
+                                cp.useOgcd(Actions.Imperator);
+                            }
+                        }
+                        else
+                        {
+                            // we could not use imperator before, so we must melee first GCD
+                            // The easiest way to check this is simply, is oGCDcounter 1 or not?
+                        }
 
-						// In this situation, we have given ourselves the req buff in the same
-						// weave window as FOF.
-						// This seems like a weird way to discern this but it makes it easier
-						// to steer the strategy_minimise pathway down here:
+                        // In this situation, we have given ourselves the req buff in the same
+                        // weave window as FOF.
+                        // This seems like a weird way to discern this but it makes it easier
+                        // to steer the strategy_minimise pathway down here:
 
-						if (oGCDcounter == 1)
-						{
-							// This burst is suggested to start blades early, to help avoid
-							// a situation where we lose BladeOfHonor due to phasing/death etc
-							cp.useGcd(Actions.Confiteor);
-							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useGcd(Actions.BladeOfFaith);
-                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useGcd(Actions.BladeOfTruth);
-                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useGcd(Actions.BladeOfValor);
-                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useOgcd(Actions.BladeOfHonor);
-							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-							cp.useGcd(Actions.GoringBlade);
-						}
-                		// In this situation, we have not yet been able to give ourselves
-                		// req stacks. We *may* have late weaved FOF:
-                		else
-                		{
-							cp.useGcd(Actions.GoringBlade);
-							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-							cp.useGcd(Actions.Confiteor);
-							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useGcd(Actions.BladeOfFaith);
-                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useGcd(Actions.BladeOfTruth);
-                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useGcd(Actions.BladeOfValor);
-                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
-                			cp.useOgcd(Actions.BladeOfHonor);
-                		}
+                        if (oGCDcounter == 1)
+                        {
+                            // This burst is suggested to start blades early, to help avoid
+                            // a situation where we lose BladeOfHonor due to phasing/death etc
+                            cp.useGcd(Actions.Confiteor);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.BladeOfFaith);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.BladeOfTruth);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.BladeOfValor);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useOgcd(Actions.BladeOfHonor);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.GoringBlade);
+                        }
+                        // In this situation, we have not yet been able to give ourselves
+                        // req stacks. We *may* have late weaved FOF:
+                        else
+                        {
+                            cp.useGcd(Actions.GoringBlade);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.Confiteor);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.BladeOfFaith);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.BladeOfTruth);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useGcd(Actions.BladeOfValor);
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                            cp.useOgcd(Actions.BladeOfHonor);
+                        }
 
-               			// How much longer is actually left on FOF?
-	
-						// Use any further ogcds, and burn down to when we only have time for
-						// 1 more GCD
-						let prioritise_melee = true;
-						if (strategy_always9 || (strategy_98_alt && even_minute))
-							prioritise_melee = true;
+                        // How much longer is actually left on FOF?
+    
+                        // Use any further ogcds, and burn down to when we only have time for
+                        // 1 more GCD
+                        let prioritise_melee = true;
+                        if (strategy_always9 || (strategy_98_alt && even_minute))
+                            prioritise_melee = true;
 
-						oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                        oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
 
-						let enough_time_if_melee = cp.fofIsActive((cp.nextGcdTime + physGCD));
-						let fof_remaining = cp.getFOFRemaining().toFixed(2);
+                        let enough_time_if_melee = cp.fofIsActive((cp.nextGcdTime + physGCD));
+                        let fof_remaining = cp.getFOFRemaining().toFixed(2);
 
-						while (enough_time_if_melee && safety < 100000)
-						{
-							safety++;
-							// Note the current status:
-							if (!strategy_250)
-								cp.addSpecialRow(`>> FOF: ${fof_remaining}s, phys prio`); 
-							// Use a burst GCD
-							cp.useBurstFiller(prioritise_melee && (!sim.settings.perform12312OldPrio));
-							// Use any remaining oGCDs:
-							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                        while (enough_time_if_melee && safety < 100000)
+                        {
+                            safety++;
+                            // Note the current status:
+                            if (!strategy_250)
+                                cp.addSpecialRow(`>> FOF: ${fof_remaining}s, phys prio`); 
+                            // Use a burst GCD
+                            cp.useBurstFiller(prioritise_melee && (!sim.settings.perform12312OldPrio));
+                            // Use any remaining oGCDs:
+                            oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
 
-							// Update our variables:
-							enough_time_if_melee = cp.fofIsActive((cp.nextGcdTime + physGCD));
-							fof_remaining = cp.getFOFRemaining().toFixed(3);
-						}
+                            // Update our variables:
+                            enough_time_if_melee = cp.fofIsActive((cp.nextGcdTime + physGCD));
+                            fof_remaining = cp.getFOFRemaining().toFixed(3);
+                        }
 
-						if (!strategy_250)
-							cp.addSpecialRow(`>> Final burst GCD margin: ${fof_remaining}s:`);
+                        if (!strategy_250)
+                            cp.addSpecialRow(`>> Final burst GCD margin: ${fof_remaining}s:`);
                         else
                             cp.addSpecialRow(`>> Final burst GCD:`);
-						cp.useBurstFiller(false);
+                        cp.useBurstFiller(false);
 
                         only_cos_once_in_filler = true;
                         only_exp_once_in_filler = true;
 
-						// Our buffs have expired, burst is complete:
-                		// Flip even minute state:
-                		even_minute = !even_minute;
-                		force_next_burst = false;
+                        // Our buffs have expired, burst is complete:
+                        // Flip even minute state:
+                        even_minute = !even_minute;
+                        force_next_burst = false;
 
-                		if (strategy_98_alt)
-                		{
-	                		if (even_minute)
-	                			cp.addSpecialRow(`>> 9/8 Even min: Hold Atonement`);
-	                		else
-	                			cp.addSpecialRow(`>> 9/8 Odd min: Spend Atonement`);
-	                	}
-					}
-					
+                        if (strategy_98_alt)
+                        {
+                            if (even_minute)
+                                cp.addSpecialRow(`>> 9/8 Even min: Hold Atonement`);
+                            else
+                                cp.addSpecialRow(`>> 9/8 Odd min: Spend Atonement`);
+                        }
+                    }
+                    
                     // If there are fewer than 20 seconds remaining in the user selected
                     // time window:
                     if (cp.remainingTime < 20 && !end_of_time_burn && !sim.settings.disableBurnDown)
@@ -800,7 +794,7 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
                         end_of_time_burn = true;
                     }
 
-					// This is the bit where we just use filler:
+                    // This is the bit where we just use filler:
                     if (end_of_time_burn)
                     {
                         // we also replace 1s with hardcasts under 3 phys GCDs, preventing a new combo starting
@@ -811,29 +805,29 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 
                     // There are some circumstances where eg 2.47 will have these come off of
                     // cd when messing with FOF. Let's only use them once between bursts.
-	                // Also: technically someone playing with hubris would clip these, too:
-					if (cp.canUseWithoutClipping(Actions.CircleOfScorn) && only_cos_once_in_filler)
-			    	{
-		    			cp.useOgcd(Actions.CircleOfScorn);
+                    // Also: technically someone playing with hubris would clip these, too:
+                    if (cp.canUseWithoutClipping(Actions.CircleOfScorn) && only_cos_once_in_filler)
+                    {
+                        cp.useOgcd(Actions.CircleOfScorn);
                         only_cos_once_in_filler = false;
-		    			if (strategy_hubris)
-		    			{
-							const beforeGCD = cp.nextGcdTime;
-		    				cp.delayForOgcd(Actions.Expiacion);
-		    				if ((cp.nextGcdTime - beforeGCD) > 0)
+                        if (strategy_hubris)
+                        {
+                            const beforeGCD = cp.nextGcdTime;
+                            cp.delayForOgcd(Actions.Expiacion);
+                            if ((cp.nextGcdTime - beforeGCD) > 0)
                             {
                                 const clip_amount = cp.nextGcdTime - beforeGCD;
-		    					cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
+                                cp.addSpecialRow("! ALERT ! Clipped GCD! " + (clip_amount).toFixed(2) + "s");
                                 clip_total_time += clip_amount;
                             }
                             only_exp_once_in_filler = false;
-		    			}
-		    		}
-					if (cp.canUseWithoutClipping(Actions.Expiacion) && only_exp_once_in_filler)
-			    	{
-		    			cp.useOgcd(Actions.Expiacion);
+                        }
+                    }
+                    if (cp.canUseWithoutClipping(Actions.Expiacion) && only_exp_once_in_filler)
+                    {
+                        cp.useOgcd(Actions.Expiacion);
                         only_exp_once_in_filler = false;
-		    		}
+                    }
                 }
 
                 const fof_delta = (time_of_last_fof - time_of_first_fof) - ((fofs_used - 1) * 60);

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -321,7 +321,7 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
         const sim = this;
 
         //nb I stole most of this from the RPR sim
-        
+
         return [{
         	// Technically our lowest common cycle time for strategies that we would actually cycle
         	// are like 14 minutes, lol:
@@ -458,7 +458,7 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 				// and juse use things as early as possible after the '3rd' GCD
 
             	// Standard opener:
-				cp.useGcd(Actions.HolySpiritHardcast);
+				//cp.useGcd(Actions.HolySpiritHardcast);
 				cp.useGcd(Actions.FastBlade);
 				cp.useGcd(Actions.RiotBlade);
 				cp.useGcd(Actions.RoyalAuthority);
@@ -692,7 +692,7 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 					
 
 					// This is the bit where we just use filler:
-	                cp.useFiller(even_minute);
+	                cp.useFiller((even_minute && strategy_98_alt) || strategy_always9);
 
 	                // Technically someone playing with hubris would clip these, too:
 					if (cp.canUseWithoutClipping(Actions.CircleOfScorn))
@@ -702,7 +702,8 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 		    			{
 							let beforeGCD = cp.nextGcdTime;
 		    				cp.delayForOgcd(Actions.Expiacion);
-		    				cp.addSpecialRow("!ALERT! Clipped GCD! " + (cp.nextGcdTime - beforeGCD).toFixed(2) + "s");
+		    				if ((cp.nextGcdTime - beforeGCD) > 0)
+		    					cp.addSpecialRow("!ALERT! Clipped GCD! " + (cp.nextGcdTime - beforeGCD).toFixed(2) + "s");
 		    			}
 		    		}
 					if (cp.canUseWithoutClipping(Actions.Expiacion))

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -319,18 +319,14 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
 
 	getRotationsToSimulate(): Rotation[] {
         const sim = this;
-        //console.log ( sim.set )
 
-        // Let's continue the time honoured tradition of making a paladin loop
-
-        //this.rotationState = new RotationState();
+        //nb I stole most of this from the RPR sim
+        
         return [{
-            cycleTime: 120,
+        	// Technically our lowest common cycle time for strategies that we would actually cycle
+        	// are like 14 minutes, lol:
+            cycleTime: 60 * 14,
 
-            /* I just used the cycle processor instead of doing any cycles, as doing so
-             * would require me to duplicate all of the 'useX(cp)' functions for CycleContext
-             * Is there a better way to do this?
-            */
 
             apply(cp: PldSKSCycleProcessor) {
 

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -1,0 +1,722 @@
+import {Ability, GcdAbility, OgcdAbility, Buff, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
+import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, 
+		AbilityUseResult, Rotation, AbilityUseRecordUnf, BuffUsage} from "@xivgear/core/sims/cycle_sim";
+import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
+import {STANDARD_ANIMATION_LOCK} from "@xivgear/xivmath/xivconstants";
+import {BaseMultiCycleSim} from "../../sim_processors";
+import {AbilitiesUsedTable} from "../../components/ability_used_table";
+import {CharacterGearSet} from "@xivgear/core/gear";
+import {ComputedSetStats} from "@xivgear/xivmath/geartypes";
+import * as Actions from './pld_actions';
+import * as Buffs from './pld_buffs';
+import {
+    FieldBoundCheckBox,
+    FieldBoundFloatField,
+    labeledCheckbox, labelFor,
+    positiveValuesOnly, quickElement
+} from "@xivgear/common-ui/components/util";
+
+
+
+class PaladinStateSystem {
+	// This simple class accepts the GCD that we performed
+	// and updates the state of our filler
+	A1Ready: number = 0b0001;
+	A2Ready: number = 0b0010;
+	A3Ready: number = 0b0100;
+
+	combo_state: number = 1;
+	sword_oath: number = 0;
+	divine_might: boolean = false;
+
+	perform_action(GCDused: GcdAbility)
+	{
+		if (GCDused == Actions.FastBlade)
+		{
+			this.combo_state = 2;
+		}
+		else if (GCDused == Actions.RiotBlade)
+		{
+			if (this.combo_state == 2)
+				this.combo_state = 3;
+			else
+				this.combo_state = 0;
+		}
+		else if (GCDused == Actions.RoyalAuthority)
+		{
+			if (this.combo_state == 3)
+			{
+				this.combo_state = 1;
+				this.divine_might = true;
+				this.sword_oath = this.sword_oath | this.A1Ready
+			}
+			else
+				this.combo_state = 0;
+		}
+		else if (GCDused == Actions.HolySpirit)
+		{
+			// Consume Divine Might:
+			this.divine_might = false;
+		}
+		else if (GCDused == Actions.Atonement)
+		{
+			if (this.sword_oath & this.A1Ready)
+			{
+				// Remove AtonementReady, Add Supplication Ready
+				this.sword_oath = (this.sword_oath & ~this.A1Ready) | this.A2Ready;
+			}
+		}
+		else if (GCDused == Actions.Supplication)
+		{
+			if (this.sword_oath & this.A2Ready)
+			{
+				// Remove Supplication Ready, Add Sepulchre Ready
+				this.sword_oath = (this.sword_oath & ~this.A2Ready) | this.A3Ready;
+			}
+		}
+		else if (GCDused == Actions.Sepulchre)
+		{
+			if (this.sword_oath & this.A3Ready)
+			{
+				// Remove Sepulchre
+				this.sword_oath = (this.sword_oath & (~this.A3Ready));
+			}
+		}
+	}
+
+	
+	debugState() {
+		console.log( [ this.combo_state , this.sword_oath , this.divine_might ].toString() );
+	}
+}
+
+export interface PldSKSSheetSimResult extends CycleSimResult {
+}
+
+export interface PldSKSSheetSettings extends SimSettings {
+	acknowledgeSKS: boolean,
+	attempt9GCDAbove247: boolean,
+	alwaysLateWeave: boolean,
+}
+
+export interface PldSKSSheetSettingsExternal extends ExternalCycleSettings<PldSKSSheetSettings> {
+
+}
+
+export const pldSKSSheetSpec: SimSpec<PldSKSSheetSim, PldSKSSheetSettingsExternal> = {
+    stub: "pldsks-sheet-sim",
+    displayName: "PLD SKS Sim",
+    loadSavedSimInstance: function (exported: PldSKSSheetSettingsExternal) {
+        return new PldSKSSheetSim(exported);
+    },
+    makeNewSimInstance: function (): PldSKSSheetSim {
+        return new PldSKSSheetSim();
+    },
+    supportedJobs: ['PLD'],
+    supportedLevels: [100],
+    description: "Paladin Fixed Time Window Simulator w/SKS",
+    isDefaultSim: true
+};
+
+class PldSKSCycleProcessor extends CycleProcessor {
+	MyState: PaladinStateSystem;
+	MySettings: PldSKSSheetSettings;
+
+	teeny_tiny_safety_margin: number = 0.001
+	// stats: ComputedSetStats;
+
+    constructor(settings: MultiCycleSettings) {
+        super(settings);
+        // More settings interpretation stuff goes here
+        this.MyState = new PaladinStateSystem();
+        // this.stats = settings.stats;
+    }
+
+    fofIsActive(atTime: number): boolean {
+    	let fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
+    	if (fofData == null)
+    		return false;
+
+    	if (fofData.end > atTime)
+    		return true;
+    	else
+    		return false;
+    }
+
+    getFOFRemaining(): number {
+    	let fofData = this.getActiveBuffData(Buffs.FightOrFlightBuff);
+    	if (fofData == null)
+    		return 0;
+    	return fofData.end - this.nextGcdTime;
+    }
+
+    useOgcdInOrder(order: OgcdAbility[], idx: number): number {
+    	if (idx < order.length) {
+    		if (this.canUseWithoutClipping(order[idx]))
+    		{
+    			this.useOgcd(order[idx]);
+    			idx++;
+    		}
+    	}
+    	if (idx < order.length) {
+			if (this.canUseWithoutClipping(order[idx]))
+    		{
+    			this.useOgcd(order[idx]);
+    			idx++;
+    		}
+    	}
+    	return idx;
+    }
+
+    useFiller(even_minute: boolean) {
+    	// During regular filler, we will always use a specific GCD based on our state
+    	let chosen_ability = Actions.FastBlade;
+
+    	// if we are atonement ready, become supplication ready:
+    	// This top If statement is what optimises us for 3 GCDs in FOF
+    	// When we have SKS and expect a 9 GCD FOF, we will skip this aspect
+    	// The parameter, even_minute, will be true when we are approaching an even minute burst
+
+    	if (this.MyState.sword_oath == this.MyState.A1Ready && even_minute == false)
+    	{
+    		chosen_ability = Actions.Atonement;
+    	}
+    	else if (this.MyState.combo_state != 3)
+    	{
+    		if (this.MyState.combo_state == 2)
+    			chosen_ability = Actions.RiotBlade;
+    		else
+    			chosen_ability = Actions.FastBlade;
+    	}
+    	else
+    	{
+    		// If we are royal ready:
+			if (this.MyState.sword_oath == this.MyState.A1Ready)
+    			chosen_ability = Actions.Atonement;
+    		else if (this.MyState.sword_oath == this.MyState.A2Ready)
+    			chosen_ability = Actions.Supplication;
+    		else if (this.MyState.divine_might == true)
+    			chosen_ability = Actions.HolySpirit;
+    		else if (this.MyState.sword_oath == this.MyState.A3Ready)
+    			chosen_ability = Actions.Sepulchre;
+    		else if (this.MyState.sword_oath == 0 && this.MyState.divine_might == false)
+    			chosen_ability = Actions.RoyalAuthority;
+    	}
+
+		this.useGcd(chosen_ability);
+    }
+
+    useBurstFiller(prioritise_melee: boolean) {
+		let chosen_ability = Actions.FastBlade;
+
+		
+		// We always Sepulcre if we have it:
+		if (this.MyState.sword_oath == this.MyState.A3Ready)
+			chosen_ability = Actions.Sepulchre;
+
+		// prioritise_melee blocks this check:
+		else if (this.MyState.divine_might == true && !prioritise_melee)
+			chosen_ability = Actions.HolySpirit;
+		else if (this.MyState.sword_oath == this.MyState.A1Ready)
+			chosen_ability = Actions.Atonement;
+		else if (this.MyState.sword_oath == this.MyState.A2Ready)
+			chosen_ability = Actions.Supplication;
+		// When we prioritise_melee, only use HS if it is our last option
+		else if (this.MyState.divine_might == true)
+			chosen_ability = Actions.HolySpirit;
+		else if (this.MyState.sword_oath == 0 && this.MyState.divine_might == false)
+		{
+			if (this.MyState.combo_state == 3)
+				chosen_ability = Actions.RoyalAuthority;
+			else if (this.MyState.combo_state == 2)
+				chosen_ability = Actions.RiotBlade;
+		}
+
+    	this.useGcd(chosen_ability);
+    }
+
+    useOgcdLateWeave(ability: OgcdAbility): AbilityUseResult {
+    	this.advanceTo(this.nextGcdTime - (STANDARD_ANIMATION_LOCK) - this.teeny_tiny_safety_margin);
+    	return this.useOgcd(ability);
+    }
+
+	override useGcd(ability: GcdAbility): AbilityUseResult {
+        // Automatically update our state when we use a GCD:
+        this.MyState.perform_action(ability);
+        //this.MyState.debugState();
+        return super.useGcd(ability);
+    }
+
+    // Stolen from Ninja sim
+    // Effectively just delays us to the time we can actually use our oGCD at the earliest in the window
+	override useOgcd(ability: OgcdAbility): AbilityUseResult {
+        // If an Ogcd isn't ready yet, but it can still be used without clipping, advance time until ready.
+        if (this.canUseWithoutClipping(ability)) {
+            const readyAt = this.cdTracker.statusOf(ability).readyAt.absolute;
+            if (this.totalTime > readyAt) {
+                this.advanceTo(readyAt);
+            }
+        }
+        // Only try to use the Ogcd if it's ready.
+        return this.cdTracker.canUse(ability) ? super.useOgcd(ability) : null;
+    }
+
+    delayForOgcd(ability: OgcdAbility) : AbilityUseResult {
+    	// Here we insist upon using it:
+    	const readyAt = this.cdTracker.statusOf(ability).readyAt.absolute;
+        if (this.totalTime > readyAt) {
+            this.advanceTo(readyAt);
+        }
+
+        return super.useOgcd(ability);
+    }
+};
+
+export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldSKSSheetSettings, PldSKSCycleProcessor> {
+
+    makeDefaultSettings(): PldSKSSheetSettings {
+        return {
+        	acknowledgeSKS: true,
+        	attempt9GCDAbove247: false,
+        	alwaysLateWeave: false
+        };
+    };
+
+	spec = pldSKSSheetSpec;
+	shortName = "pld-sheet-sim";
+	displayName = pldSKSSheetSpec.displayName;
+
+	constructor(settings?: PldSKSSheetSettingsExternal) {
+        super('PLD', settings);
+
+    }
+
+
+	override makeCustomConfigInterface(settings: PldSKSSheetSettings): HTMLElement {
+
+        const outerDiv = document.createElement("div");
+        const checkboxesDiv = document.createElement("div");
+
+        const sksCheck = new FieldBoundCheckBox<PldSKSSheetSettings>(settings, 'acknowledgeSKS', {id: 'sks-checkbox'});
+        checkboxesDiv.appendChild(labeledCheckbox('Acknowledge Skill Speed', sksCheck));
+        const tryCheck = new FieldBoundCheckBox<PldSKSSheetSettings>(settings, 'attempt9GCDAbove247', {id: 'try-checkbox'});
+        checkboxesDiv.appendChild(labeledCheckbox('Force trying for 9/8 at 2.47+', tryCheck));
+        const lateCheck = new FieldBoundCheckBox<PldSKSSheetSettings>(settings, 'alwaysLateWeave', {id: 'late-checkbox'});
+        checkboxesDiv.appendChild(labeledCheckbox('Force always Late FOF at 2.43+', lateCheck));
+
+        outerDiv.appendChild(checkboxesDiv);
+
+        return outerDiv;
+    }
+
+
+    protected createCycleProcessor(settings: MultiCycleSettings): PldSKSCycleProcessor {
+        return new PldSKSCycleProcessor({
+            ...settings,
+            hideCycleDividers: true
+        });
+    }
+
+	getRotationsToSimulate(): Rotation[] {
+        const sim = this;
+        //console.log ( sim.set )
+
+        // Let's continue the time honoured tradition of making a paladin loop
+
+        //this.rotationState = new RotationState();
+        return [{
+            cycleTime: 120,
+
+            /* I just used the cycle processor instead of doing any cycles, as doing so
+             * would require me to duplicate all of the 'useX(cp)' functions for CycleContext
+             * Is there a better way to do this?
+            */
+
+            apply(cp: PldSKSCycleProcessor) {
+
+            	let physGCD = cp.stats.gcdPhys(2.5);
+            	let magicGCD = cp.stats.gcdMag(2.5);
+
+            	let strategy_250 = false;
+            	let strategy_98_alt = false;
+            	let strategy_98_force = false;
+            	let strategy_always9 = false;
+            	let strategy_minimise = false;
+            	let strategy_hubris = (sim.settings.acknowledgeSKS == false);
+
+            	// Let's assume that we are going to do a fixed time window
+            	// optimisation, so, let's have an actual opener
+
+            	// A fixed time window is favourable to the perception of SKS
+            	// as even minimal delays to burst on an *infinite* dummy translate
+            	// to DPS losses that kinda do not exist in situations where you never
+            	// actually lose a usage: over *infinte* time, even a 0.1s delay
+            	// means you *eventually* lose a usage.
+
+				cp.addSpecialRow(`Phys GCD is: ${physGCD}`);
+            	cp.addSpecialRow(`Magic GCD is: ${magicGCD}`);
+
+				// However, if we are going to pretend SKS does not exist
+				// (or, SKS does in fact not exist), we don't need this:
+				if (physGCD > 2.49)
+				{
+					cp.addSpecialRow(`No SKS to consider due to 2.5 GCD`);
+					strategy_250 = true;
+				}
+				else if (strategy_hubris)
+				{
+					cp.addSpecialRow(`SKS Acknowledgement is disabled.`);
+					cp.addSpecialRow(`Sim will DELIBERATELY CLIP GCD`);
+					strategy_250 = true;
+				}
+				// We then have a variety of things to consider.
+				// at 2.47 and above, PLD is unlikely to achieve a 9 GCD FOF
+				// So we don't try, and instead aim to minimise buff drift
+				else if (physGCD > 2.46) 
+				{
+					// However we have setting over rides to force our hand:
+					if (sim.settings.attempt9GCDAbove247 == true)
+					{
+						cp.addSpecialRow(`Late FOF w/2.47+ GCD (Override)`);
+						strategy_98_alt = true;
+					}
+					else if (sim.settings.alwaysLateWeave == true)
+					{
+						cp.addSpecialRow(`Late FOF w/2.43+ GCD (Override)`);
+						strategy_always9 = true;
+					}
+					else
+					{
+						cp.addSpecialRow(`2.47+ GCD, aim to minimise drift`);
+						strategy_minimise = true;
+					}
+				}
+				// At 2.43 to 2.46, it should be possible to alternate a 9 GCD and an 8 GCD
+				// FOF to minimise drift, and just get a little extra from party buffs
+				// It's so, so little though, lol.
+				else if (physGCD > 2.42)
+				{
+					// 2.43 specifically is cursed:
+					if (physGCD < 2.44)
+					{
+						cp.addSpecialRow(`2.43 Phys GCD is particularly challenging.`);
+						cp.addSpecialRow(`It either delays fof significantly`);
+						cp.addSpecialRow(`or risks clipping it's GCD to do 9/8`);
+
+						if (sim.settings.alwaysLateWeave)
+						{
+							strategy_always9 = true;
+							cp.addSpecialRow(`Late FOF w/2.43 GCD (Override)`);
+						}
+						else
+						{
+							strategy_98_alt = true;
+							strategy_98_force = true;
+							cp.addSpecialRow(`Presenting CLIP GCD strat`);
+							cp.addSpecialRow(`(consider always late weave option)`);
+						}
+					}
+					else
+					{
+						// If we're 2.44 - 2.46
+						if (sim.settings.alwaysLateWeave == true)
+						{
+							cp.addSpecialRow(`Late FOF w/2.43+ GCD (Override)`);
+							strategy_always9 = true;
+						}
+						else
+						{
+							cp.addSpecialRow(`2.44-2.46 GCD, alternating 9/8 FOFs`);
+							strategy_98_alt = true;
+						}
+					}
+				}
+				// Otherwise, if our GCD is 2.37 - 2.42 We will always late weave FOF:
+				else if (physGCD > 2.36)
+				{
+					cp.addSpecialRow(`Always Late FOF at 2.37+ GCD`);
+					strategy_always9 = true;
+				}
+				// Below that, things get weird, so let's just rely on the sim's override options:
+				else
+				{
+					cp.addSpecialRow(`Phys GCD very low! Use Overrides to trial behavior:`);
+					if (sim.settings.attempt9GCDAbove247 == true)
+					{
+						cp.addSpecialRow(`9/8 Override, will late weave evens`);
+						strategy_98_alt = true;
+					}
+					else if (sim.settings.alwaysLateWeave == true)
+					{
+						cp.addSpecialRow(`Always late override, Late FOFs`);
+						strategy_always9 = true;
+					}
+					else
+					{
+						cp.addSpecialRow(`No Overrides, Minimizing Drift`);
+						strategy_minimise = true;
+					}
+				}
+
+				// We will not set our loop up to attempt a special first burst
+				// and juse use things as early as possible after the '3rd' GCD
+
+            	// Standard opener:
+				cp.useGcd(Actions.HolySpiritHardcast);
+				cp.useGcd(Actions.FastBlade);
+				cp.useGcd(Actions.RiotBlade);
+				cp.useGcd(Actions.RoyalAuthority);
+
+				let safety = 0;
+				let even_minute = true;
+				let force_next_burst = false;
+				while ((cp.remainingGcdTime > 0) && (safety < 100000) ) {
+					// While loops with no safety clause!
+					safety++;
+
+					//console.log( [ cp.nextGcdTime - cp.currentTime , cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.relative , cp.canUseWithoutClipping(Actions.FightOrFlight) ].toString() );
+
+					if (strategy_minimise || strategy_98_alt || strategy_hubris)
+					{
+						// if we are forcing 9/8s, we can't rely on canUseWithoutClipping
+						// this is because: we will clip, lol.
+						// We also want to provide feedback on if we delayed FOF across a GCD
+						
+				        let readyAt = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.absolute;
+				        let next_early = cp.nextGcdTime + STANDARD_ANIMATION_LOCK;
+				        // note that this is the going to delay up to the earliest weave after the next GCD:
+				    	if (readyAt > cp.currentTime && readyAt < ( next_early ))
+				    	{
+				    		// If this is going to collide with the next GCD, we want to know about it
+
+				    		// If we are forcing 98s and this is an even minute, we will get our awareness
+				    		// elsewhere:
+				    		if ((strategy_98_force && even_minute))
+				    			force_next_burst = true;
+				    		else
+				    		{
+				    			let is_after_late_weave_limit = (readyAt > (cp.nextGcdTime - STANDARD_ANIMATION_LOCK));
+				    			let is_after_next_gcd = readyAt > cp.nextGcdTime;
+				    			// Otherwise, add to the log what we are doing:
+								if (is_after_late_weave_limit)
+								{
+									if (strategy_hubris)
+									{
+										cp.addSpecialRow("FOF comes up in " + (readyAt - cp.currentTime).toFixed(2));
+										if (is_after_next_gcd)
+										{
+											cp.addSpecialRow("This is after the next GCD.");
+											cp.addSpecialRow("A Lazy player likely uses the GCD");
+											cp.addSpecialRow("Delaying FOF by " + (next_early - readyAt).toFixed(2));
+										}
+										else
+										{
+											cp.addSpecialRow("Delaying until available!");
+											cp.advanceTo(readyAt);
+											force_next_burst = true;
+										}
+									}
+									else
+					    				cp.addSpecialRow("Delaying FOF " + (next_early - readyAt).toFixed(2) +  " across GCD...");
+								}
+					    	}
+				    	}
+					}
+
+					if (cp.canUseWithoutClipping(Actions.FightOrFlight) || force_next_burst)
+					{
+						if (strategy_250 || strategy_minimise)
+						{
+							if (strategy_minimise)
+								cp.addSpecialRow(`Using FOF ASAP`);
+							cp.useOgcd(Actions.FightOrFlight);
+						}
+						else
+						{
+							// Should we try to late weave?
+							// DANGER DANGER: Magic number:
+							//let fof_is_not_early = cp.cdTracker.statusOf(Actions.FightOrFlight).readyAt.relative > 1.0;
+
+							// if we are on an even minute, and we're 98ing
+							if ((strategy_98_alt && even_minute) || strategy_always9)
+							{
+								cp.addSpecialRow(`Late Weaving FOF!`);
+								// if force is on, we are here because we are clipping our GCD:
+								if (strategy_98_force)
+								{
+									if (!cp.canUseWithoutClipping(Actions.FightOrFlight))
+									{
+										let beforeGCD = cp.nextGcdTime;
+										cp.delayForOgcd(Actions.FightOrFlight);
+										cp.addSpecialRow("!ALERT! Clipped GCD! " + (cp.nextGcdTime - beforeGCD).toFixed(2) + "s");
+									}
+									else
+									{
+										cp.useOgcdLateWeave(Actions.FightOrFlight);
+									}
+
+								}
+								else
+								{
+									// a normal late weave is fine:
+									cp.useOgcdLateWeave(Actions.FightOrFlight);
+								}
+							}
+							else
+							{
+								cp.addSpecialRow(`Using FOF ASAP`);
+								cp.useOgcd(Actions.FightOrFlight);
+							}
+						}
+
+						let oGCDcounter = 0;
+
+						// TODO: Intervene will be available earlier than other other oGCDs after a certain point:
+						const ogcdOrder = [Actions.Imperator, Actions.CircleOfScorn, Actions.Expiacion,
+						Actions.Intervene,Actions.Intervene];
+
+						/////////////////
+						// We have now entered burst: perform all burst actions:
+
+						// Sks Pattern Detection:
+						if (strategy_250 || strategy_hubris || cp.canUseWithoutClipping(Actions.Imperator))
+						{
+							// In this case, we definitely haven't late weaved
+							// Set counter to 1, as we will have already used our burst first oGCD
+							oGCDcounter = 1;
+
+							if (strategy_hubris)
+							{
+								let is_gonna_clip = false;
+								let beforeGCD = cp.nextGcdTime;
+								// If we're specifically pretending SKS doesn't exist, delay for Req+
+								if (!cp.canUseWithoutClipping(Actions.Imperator))
+									is_gonna_clip = true;
+
+								cp.delayForOgcd(Actions.Imperator);
+
+								if (is_gonna_clip)
+									cp.addSpecialRow("!ALERT! Clipped GCD! " + (cp.nextGcdTime - beforeGCD).toFixed(2) + "s");
+								
+							}
+							else
+							{
+								cp.useOgcd(Actions.Imperator);
+							}
+						}
+						else
+						{
+							// we could not use imperator before, so we must melee first GCD
+							// The easiest way to check this is simply, is oGCDcounter 1 or not?
+						}
+
+						// In this situation, we have given ourselves the req buff in the same
+						// weave window as FOF.
+						// This seems like a weird way to discern this but it makes it easier
+						// to steer the strategy_minimise pathway down here:
+
+						if (oGCDcounter == 1)
+						{
+							// This burst is suggested to start blades early, to help avoid
+							// a situation where we lose BladeOfHonor due to phasing/death etc
+							cp.useGcd(Actions.Confiteor);
+							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useGcd(Actions.BladeOfFaith);
+                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useGcd(Actions.BladeOfTruth);
+                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useGcd(Actions.BladeOfValor);
+                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useOgcd(Actions.BladeOfHonor);
+							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+							cp.useGcd(Actions.GoringBlade);
+						}
+                		// In this situation, we have not yet been able to give ourselves
+                		// req stacks. We *may* have late weaved FOF:
+                		else
+                		{
+							cp.useGcd(Actions.GoringBlade);
+							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+							cp.useGcd(Actions.Confiteor);
+							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useGcd(Actions.BladeOfFaith);
+                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useGcd(Actions.BladeOfTruth);
+                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useGcd(Actions.BladeOfValor);
+                			oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+                			cp.useOgcd(Actions.BladeOfHonor);
+                		}
+
+               			// How much longer is actually left on FOF?
+	
+						// Use any further ogcds, and burn down to when we only have time for
+						// 1 more GCD
+						let prioritise_melee = true;
+						if (strategy_always9 || (strategy_98_alt && even_minute))
+							prioritise_melee = true;
+
+						oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+
+						let enough_time_if_melee = cp.fofIsActive((cp.nextGcdTime + physGCD));
+						let fof_remaining = cp.getFOFRemaining().toFixed(2);
+
+						while (enough_time_if_melee && safety < 100000)
+						{
+							safety++;
+							// Note the current status:
+							cp.addSpecialRow(`FOF: ${fof_remaining}, melee+1? ${enough_time_if_melee}`); 
+							// Use a burst GCD
+							cp.useBurstFiller(prioritise_melee);
+							// Use any remaining oGCDs:
+							oGCDcounter = cp.useOgcdInOrder(ogcdOrder, oGCDcounter);
+
+							// Update our variables:
+							enough_time_if_melee = cp.fofIsActive((cp.nextGcdTime + physGCD));
+							fof_remaining = cp.getFOFRemaining().toFixed(2);
+						}
+
+						cp.addSpecialRow(`FOF: ${fof_remaining}, melee+1? ${enough_time_if_melee}`);
+						cp.addSpecialRow(`Final burst GCD:`);
+						cp.useBurstFiller(false);
+
+						// Our buffs have expired, burst is complete:
+                		// Flip even minute state:
+                		even_minute = !even_minute;
+                		force_next_burst = false;
+
+                		if (strategy_98_alt)
+                		{
+	                		if (even_minute)
+	                			cp.addSpecialRow(`9/8 Now: Hold Atonement`);
+	                		else
+	                			cp.addSpecialRow(`9/8 Now: Spend Atonement`);
+	                	}
+					}
+					
+
+					// This is the bit where we just use filler:
+	                cp.useFiller(even_minute);
+
+	                // Technically someone playing with hubris would clip these, too:
+					if (cp.canUseWithoutClipping(Actions.CircleOfScorn))
+			    	{
+		    			cp.useOgcd(Actions.CircleOfScorn);
+		    			if (strategy_hubris)
+		    			{
+							let beforeGCD = cp.nextGcdTime;
+		    				cp.delayForOgcd(Actions.Expiacion);
+		    				cp.addSpecialRow("!ALERT! Clipped GCD! " + (cp.nextGcdTime - beforeGCD).toFixed(2) + "s");
+		    			}
+		    		}
+					if (cp.canUseWithoutClipping(Actions.Expiacion))
+			    	{
+		    			cp.useOgcd(Actions.Expiacion);
+		    		}
+                }
+            }
+
+        }]
+    }
+
+}

--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -106,7 +106,7 @@ export interface PldSKSSheetSettingsExternal extends ExternalCycleSettings<PldSK
 
 export const pldSKSSheetSpec: SimSpec<PldSKSSheetSim, PldSKSSheetSettingsExternal> = {
     stub: "pldsks-sheet-sim",
-    displayName: "PLD SKS Sim",
+    displayName: "PLD Skill Speed Sim",
     loadSavedSimInstance: function (exported: PldSKSSheetSettingsExternal) {
         return new PldSKSSheetSim(exported);
     },


### PR DESCRIPTION
Hello, I have made a paladin simulator that aims to demonstrate the limited but attainable benefits of skill speed via effectively executing a variety of strategies.

I've marked it as a non default sim for PLD as this a) isn't an infinite dummy model, and b) PLD is going to be a 2.50 GCD job as soon as it can be - as such, Nikroulah's PLD cycle sim is a much better tool to select a BIS gearset. However, it's still quite easy to add this one, if desired, and ensures that people see its copious description. It is intended more of a playground to test the impact of non-optimal behaviors, as well as demonstrate possible approaches to situations outside of the norm - showing the impact of mistakes as much as it aims to show any benefits.

It is not abnormal to find the Skill Speed stat on ones gear, especially early in tiers or during prog. Without a simulator like this, it can be very difficult to gauge between 2 close in ilvl items, where the higher one has sks - it may be desirable to a Paladin for it's other stats, or, it may be more trouble that it is worth to them. Being able to get a feel for it's benefit, while also taking into consideration the methods they might use to engage with the substat (including to pretend it does not exist) seems quite pragmatic to me.
