### PR TITLE
Improve multi-rotation support

### DIFF
--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -41,6 +41,7 @@ import {SHARED_SET_NAME} from "@xivgear/core/imports/imports";
 import {SimCurrentResult, SimResult, Simulation} from "./sims/sim_types";
 import {getDefaultSims, getRegisteredSimSpecs, getSimSpecByStub} from "./sims/sim_registry";
 import {getNextSheetInternalName} from "./persistence/saved_sheets";
+import {makeResolver} from "ts-loader/dist/resolver";
 
 export type SheetCtorArgs = ConstructorParameters<typeof GearPlanSheet>
 export type SheetContstructor<SheetType extends GearPlanSheet> = (...values: SheetCtorArgs) => SheetType;
@@ -524,7 +525,11 @@ export class GearPlanSheet {
     // TODO: this needs to only update when we have updated that specific gear set, not any random gear set.
     // If this gear set was not updated, then a cached result should be returned.
     getSimResult(simulation: Simulation<any, any, any>, set: CharacterGearSet): SimCurrentResult<SimResult> {
-        const simPromise = simulation.simulate(set);
+        const simPromise = (async () => {
+            // Intentionally de-prioritize this over other tasks so that it doesn't slow down an initial sheet load.
+            await new Promise(resolve => setTimeout(resolve, 0));
+            return await simulation.simulate(set);
+        })();
         const out: SimCurrentResult<any> = {
             result: undefined,
             resultPromise: undefined,

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -41,7 +41,6 @@ import {SHARED_SET_NAME} from "@xivgear/core/imports/imports";
 import {SimCurrentResult, SimResult, Simulation} from "./sims/sim_types";
 import {getDefaultSims, getRegisteredSimSpecs, getSimSpecByStub} from "./sims/sim_registry";
 import {getNextSheetInternalName} from "./persistence/saved_sheets";
-import {makeResolver} from "ts-loader/dist/resolver";
 
 export type SheetCtorArgs = ConstructorParameters<typeof GearPlanSheet>
 export type SheetContstructor<SheetType extends GearPlanSheet> = (...values: SheetCtorArgs) => SheetType;

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -493,7 +493,7 @@ export class CycleProcessor {
 
     /**
      * Modifies the stack value for a given buff. The stack value provided should be the modified amount and not the final amount
-     * 
+     *
      * @param buff The Buff
      * @param stacks The stack modification to add
      */
@@ -630,7 +630,7 @@ export class CycleProcessor {
 
     /**
      * Get the buff data for an active buff.
-     * 
+     *
      * @param buff The buff
      * @returns BuffUsage for the buff, or null if this buff is not active
      */
@@ -851,7 +851,7 @@ export class CycleProcessor {
 
     /**
      * Determines whether or not an Off-GCD ability can be used without clipping the GCD
-     * 
+     *
      * @param action The Off-GCD ability to check for
      * @returns whether or not this ability can be used without clipping the GCD
      */
@@ -1318,7 +1318,13 @@ export interface CycleSimResult extends SimResult {
     unbuffedPps: number,
     buffTimings: readonly BuffUsage[],
     totalDamage: ValueWithDev,
-    mainDpsFull: ValueWithDev
+    mainDpsFull: ValueWithDev,
+    label: string
+}
+
+export interface CycleSimResultFull<T extends SimResult> extends SimResult {
+    best: T,
+    all: T[]
 }
 
 export type ExternalCycleSettings<InternalSettingsType extends SimSettings> = {
@@ -1342,6 +1348,10 @@ export type Rotation<CycleProcessorType = CycleProcessor> = {
      * @param cp The CycleProcessor instance (or instance of a subclass)
      */
     apply(cp: CycleProcessorType): void;
+    /**
+     * Optional name
+     */
+    name?: string;
 }
 
 export type ResultSettings = {

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -2,17 +2,17 @@ export function sum(numbers: number[]) {
     return numbers.reduce((sum, val) => sum + val, 0);
 }
 
-export function range(startInclusive: number, endExclusive: number) {
+export function range(startInclusive: number, endExclusive: number, increment: number = 1) {
     const out = [];
-    for (let i = 0; i < endExclusive; i++) {
+    for (let i = 0; i < endExclusive; i += increment) {
         out.push(i);
     }
     return out;
 }
 
-export function rangeInc(startInclusive: number, endInclusive: number) {
+export function rangeInc(startInclusive: number, endInclusive: number, increment: number = 1) {
     const out = [];
-    for (let i = 0; i <= endInclusive; i++) {
+    for (let i = 0; i <= endInclusive; i += increment) {
         out.push(i);
     }
     return out;

--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -77,7 +77,7 @@ export function formatTopMenu(hash: string[]) {
         applyCommonTopMenuFormatting(link);
         if (href?.startsWith('?page=')) {
             const expected = splitPath(href.slice(6));
-            console.trace(`Expected: ${expected}, actual: ${hash}`);
+            console.debug(`Expected: ${expected}, actual: ${hash}`);
             if (arrayEq(expected, hash)) {
                 link.classList.add('current-page');
             }

--- a/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
+++ b/packages/frontend/src/scripts/sims/healer/sge_sheet_sim_mk2.ts
@@ -10,6 +10,7 @@ import {
 import {BaseMultiCycleSim} from "../sim_processors";
 import {gemdraught1mind} from "@xivgear/core/sims/common/potion";
 import {FieldBoundCheckBox, labeledCheckbox} from "@xivgear/common-ui/components/util";
+import {rangeInc} from "@xivgear/core/util/array_utils";
 
 /**
  * Used for all 360p filler abilities
@@ -147,7 +148,7 @@ export class SgeSheetSim extends BaseMultiCycleSim<SgeSheetSimResult, SgeNewShee
     getRotationsToSimulate(): Rotation[] {
         const outer = this;
         return [{
-            // Normal DoT
+            name: 'Normal DoT',
             cycleTime: 120,
             apply(cp: SageCycleProcessor) {
                 if (outer.settings.usePotion) {
@@ -171,17 +172,15 @@ export class SgeSheetSim extends BaseMultiCycleSim<SgeSheetSimResult, SgeNewShee
                     cp.useDotIfWorth();
                     cycle.useUntil(filler, 'end');
                 });
-
             }
-
-        }, {
-            // Dot early refresh
+        }, ...rangeInc(2, 20, 2).map(i => ({
+            name: `DoT clip ${i}s`,
             cycleTime: 120,
             apply(cp: SageCycleProcessor) {
                 if (outer.settings.usePotion) {
                     cp.useOgcd(gemdraught1mind);
                 }
-                const DOT_CLIP_AMOUNT = 10;
+                const DOT_CLIP_AMOUNT = i;
                 cp.useGcd(filler);
                 cp.oneCycle(cycle => {
                     cp.useDotIfWorth();
@@ -225,7 +224,7 @@ export class SgeSheetSim extends BaseMultiCycleSim<SgeSheetSimResult, SgeNewShee
                     cycle.useUntil(filler, 'end');
                 });
             },
-        }
+        }))
             // , {
             //     // Dot late
             //     cycleTime: 120,

--- a/packages/frontend/src/scripts/sims/processors/count_sim.ts
+++ b/packages/frontend/src/scripts/sims/processors/count_sim.ts
@@ -122,16 +122,16 @@ export abstract class BaseUsageCountSim<ResultType extends CountSimResult, Inter
             // The math works by starting with the previous bucket (thus larger), and subtracting the
             // next (thus smaller) bucket from it.
             const thisDurationCumulative = this.skillsInBuffDuration(set, duration);
-            console.trace(`Duration before ${duration} - raw ${JSON.stringify(thisDurationCumulative)}`);
+            console.debug(`Duration before ${duration} - raw ${JSON.stringify(thisDurationCumulative)}`);
             for (const skillCount of thisDurationCumulative) {
                 const matchingSkill = previous.find(val => abilityEquals(val[0], skillCount[0]));
                 if (matchingSkill) {
-                    console.trace(`Skill ${skillCount[0].name} (${duration}) = ${matchingSkill[1]} - ${skillCount[1]}`);
+                    console.debug(`Skill ${skillCount[0].name} (${duration}) = ${matchingSkill[1]} - ${skillCount[1]}`);
                     matchingSkill[1] -= skillCount[1];
                 }
             }
             skillsDurationMap.set(duration, thisDurationCumulative);
-            console.trace(`Duration after ${duration} - raw ${JSON.stringify(thisDurationCumulative)}`);
+            console.debug(`Duration after ${duration} - raw ${JSON.stringify(thisDurationCumulative)}`);
             previous = thisDurationCumulative;
         }
         // Organize into buckets
@@ -170,13 +170,13 @@ export abstract class BaseUsageCountSim<ResultType extends CountSimResult, Inter
                 const result = [];
                 if (dmg.directDamage) {
                     const valueWithDev = multiplyIndependent(dmg.directDamage, count);
-                    console.trace(`Skill ${skill.name}, count ${count}, duration ${bucket.maxDuration}, total ${valueWithDev.expected}`);
+                    console.debug(`Skill ${skill.name}, count ${count}, duration ${bucket.maxDuration}, total ${valueWithDev.expected}`);
                     result.push(valueWithDev);
                 }
                 // TODO handle indefinite dots? only one I can think of is blu so maybe not worth
                 if (dmg.dot && dmg.dot.fullDurationTicks !== 'indefinite') {
                     const valueWithDev = multiplyIndependent(dmg.dot.damagePerTick, dmg.dot.fullDurationTicks * count);
-                    console.trace(`Skill ${skill.name}, count ${count}, duration ${bucket.maxDuration}, total ${valueWithDev.expected}`);
+                    console.debug(`Skill ${skill.name}, count ${count}, duration ${bucket.maxDuration}, total ${valueWithDev.expected}`);
                     result.push(valueWithDev);
                 }
                 return result;

--- a/packages/frontend/src/scripts/test/sims/sim_test_utils.ts
+++ b/packages/frontend/src/scripts/test/sims/sim_test_utils.ts
@@ -2,7 +2,7 @@
 import {isClose} from "@xivgear/core/test/test_utils";
 import {BaseMultiCycleSim} from "../../sims/sim_processors";
 import {FinalizedAbility, PartyBuff} from "@xivgear/core/sims/sim_types";
-import {CycleSimResult, DisplayRecordFinalized} from "@xivgear/core/sims/cycle_sim";
+import {CycleSimResult, CycleSimResultFull, DisplayRecordFinalized} from "@xivgear/core/sims/cycle_sim";
 
 /**
  * Type that represents the time, name, and damage of an ability
@@ -28,9 +28,18 @@ export function setPartyBuffEnabled(sim: BaseMultiCycleSim<any, any>, buff: Part
     buffSettings.enabled = true;
 }
 
-export function assertSimAbilityResults(result: CycleSimResult | readonly DisplayRecordFinalized[], expectedAbilities: UseResult[]) {
+export function assertSimAbilityResults(result: CycleSimResultFull<CycleSimResult> | CycleSimResult | readonly DisplayRecordFinalized[], expectedAbilities: UseResult[]) {
 
-    const displayRecords: readonly DisplayRecordFinalized[] = 'displayRecords' in result ? result.displayRecords : result;
+    let displayRecords: readonly DisplayRecordFinalized[];
+    if ('all' in result) {
+        result = result.best;
+    }
+    if ('displayRecords' in result) {
+        displayRecords = result.displayRecords;
+    }
+    else {
+        displayRecords = result;
+    }
     const actualAbilities: FinalizedAbility[] = displayRecords.filter<FinalizedAbility>((record): record is FinalizedAbility => {
         return 'ability' in record;
     });


### PR DESCRIPTION
Now supports naming rotations + displays which rotation was used if a sim has multiple:

![image](https://github.com/xiv-gear-planner/gear-planner/assets/14287379/535ae9ad-f0de-44a2-958f-aa8288f86244)

Cycle sim results now contain all rotations' individual results for future UI use.

Cleaned up some unnecessary tracing.

Sim execution should also have less of an impact on page load times.