### PR TITLE
Fix DNC auto usages

### DIFF
--- a/packages/frontend/src/scripts/sims/ranged/dnc_sim.ts
+++ b/packages/frontend/src/scripts/sims/ranged/dnc_sim.ts
@@ -453,7 +453,7 @@ export class DncDtSim extends BaseUsageCountSim<DncDtSimResults, DncDtSimSetting
             return []
         }
         result.push(...common);
-        result.push([auto, (buffDuration ?? FullCycleTime) / 3.12]);
+        result.push([auto, (buffDuration ?? FullCycleTime) / set.computedStats.aaDelay]);
         return result;
     }
 

--- a/packages/frontend/src/scripts/sims/ranged/dnc_sim.ts
+++ b/packages/frontend/src/scripts/sims/ranged/dnc_sim.ts
@@ -453,7 +453,7 @@ export class DncDtSim extends BaseUsageCountSim<DncDtSimResults, DncDtSimSetting
             return []
         }
         result.push(...common);
-        result.push([auto, (buffDuration ?? FullCycleTime) / 3]);
+        result.push([auto, (buffDuration ?? FullCycleTime) / 3.12]);
         return result;
     }
 

--- a/packages/frontend/src/scripts/sims/tank/pld/pld_usage_sim_no_sks.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pld_usage_sim_no_sks.ts
@@ -147,7 +147,7 @@ export class PldUsageSim extends BaseUsageCountSim<PldUsageSimResults, PldUsageS
             result.push([Actions.auto, 70 / 2.24])
             result.push([Actions.buffed(Actions.auto), 140 / 2.24])
         } else if (buffDuration >= 15) {
-            result.push([Actions.buffed(Actions.auto), 7 * buffDuration / 2.24])
+            result.push([Actions.buffed(Actions.auto), 7 * buffDuration / set.computedStats.aaDelay])
         }
 
         return result;


### PR DESCRIPTION
auto potency based on auto delay is actually baked into the auto dmg calculation, so the number of usages should be based on the actual number of autos rather than the normalized p/3s "usages"