### PR TITLE
Fix vit order

### DIFF
--- a/packages/core/src/datamanager.ts
+++ b/packages/core/src/datamanager.ts
@@ -268,9 +268,9 @@ export class DataManager implements DataManagerIntf {
                     extraPromises.push(Promise.all([itemIlvlPromise, ilvlSyncPromise]).then(([native, sync]) => {
                         item.applyIlvlData(native, sync);
                         if (item.isCustomRelic) {
-                            console.log('Applying relic model');
+                            console.debug('Applying relic model');
                             item.relicStatModel = getRelicStatModelFor(item, this._baseParams, this._classJob);
-                            console.log('Applied', item.relicStatModel)
+                            console.debug('Applied', item.relicStatModel)
                         }
                     }));
                 }
@@ -278,9 +278,9 @@ export class DataManager implements DataManagerIntf {
                     extraPromises.push(itemIlvlPromise.then(native => {
                         item.applyIlvlData(native);
                         if (item.isCustomRelic) {
-                            console.log('Applying relic model');
+                            console.debug('Applying relic model');
                             item.relicStatModel = getRelicStatModelFor(item, this._baseParams, this._classJob);
-                            console.log('Applied', item.relicStatModel)
+                            console.debug('Applied', item.relicStatModel)
                         }
                     }));
                 }

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -44,7 +44,6 @@ import {
     RelicStatModel,
     RelicStats,
     SetDisplaySettingsExport,
-    FoodStatBonus,
     XivCombatItem
 } from "@xivgear/xivmath/geartypes";
 import {xivApiIconUrl} from "./external/xivapi";

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -357,19 +357,10 @@ export class CharacterGearSet {
         // Add race stats
         addStats(combinedStats, raceStats);
 
-        // Food stats
-        if (this._food) {
-            for (const stat in this._food.bonuses) {
-                const bonus: FoodStatBonus = this._food.bonuses[stat];
-                const startingValue = combinedStats[stat];
-                const extraValue = Math.min(bonus.max, Math.floor(startingValue * (bonus.percentage / 100)));
-                combinedStats[stat] = startingValue + extraValue;
-            }
-        }
         this._dirtyComp = false;
         // Add BLU weapon damage modifier
         combinedStats.wdMag += classJob === "BLU" ? bluWdfromInt(gearIntStat) : 0;
-        const computedStats = finalizeStats(combinedStats, level, levelStats, classJob, classJobStats, this._sheet.partyBonus);
+        const computedStats = finalizeStats(combinedStats, this._food?.bonuses ?? {}, level, levelStats, classJob, classJobStats, this._sheet.partyBonus);
         const leftRing = this.getItemInSlot('RingLeft');
         const rightRing = this.getItemInSlot('RingRight');
         if (leftRing && leftRing.isUnique && rightRing && rightRing.isUnique) {

--- a/packages/core/src/test/general_stats_tests.ts
+++ b/packages/core/src/test/general_stats_tests.ts
@@ -1,0 +1,216 @@
+import {finalizeStats} from "@xivgear/xivmath/xivstats";
+import {RawStats} from "@xivgear/xivmath/geartypes";
+import {getLevelStats} from "@xivgear/xivmath/xivconstants";
+import {HEADLESS_SHEET_PROVIDER} from "../sheet";
+import {expect} from "chai";
+import {fl} from "@xivgear/xivmath/xivmath";
+
+
+const level = 100;
+const job = 'SCH';
+const fakeSheet = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", job, level, undefined);
+
+const loadPromise = fakeSheet.load();
+
+// TODO: make a version of these tests that uses live items
+describe("ComputedSetStats", () => {
+    // from https://xivgear.app/?page=sl%7C159ef597-02ed-4fc9-9290-5de6c16c3af9
+    it('computes correctly with no food and no party bonus', async () => {
+        await loadPromise;
+        const stats = finalizeStats(new RawStats({
+            hp: 0,
+            vitality: 4119,
+            strength: fl(440 * 0.9),
+            dexterity: 440,
+            intelligence: 462,
+            mind: 4448,
+            piety: 564,
+            crit: 2988,
+            dhit: 690,
+            determination: 2706,
+            tenacity: 420,
+            skillspeed: 420,
+            spellspeed: 1134,
+            wdPhys: 141,
+            wdMag: 141,
+            weaponDelay: 3.12
+        }), {}, level, getLevelStats(level), job, fakeSheet.classJobStats, 0);
+        expect(stats.aaDelay).to.eq(3.12);
+        expect(stats.aaMulti).to.eq(187.2);
+        expect(stats.aaStatMulti).to.eq(0.76);
+        expect(stats.autoDhBonus).to.eq(0.013);
+        expect(stats.crit).to.eq(2988);
+        expect(stats.critChance).to.eq(0.234);
+        expect(stats.critMulti).to.eq(1.584);
+        expect(stats.detMulti).to.eq(1.114);
+        expect(stats.determination).to.eq(2706);
+        expect(stats.dexterity).to.eq(440);
+        expect(stats.dhit).to.eq(690);
+        expect(stats.dhitChance).to.eq(0.053);
+        expect(stats.dhitMulti).to.eq(1.25);
+        expect(stats.gcdMag(2.50)).to.eq(2.41);
+        expect(stats.gcdPhys(2.50)).to.eq(2.50);
+        expect(stats.haste('Spell')).to.eq(0);
+        expect(stats.hp).to.eq(114937);
+        expect(stats.intelligence).to.eq(462);
+        expect(stats.mainStatMulti).to.eq(22.58);
+        expect(stats.mind).to.eq(4448);
+        expect(stats.mpPerTick).to.eq(206);
+        expect(stats.piety).to.eq(564);
+        expect(stats.skillspeed).to.eq(420);
+        expect(stats.sksDotMulti).to.eq(1);
+        expect(stats.spellspeed).to.eq(1134);
+        expect(stats.spsDotMulti).to.eq(1.033);
+        expect(stats.strength).to.eq(396);
+        expect(stats.tenacity).to.eq(420);
+        expect(stats.tncIncomingMulti).to.eq(1);
+        expect(stats.tncMulti).to.eq(1);
+        expect(stats.vitality).to.eq(4119);
+        expect(stats.wdMag).to.eq(141);
+        expect(stats.wdMulti).to.eq(191);
+        expect(stats.wdPhys).to.eq(141);
+        expect(stats.weaponDelay).to.eq(3.12);
+    }).timeout(30_000);
+    it('computes correctly with food and no party bonus', async () => {
+        await loadPromise;
+        const stats = finalizeStats(new RawStats({
+                hp: 0,
+                vitality: 4119,
+                strength: fl(440 * 0.9),
+                dexterity: 440,
+                intelligence: 462,
+                mind: 4448,
+                piety: 564,
+                crit: 2988,
+                dhit: 690,
+                determination: 2706,
+                tenacity: 420,
+                skillspeed: 420,
+                spellspeed: 1134,
+                wdPhys: 141,
+                wdMag: 141,
+                weaponDelay: 3.12
+            }),
+            // Pineapple Orange Jelly
+            {
+                vitality: {
+                    max: 203,
+                    percentage: 10
+                },
+                crit: {
+                    max: 132,
+                    percentage: 10,
+                },
+                spellspeed: {
+                    max: 79,
+                    percentage: 10
+                }
+            }, level, getLevelStats(level), job, fakeSheet.classJobStats, 0);
+        expect(stats.aaDelay).to.eq(3.12);
+        expect(stats.aaMulti).to.eq(187.2);
+        expect(stats.aaStatMulti).to.eq(0.76);
+        expect(stats.autoDhBonus).to.eq(0.013);
+        expect(stats.crit).to.eq(2988 + 132);
+        expect(stats.critChance).to.eq(0.244);
+        expect(stats.critMulti).to.eq(1.594);
+        expect(stats.detMulti).to.eq(1.114);
+        expect(stats.determination).to.eq(2706);
+        expect(stats.dexterity).to.eq(440);
+        expect(stats.dhit).to.eq(690);
+        expect(stats.dhitChance).to.eq(0.053);
+        expect(stats.dhitMulti).to.eq(1.25);
+        expect(stats.gcdMag(2.50)).to.eq(2.40);
+        expect(stats.gcdPhys(2.50)).to.eq(2.50);
+        expect(stats.haste('Spell')).to.eq(0);
+        expect(stats.hp).to.eq(121048);
+        expect(stats.intelligence).to.eq(462);
+        expect(stats.mainStatMulti).to.eq(22.58);
+        expect(stats.mind).to.eq(4448);
+        expect(stats.mpPerTick).to.eq(206);
+        expect(stats.piety).to.eq(564);
+        expect(stats.skillspeed).to.eq(420);
+        expect(stats.sksDotMulti).to.eq(1);
+        expect(stats.spellspeed).to.eq(1134 + 79);
+        expect(stats.spsDotMulti).to.eq(1.037);
+        expect(stats.strength).to.eq(396);
+        expect(stats.tenacity).to.eq(420);
+        expect(stats.tncIncomingMulti).to.eq(1);
+        expect(stats.tncMulti).to.eq(1);
+        expect(stats.vitality).to.eq(4119 + 203);
+        expect(stats.wdMag).to.eq(141);
+        expect(stats.wdMulti).to.eq(191);
+        expect(stats.wdPhys).to.eq(141);
+        expect(stats.weaponDelay).to.eq(3.12);
+    }).timeout(30_000);
+    it('computes correctly with food and with party bonus', async () => {
+        await loadPromise;
+        const stats = finalizeStats(new RawStats({
+                hp: 0,
+                vitality: 4119,
+                strength: fl(440 * 0.9),
+                dexterity: 440,
+                intelligence: 462,
+                mind: 4448,
+                piety: 564,
+                crit: 2988,
+                dhit: 690,
+                determination: 2706,
+                tenacity: 420,
+                skillspeed: 420,
+                spellspeed: 1134,
+                wdPhys: 141,
+                wdMag: 141,
+                weaponDelay: 3.12
+            }),
+            // Pineapple Orange Jelly
+            {
+                vitality: {
+                    max: 203,
+                    percentage: 10
+                },
+                crit: {
+                    max: 132,
+                    percentage: 10,
+                },
+                spellspeed: {
+                    max: 79,
+                    percentage: 10
+                }
+            }, level, getLevelStats(level), job, fakeSheet.classJobStats, 5);
+        expect(stats.aaDelay).to.eq(3.12);
+        expect(stats.aaMulti).to.eq(187.2);
+        expect(stats.aaStatMulti).to.eq(0.86);
+        expect(stats.autoDhBonus).to.eq(0.013);
+        expect(stats.crit).to.eq(2988 + 132);
+        expect(stats.critChance).to.eq(0.244);
+        expect(stats.critMulti).to.eq(1.594);
+        expect(stats.detMulti).to.eq(1.114);
+        expect(stats.determination).to.eq(2706);
+        expect(stats.dexterity).to.eq(440);
+        expect(stats.dhit).to.eq(690);
+        expect(stats.dhitChance).to.eq(0.053);
+        expect(stats.dhitMulti).to.eq(1.25);
+        expect(stats.gcdMag(2.50)).to.eq(2.40);
+        expect(stats.gcdPhys(2.50)).to.eq(2.50);
+        expect(stats.haste('Spell')).to.eq(0);
+        expect(stats.hp).to.eq(127218);
+        expect(stats.intelligence).to.eq(462);
+        expect(stats.mainStatMulti).to.eq(23.78);
+        expect(stats.mind).to.eq(4670);
+        expect(stats.mpPerTick).to.eq(206);
+        expect(stats.piety).to.eq(564);
+        expect(stats.skillspeed).to.eq(420);
+        expect(stats.sksDotMulti).to.eq(1);
+        expect(stats.spellspeed).to.eq(1134 + 79);
+        expect(stats.spsDotMulti).to.eq(1.037);
+        expect(stats.strength).to.eq(415);
+        expect(stats.tenacity).to.eq(420);
+        expect(stats.tncIncomingMulti).to.eq(1);
+        expect(stats.tncMulti).to.eq(1);
+        expect(stats.vitality).to.eq(4527); // Base * Party + Food
+        expect(stats.wdMag).to.eq(141);
+        expect(stats.wdMulti).to.eq(191);
+        expect(stats.wdPhys).to.eq(141);
+        expect(stats.weaponDelay).to.eq(3.12);
+    }).timeout(30_000);
+});

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1015,6 +1015,10 @@ export class GearSetViewer extends HTMLElement {
     get toolbar(): Node {
         return new SetViewToolbar(this.gearSet);
     }
+
+    refresh() {
+        // Avoids an error in the console in view-only mode
+    }
 }
 
 function formatSimulationConfigArea<SettingsType extends SimSettings>(

--- a/packages/frontend/src/scripts/test/sims/common_values.ts
+++ b/packages/frontend/src/scripts/test/sims/common_values.ts
@@ -124,7 +124,7 @@ const rawStats = {
     weaponDelay: 3.44
 };
 // Finalize the stats (add class modifiers, party bonus, etc)
-const stats = finalizeStats(rawStats, 90, getLevelStats(90), 'WHM', {
+const stats = finalizeStats(rawStats, {}, 90, getLevelStats(90), 'WHM', {
     ...getClassJobStats('WHM'),
     jobStatMultipliers: jobStatMultipliers
 }, 5);

--- a/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
@@ -232,7 +232,7 @@ const rawStats = {
     weaponDelay: 3.44
 };
 // Finalize the stats (add class modifiers, party bonus, etc)
-const stats = finalizeStats(rawStats, 90, getLevelStats(90), 'WHM', {
+const stats = finalizeStats(rawStats, {}, 90, getLevelStats(90), 'WHM', {
     ...getClassJobStats('WHM'),
     jobStatMultipliers: jobStatMultipliers
 }, 5);

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -543,7 +543,7 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
     100: {
         minILvl: 640,
         maxILvl: 999,
-        minILvlFood: 570,
+        minILvlFood: 640,
         maxILvlFood: 999,
         minMateria: 9,
         maxMateria: 12,
@@ -551,7 +551,7 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
             // Raise this when more gear is available
             minILvl: 680,
             maxILvl: 999,
-            minILvlFood: 640,
+            minILvlFood: 670,
             maxILvlFood: 999,
             higherRelics: true
         }

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -45,6 +45,7 @@ export function addStats(baseStats: RawStats, addedStats: RawStats): void {
 }
 
 export function finalizeStats(
+    // TODO: gearStats is currently gear + race/job base stuff. Separate these out.
     gearStats: RawStats,
     foodStats: FoodBonuses,
     level: SupportedLevel,
@@ -63,10 +64,11 @@ export function finalizeStats(
     combinedStats.vitality = fl(combinedStats.vitality * (1 + 0.01 * partyBonus));
     // Food stats
     for (const stat in foodStats) {
+        // These operate on base values, without the party buff
         const bonus: FoodStatBonus = foodStats[stat];
-        const startingValue = combinedStats[stat];
+        const startingValue = gearStats[stat];
         const extraValue = Math.min(bonus.max, Math.floor(startingValue * (bonus.percentage / 100)));
-        combinedStats[stat] = startingValue + extraValue;
+        combinedStats[stat] += extraValue;
     }
     const wdEffective = Math.max(combinedStats.wdMag, combinedStats.wdPhys);
     const hp = combinedStats.hp + vitToHp(levelStats, classJobStats, combinedStats.vitality);

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -14,7 +14,8 @@ import {
     critDmg,
     detDmg,
     dhitChance,
-    dhitDmg, fl,
+    dhitDmg,
+    fl,
     mainStatMulti,
     mpTick,
     sksTickMulti,
@@ -53,13 +54,13 @@ export function finalizeStats(
     partyBonus: PartyBonusAmount
 ): ComputedSetStats {
     const combinedStats: RawStats = {...gearStats};
-    // const withPartyBonus: RawStats = {...combinedStats};
-    const withPartyBonus = combinedStats;
     const mainStatKey = classJobStats.mainStat;
     const aaStatKey = classJobStats.autoAttackStat;
-    withPartyBonus[mainStatKey] = fl(withPartyBonus[mainStatKey] * (1 + 0.01 * partyBonus));
-    withPartyBonus[aaStatKey] = fl(combinedStats[mainStatKey] * (1 + 0.01 * partyBonus));
-    withPartyBonus.vitality = fl(combinedStats.vitality * (1 + 0.01 * partyBonus));
+    combinedStats[mainStatKey] = fl(combinedStats[mainStatKey] * (1 + 0.01 * partyBonus));
+    if (mainStatKey !== aaStatKey) {
+        combinedStats[aaStatKey] = fl(combinedStats[aaStatKey] * (1 + 0.01 * partyBonus));
+    }
+    combinedStats.vitality = fl(combinedStats.vitality * (1 + 0.01 * partyBonus));
     // Food stats
     for (const stat in foodStats) {
         const bonus: FoodStatBonus = foodStats[stat];
@@ -68,42 +69,42 @@ export function finalizeStats(
         combinedStats[stat] = startingValue + extraValue;
     }
     const wdEffective = Math.max(combinedStats.wdMag, combinedStats.wdPhys);
-    const hp = withPartyBonus.hp + vitToHp(levelStats, classJobStats, withPartyBonus.vitality);
-    const mainStat = withPartyBonus[mainStatKey];
-    const aaStat = withPartyBonus[aaStatKey];
+    const hp = combinedStats.hp + vitToHp(levelStats, classJobStats, combinedStats.vitality);
+    const mainStat = combinedStats[mainStatKey];
+    const aaStat = combinedStats[aaStatKey];
     const computedStats: ComputedSetStats = {
         ...combinedStats,
-        vitality: withPartyBonus.vitality,
+        vitality: combinedStats.vitality,
         level: level,
         levelStats: levelStats,
         job: classJob,
         jobStats: classJobStats,
-        gcdPhys: (base, haste = 0) => sksToGcd(base, levelStats, withPartyBonus.skillspeed, haste),
-        gcdMag: (base, haste = 0) => spsToGcd(base, levelStats, withPartyBonus.spellspeed, haste),
+        gcdPhys: (base, haste = 0) => sksToGcd(base, levelStats, combinedStats.skillspeed, haste),
+        gcdMag: (base, haste = 0) => spsToGcd(base, levelStats, combinedStats.spellspeed, haste),
         haste: () => 0,
         hp: hp,
-        critChance: critChance(levelStats, withPartyBonus.crit),
-        critMulti: critDmg(levelStats, withPartyBonus.crit),
-        dhitChance: dhitChance(levelStats, withPartyBonus.dhit),
-        dhitMulti: dhitDmg(levelStats, withPartyBonus.dhit),
-        detMulti: detDmg(levelStats, withPartyBonus.determination),
-        spsDotMulti: spsTickMulti(levelStats, withPartyBonus.spellspeed),
-        sksDotMulti: sksTickMulti(levelStats, withPartyBonus.skillspeed),
-        tncMulti: classJobStats.role === 'Tank' ? tenacityDmg(levelStats, withPartyBonus.tenacity) : 1,
-        tncIncomingMulti: classJobStats.role === 'Tank' ? tenacityIncomingDmg(levelStats, withPartyBonus.tenacity) : 1,
+        critChance: critChance(levelStats, combinedStats.crit),
+        critMulti: critDmg(levelStats, combinedStats.crit),
+        dhitChance: dhitChance(levelStats, combinedStats.dhit),
+        dhitMulti: dhitDmg(levelStats, combinedStats.dhit),
+        detMulti: detDmg(levelStats, combinedStats.determination),
+        spsDotMulti: spsTickMulti(levelStats, combinedStats.spellspeed),
+        sksDotMulti: sksTickMulti(levelStats, combinedStats.skillspeed),
+        tncMulti: classJobStats.role === 'Tank' ? tenacityDmg(levelStats, combinedStats.tenacity) : 1,
+        tncIncomingMulti: classJobStats.role === 'Tank' ? tenacityIncomingDmg(levelStats, combinedStats.tenacity) : 1,
         // TODO: does this need to be phys/magic split?
         wdMulti: wdMulti(levelStats, classJobStats, wdEffective),
         mainStatMulti: mainStatMulti(levelStats, classJobStats, mainStat),
         aaStatMulti: mainStatMulti(levelStats, classJobStats, aaStat),
         traitMulti: classJobStats.traitMulti ? (type) => classJobStats.traitMulti(level, type) : () => 1,
-        autoDhBonus: autoDhBonusDmg(levelStats, withPartyBonus.dhit),
-        mpPerTick: mpTick(levelStats, withPartyBonus.piety),
-        aaMulti: autoAttackModifier(levelStats, classJobStats, withPartyBonus.weaponDelay, withPartyBonus.wdPhys),
+        autoDhBonus: autoDhBonusDmg(levelStats, combinedStats.dhit),
+        mpPerTick: mpTick(levelStats, combinedStats.piety),
+        aaMulti: autoAttackModifier(levelStats, classJobStats, combinedStats.weaponDelay, combinedStats.wdPhys),
         aaDelay: combinedStats.weaponDelay
     };
     // TODO: should this just apply to all main stats, even ones that are irrelevant to the class?
-    computedStats[mainStatKey] = mainStat;
-    computedStats[aaStatKey] = aaStat;
+    // computedStats[mainStatKey] = mainStat;
+    // computedStats[aaStatKey] = aaStat;
     if (classJobStats.traits) {
         classJobStats.traits.forEach(trait => {
             if (trait.minLevel && trait.minLevel > level) {


### PR DESCRIPTION
Fixes issue with order of operations when computing vit when you have both food and a party bonus.