### PR TITLE
Adjust potion exports

### DIFF
--- a/packages/core/src/sims/common/potion.ts
+++ b/packages/core/src/sims/common/potion.ts
@@ -1,6 +1,7 @@
 import {OgcdAbility} from "../sim_types";
 import {fl, mainStatMulti} from "@xivgear/xivmath/xivmath";
 import {RawStatKey} from "@xivgear/xivmath/geartypes";
+import {camel2title} from "@xivgear/core/util/strutils";
 
 function applyPotionBuff(initialValue: number, bonus: number, cap: number): number {
     const effectiveBonus = Math.min(fl(initialValue * bonus), cap);
@@ -41,8 +42,27 @@ function makePotion(name: string, stat: RawStatKey, itemId: number, bonus: numbe
     };
 }
 
+function makeGemdraught(stat: RawStatKey, grade: number): Readonly<OgcdAbility> {
+    const statToPotItemId = {
+        mind: 44161,
+        strength: 44157,
+        dexterity: 44158,
+        intelligence: 44160,
+    }
+    const gradeToStatCap = [351, 392];
+
+    return makePotion(`Grade ${grade} Gemdraught of ${camel2title(stat)}`, stat, statToPotItemId[stat], 0.1, gradeToStatCap[grade - 1]);
+}
+
+// 6.x
 export const tincture8mind = makePotion('Grade 8 Tincture of Mind', 'mind', 39731, 0.1, 262);
-export const gemdraught1str = makePotion('Grade 1 Gemdraught of Strength', 'strength', 44157, 0.1, 351);
-export const gemdraught1dex = makePotion('Grade 1 Gemdraught of Dexterity', 'dexterity', 44158, 0.1, 351);
-export const gemdraught1int = makePotion('Grade 1 Gemdraught of Intelligence', 'intelligence', 44160, 0.1, 351);
-export const gemdraught1mind = makePotion('Grade 1 Gemdraught of Mind', 'mind', 44161, 0.1, 351);
+// 7.0
+export const gemdraught1str = makeGemdraught('strength', 1);
+export const gemdraught1dex = makeGemdraught('dexterity', 1);
+export const gemdraught1int = makeGemdraught('intelligence', 1);
+export const gemdraught1mind = makeGemdraught('mind', 1);
+// 7.05
+export const gemdraught2str = makeGemdraught('strength', 2);
+export const gemdraught2dex = makeGemdraught('dexterity', 2);
+export const gemdraught2int = makeGemdraught('intelligence', 2);
+export const gemdraught2mind = makeGemdraught('mind', 2);

--- a/packages/core/src/sims/common/potion.ts
+++ b/packages/core/src/sims/common/potion.ts
@@ -42,7 +42,9 @@ function makePotion(name: string, stat: RawStatKey, itemId: number, bonus: numbe
     };
 }
 
