### PR TITLE
Fix dragging hand getting stuck on

### DIFF
--- a/packages/frontend/src/scripts/components/draghelpers.ts
+++ b/packages/frontend/src/scripts/components/draghelpers.ts
@@ -18,7 +18,7 @@ export function installDragHelper(args: {dragHandle: HTMLElement, dragOuter: HTM
             body.removeEventListener('pointerup', up);
             // body.releasePointerCapture(ev.pointerId);
             args.dragHandle.style.cursor = elementCursorBefore;
-            args.dragOuter.style.cursor = bodyCursorBefore;
+            body.style.cursor = bodyCursorBefore;
             args.upHandler?.(ev);
         };
         body.addEventListener('pointermove', move);


### PR DESCRIPTION
The cursor style applied while dragging was not getting removed causing the grabbing hand to always be applied.

### Test

1. Create or use a sheet with more than 2 gearsets
2. Drag one of the sets
3. Ensure the grabbing hand does not remain stuck on after dropping the gearset