### PR TITLE
Consolidate ItemFood requests into single batch

### DIFF
--- a/packages/core/src/datamanager.ts
+++ b/packages/core/src/datamanager.ts
@@ -7,7 +7,7 @@ import {
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
 import {GearItem, JobMultipliers, Materia, OccGearSlotKey, RawStatKey,} from "@xivgear/xivmath/geartypes";
-import {xivApiGet, XivApiResultSingle, xivApiSingleCols} from "./external/xivapi";
+import {xivApiGet, XivApiResultSingle} from "./external/xivapi";
 import {BaseParamToStatKey, RelevantBaseParam, xivApiStatMapping} from "./external/xivapitypes";
 import {getRelicStatModelFor} from "./relicstats/relicstats";
 

--- a/packages/core/src/datamanager.ts
+++ b/packages/core/src/datamanager.ts
@@ -327,13 +327,22 @@ export class DataManager implements DataManagerIntf {
                 console.log(`Got ${data.Results.length} Food Items`);
                 return data.Results;
             })
-            .then((rawFoods) => rawFoods.map(async i => {
-                // TODO: is there a better way to get this?
-                const itemActionId = i.ItemAction['fields']['Data'][1] as number;
-                const itemFoodData = await xivApiSingleCols('ItemFood', itemActionId, foodItemFoodCols);
-                return new XivApiFoodInfo(i, itemFoodData);
-            }))
-            .then(async (processedFoods) => (await Promise.all(processedFoods)).filter(food => Object.keys(food.bonuses).length > 1))
+            .then(async (rawFoods) => {
+                const foodIds = rawFoods.map(item => item.ItemAction['fields']['Data'][1] as number);
+                const food = await xivApiGet({
+                    requestType:'list',
+                    sheet: 'ItemFood',
+                    columns: foodItemFoodCols,
+                    rows: foodIds,
+                });
+                const foodMap = new Map(food.Results.map(result => [result.ID, result]));
+
+                return rawFoods.map(item => {
+                    const itemFoodData = foodMap.get(item.ItemAction['fields']['Data'][1]);
+                    return new XivApiFoodInfo(item, itemFoodData);
+                });
+            })
+            .then((processedFoods) => processedFoods.filter(food => Object.keys(food.bonuses).length > 1))
             .then((foods) => this._allFoodItems = foods,
                 e => console.error(e));
         console.log("Loading jobs");

--- a/packages/core/src/external/xivapi.ts
+++ b/packages/core/src/external/xivapi.ts
@@ -10,6 +10,7 @@ export type XivApiRequest = {
 
 export type XivApiListRequest = XivApiRequest & {
     requestType: 'list',
+    rows?: number[],
 }
 
 export type XivApiFilter = string;
@@ -146,6 +147,9 @@ export async function xivApiGetList<RequestType extends XivApiListRequest>(reque
     let query = `${XIVAPI_SERVER}/api/1/sheet/${request.sheet}?limit=${perPage}`;
     if (request.columns?.length > 0) {
         query += '&fields=' + request.columns.join(',');
+    }
+    if (request.rows != null) {
+        query += '&rows=' + request.rows.join(',');
     }
     let remainingPages = request.pageLimit ?? 4;
     let after = request.startPage !== undefined ? (request.startPage * perPage) : 0;


### PR DESCRIPTION
Title. This is a pretty naive implementation, but should at least _help_ remedy the current hug of death y'all sending to the beta.

Just using the `rows=` query parameter to consolidate the `ItemFood` requests into one batch, rather than a seperate request per item. Each request has a bit of overhead I can't do much to avoid, so this should reduce the load a little.

Linting seems to be complaining about something I don't have the brain space to deal with right now.