-function makeGemdraught(stat: RawStatKey, grade: number): Readonly<OgcdAbility> {
+export const GemdraughtGrades = [1, 2] as const;
+export type GemdraughtGrade = typeof GemdraughtGrades[number];
+export function makeGemdraught(stat: RawStatKey, grade: GemdraughtGrade): Readonly<OgcdAbility> {
     const statToPotItemId = {
         mind: 44161,
         strength: 44157,
@@ -61,8 +63,10 @@ export const gemdraught1str = makeGemdraught('strength', 1);
 export const gemdraught1dex = makeGemdraught('dexterity', 1);
 export const gemdraught1int = makeGemdraught('intelligence', 1);
 export const gemdraught1mind = makeGemdraught('mind', 1);
-// 7.05
-export const gemdraught2str = makeGemdraught('strength', 2);
-export const gemdraught2dex = makeGemdraught('dexterity', 2);
-export const gemdraught2int = makeGemdraught('intelligence', 2);
-export const gemdraught2mind = makeGemdraught('mind', 2);
+
+// Latest
+const MAX_GEMDRAUGHT_GRADE = GemdraughtGrades.slice(-1)[0];
+export const potionMaxStr = makeGemdraught('strength', MAX_GEMDRAUGHT_GRADE);
+export const potionMaxDex = makeGemdraught('dexterity', MAX_GEMDRAUGHT_GRADE);
+export const potionMaxInt = makeGemdraught('intelligence', MAX_GEMDRAUGHT_GRADE);
+export const potionMaxMind = makeGemdraught('mind', MAX_GEMDRAUGHT_GRADE);

--- a/packages/frontend/src/scripts/sims/melee/nin/nin_lv100_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/nin/nin_lv100_sim.ts
@@ -4,7 +4,7 @@ import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
 import {STANDARD_ANIMATION_LOCK} from "@xivgear/xivmath/xivconstants";
 import {BaseMultiCycleSim} from "../../sim_processors";
 import {AbilitiesUsedTable} from "../../components/ability_used_table";
-import {gemdraught1dex} from "@xivgear/core/sims/common/potion";
+import {gemdraught2dex} from "@xivgear/core/sims/common/potion";
 import {Dokumori} from "@xivgear/core/sims/buffs";
 import NINGauge from "./nin_gauge";
 import {NinAbility, NinGcdAbility, MudraStep, NinjutsuAbility, NINExtraData} from "./nin_types";
@@ -313,7 +313,7 @@ class NINCycleProcessor extends CycleProcessor {
         this.useOgcd(Actions.Kassatsu);
 
         this.useCombo();
-        this.useOgcd(gemdraught1dex);
+        this.useOgcd(gemdraught2dex);
 
         this.useCombo();
         this.useOgcd(Actions.DokumoriAbility);

--- a/packages/frontend/src/scripts/sims/melee/nin/nin_lv100_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/nin/nin_lv100_sim.ts
@@ -4,7 +4,7 @@ import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
 import {STANDARD_ANIMATION_LOCK} from "@xivgear/xivmath/xivconstants";
 import {BaseMultiCycleSim} from "../../sim_processors";
 import {AbilitiesUsedTable} from "../../components/ability_used_table";
-import {gemdraught2dex} from "@xivgear/core/sims/common/potion";
+import {potionMaxDex} from "@xivgear/core/sims/common/potion";
 import {Dokumori} from "@xivgear/core/sims/buffs";
 import NINGauge from "./nin_gauge";
 import {NinAbility, NinGcdAbility, MudraStep, NinjutsuAbility, NINExtraData} from "./nin_types";
@@ -313,7 +313,7 @@ class NINCycleProcessor extends CycleProcessor {
         this.useOgcd(Actions.Kassatsu);
 
         this.useCombo();
-        this.useOgcd(gemdraught2dex);
+        this.useOgcd(potionMaxDex);
 
         this.useCombo();
         this.useOgcd(Actions.DokumoriAbility);

--- a/packages/frontend/src/scripts/sims/melee/rpr/rpr_actions.ts
+++ b/packages/frontend/src/scripts/sims/melee/rpr/rpr_actions.ts
@@ -1,10 +1,6 @@
 import { ArcaneCircleBuff } from "@xivgear/core/sims/buffs";
 import { RprGcdAbility, RprOgcdAbility } from "./rpr_types";
 import { DeathsDesign, IdealHost } from "./rpr_buff";
-import { OgcdAbility } from "@xivgear/core/sims/sim_types";
-import { gemdraught1str } from "@xivgear/core/sims/common/potion";
-
-export const Potion: OgcdAbility = gemdraught1str;
 
 export const Slice: RprGcdAbility = {
     type: 'gcd',

--- a/packages/frontend/src/scripts/sims/melee/rpr/rpr_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/rpr/rpr_sheet_sim.ts
@@ -2,6 +2,7 @@ import {ArcaneCircleBuff} from "@xivgear/core/sims/buffs";
 import {Ability, Buff, OgcdAbility, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
 import {AbilityUseRecordUnf, AbilityUseResult, CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation} from "@xivgear/core/sims/cycle_sim";
 import {BaseMultiCycleSim} from "../../sim_processors";
+import { potionMaxStr } from "@xivgear/core/sims/common/potion";
 import * as Actions from "./rpr_actions"
 import { RprAbility, RprExtraData, RprGcdAbility } from "./rpr_types";
 import { RprGauge } from "./rpr_gauge";
@@ -224,9 +225,9 @@ class RprCycleProcessor extends CycleProcessor {
 
         this.useGcd(Actions.ShadowOfDeath);
 
-        this.advanceForLateWeave([Actions.Potion]);
+        this.advanceForLateWeave([potionMaxStr]);
         if (pot) {
-            this.useOgcd(Actions.Potion);
+            this.useOgcd(potionMaxStr);
         }
 
         this.useGcd(Actions.SoulSlice);
@@ -264,24 +265,24 @@ class RprCycleProcessor extends CycleProcessor {
 
         }
 
-        if (this.cdTracker.canUse(Actions.Potion)) {
+        if (this.cdTracker.canUse(potionMaxStr)) {
 
             /** If we can weave potion between AC and next gcd */
-            if (nextReaping - acTime >= animationLock(Actions.Potion)) {
+            if (nextReaping - acTime >= animationLock(potionMaxStr)) {
                 this.useGcd(Actions.ShadowOfDeath);
                 this.useOgcd(Actions.ArcaneCircle);
-                this.useOgcd(Actions.Potion);
+                this.useOgcd(potionMaxStr);
             }
             else {
                 /** If we can weave potion before AC */
-                if (acTime - (this.nextGcdTime + animationLock(Actions.ShadowOfDeath)) >= animationLock(Actions.Potion)) {
+                if (acTime - (this.nextGcdTime + animationLock(Actions.ShadowOfDeath)) >= animationLock(potionMaxStr)) {
                     this.useGcd(Actions.ShadowOfDeath);
-                    this.useOgcd(Actions.Potion);
+                    this.useOgcd(potionMaxStr);
                     this.useOgcd(Actions.ArcaneCircle);
                 }
                 /** We cannot fit both pot and AC, move pot back */
                 else {
-                    this.useOgcd(Actions.Potion);
+                    this.useOgcd(potionMaxStr);
                     this.useGcd(Actions.ShadowOfDeath);
                     this.useOgcd(Actions.ArcaneCircle);
                 }

--- a/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_200.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_200.ts
@@ -1,12 +1,12 @@
 import { SamAbility } from "../sam_types";
-import { gemdraught2str } from "@xivgear/core/sims/common/potion";
+import { potionMaxStr } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../sam_actions';
 
 export const Opener: SamAbility[] = [
     Actions.MeikyoShisui,
     Actions.Gekko,
     Actions.Ikishoten,
-    gemdraught2str,
+    potionMaxStr,
     Actions.Kasha,
     Actions.Yukikaze,
     Actions.TendoSetsugekka,

--- a/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_200.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_200.ts
@@ -1,12 +1,12 @@
 import { SamAbility } from "../sam_types";
-import { gemdraught1str } from "@xivgear/core/sims/common/potion";
+import { gemdraught2str } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../sam_actions';
 
 export const Opener: SamAbility[] = [
     Actions.MeikyoShisui,
     Actions.Gekko,
     Actions.Ikishoten,
-    gemdraught1str,
+    gemdraught2str,
     Actions.Kasha,
     Actions.Yukikaze,
     Actions.TendoSetsugekka,

--- a/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_207.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_207.ts
@@ -1,12 +1,12 @@
 import { SamAbility } from "../sam_types";
-import { gemdraught2str } from "@xivgear/core/sims/common/potion";
+import { potionMaxStr } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../sam_actions';
 
 export const Opener: SamAbility[] = [
     Actions.MeikyoShisui,
     Actions.Gekko,
     Actions.Ikishoten,
-    gemdraught2str,
+    potionMaxStr,
     Actions.Kasha,
     Actions.Yukikaze,
     Actions.TendoSetsugekka,

--- a/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_207.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_207.ts
@@ -1,12 +1,12 @@
 import { SamAbility } from "../sam_types";
-import { gemdraught1str } from "@xivgear/core/sims/common/potion";
+import { gemdraught2str } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../sam_actions';
 
 export const Opener: SamAbility[] = [
     Actions.MeikyoShisui,
     Actions.Gekko,
     Actions.Ikishoten,
-    gemdraught1str,
+    gemdraught2str,
     Actions.Kasha,
     Actions.Yukikaze,
     Actions.TendoSetsugekka,

--- a/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_214.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_214.ts
@@ -1,12 +1,12 @@
 import { SamAbility } from "../sam_types";
-import { gemdraught2str } from "@xivgear/core/sims/common/potion";
+import { potionMaxStr } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../sam_actions';
 
 export const Opener: SamAbility[] = [
     Actions.MeikyoShisui,
     Actions.Gekko,
     Actions.Ikishoten,
-    gemdraught2str,
+    potionMaxStr,
     Actions.Kasha,
     Actions.Yukikaze,
     Actions.TendoSetsugekka,

--- a/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_214.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/rotations/sam_lv100_214.ts
@@ -1,12 +1,12 @@
 import { SamAbility } from "../sam_types";
-import { gemdraught1str } from "@xivgear/core/sims/common/potion";
+import { gemdraught2str } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../sam_actions';
 
 export const Opener: SamAbility[] = [
     Actions.MeikyoShisui,
     Actions.Gekko,
     Actions.Ikishoten,
-    gemdraught1str,
+    gemdraught2str,
     Actions.Kasha,
     Actions.Yukikaze,
     Actions.TendoSetsugekka,

--- a/packages/frontend/src/scripts/sims/melee/vpr/vpr_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/vpr/vpr_sheet_sim.ts
@@ -5,7 +5,7 @@ import { VprGauge } from "./vpr_gauge";
 import { VprAbility, VprExtraData, VprGcdAbility } from "./vpr_types";
 import * as Actions from "./vpr_actions";
 import { FlanksbaneVenom, FlankstungVenom, HindsbaneVenom, HindstungVenom, HuntersInstinct, NoxiousGnash, ReadyToReawaken, Swiftscaled } from "./vpr_buffs";
-import { gemdraught1dex } from "@xivgear/core/sims/common/potion";
+import { potionMaxDex } from "@xivgear/core/sims/common/potion";
 import { sum } from "@xivgear/core/util/array_utils";
 import { STANDARD_ANIMATION_LOCK } from "@xivgear/xivmath/xivconstants";
 import { AbilitiesUsedTable } from "../../components/ability_used_table";
@@ -296,8 +296,8 @@ export class VprCycleProcessor extends CycleProcessor {
         this.useDualWieldCombo(); // Will be Swifstkin's Sting because it is first to be used
         this.useGcd(Actions.Dreadwinder);
 
-        this.advanceForLateWeave([gemdraught1dex]);
-        this.useOgcd(gemdraught1dex)
+        this.advanceForLateWeave([potionMaxDex]);
+        this.useOgcd(potionMaxDex)
 
         this.useHuntersCoil();
         this.useSwiftskinsCoil();
@@ -413,9 +413,9 @@ export class VprCycleProcessor extends CycleProcessor {
             }
 
             this.useDualWieldCombo();
-            if (this.canUseWithoutClipping(gemdraught1dex)) {
-                this.advanceForLateWeave([gemdraught1dex]);
-                this.useOgcd(gemdraught1dex);
+            if (this.canUseWithoutClipping(potionMaxDex)) {
+                this.advanceForLateWeave([potionMaxDex]);
+                this.useOgcd(potionMaxDex);
             }
 
             return;


### PR DESCRIPTION
This PR Adjusts the potion exports so that there is one generic "max level" potion. This way, sims that only care to use the max grade potion available do not need to be updated every time the game adds a new potion.

I have also exported a few extra variables, so that sims could add settings in the future that would allow users to configure which grade potion they would like to use.