### PR TITLE
Add ability to have stat caps on custom items

### DIFF
--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -170,7 +170,7 @@ export class CustomItem implements GearItem {
     }
 
     private applyIlvlData(nativeIlvlInfo: IlvlSyncInfo, syncIlvlInfo?: IlvlSyncInfo) {
-        if (this.respectCaps) {
+        if (this.respectCaps && nativeIlvlInfo) {
             const statCapsNative = {};
             Object.entries(this.stats).forEach(([stat, _]) => {
                 statCapsNative[stat] = nativeIlvlInfo.substatCap(this.occGearSlotName, stat as RawStatKey);

--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -6,10 +6,14 @@ import {
     GearItem,
     MateriaSlot,
     OccGearSlotKey,
+    RawStatKey,
     RawStats
 } from "@xivgear/xivmath/geartypes";
 import {xivApiIconUrl} from "../external/xivapi";
 import {CURRENT_MAX_LEVEL, LEVEL_ITEMS, MATERIA_LEVEL_MAX_NORMAL} from "@xivgear/xivmath/xivconstants";
+import {IlvlSyncInfo} from "../datamanager_xivapi";
+import {applyStatCaps} from "../gear";
+import {GearPlanSheet} from "../sheet";
 
 export type CustomItemExport = {
     ilvl: number;
@@ -21,6 +25,7 @@ export type CustomItemExport = {
     slot: OccGearSlotKey;
     isUnique: boolean;
     stats: RawStats;
+    respectCaps: boolean;
 }
 
 export class CustomItem implements GearItem {
@@ -37,17 +42,16 @@ export class CustomItem implements GearItem {
     primarySubstat: keyof RawStats = null;
     secondarySubstat: keyof RawStats = null;
     // statCaps: { determination?: number; piety?: number; crit?: number; dhit?: number; spellspeed?: number; skillspeed?: number; tenacity?: number; hp?: number; vitality?: number; strength?: number; dexterity?: number; intelligence?: number; mind?: number; wdPhys?: number; wdMag?: number; weaponDelay?: number; };
-    // TODO: syncing and stat caps not supported
     statCaps = {};
-    // TODO
     iconUrl: URL = new URL(xivApiIconUrl(26270));
     private _data: CustomItemExport;
 
-    private constructor(exportedData: CustomItemExport) {
+    private constructor(exportedData: CustomItemExport, private readonly sheet: GearPlanSheet) {
         this._data = exportedData;
+        this.recheckStats();
     }
 
-    private static defaults(): Omit<CustomItemExport, 'fakeId' | 'name' | 'slot'> {
+    private static defaults(): Omit<CustomItemExport, 'fakeId' | 'name' | 'slot' | 'respectCaps'> {
         return {
             isUnique: false,
             ilvl: LEVEL_ITEMS[CURRENT_MAX_LEVEL].minILvl,
@@ -58,22 +62,33 @@ export class CustomItem implements GearItem {
         };
     }
 
-    static fromExport(exportedData: CustomItemExport): CustomItem {
+    static fromExport(exportedData: CustomItemExport, sheet: GearPlanSheet): CustomItem {
         // Copy the defaults so that new fields can be added to existing items
         return new CustomItem({
             ...this.defaults(),
+            // respectCaps is false for existing items to not cause changes to sheets
+            respectCaps: false,
             ...exportedData
-        });
+        }, sheet);
     }
 
-    static fromScratch(fakeId: number, slot: OccGearSlotKey): CustomItem {
+    static fromScratch(fakeId: number, slot: OccGearSlotKey, sheet: GearPlanSheet): CustomItem {
         const data: CustomItemExport = {
             ...this.defaults(),
             fakeId: fakeId,
             name: "My Custom " + slot,
+            // respectCaps is true for new items
+            respectCaps: true,
             slot: slot,
         };
-        return new CustomItem(data);
+        return new CustomItem(data, sheet);
+    }
+
+    recheckStats(): void {
+        const nativeInfo = this.sheet.ilvlSyncInfo(this.ilvl);
+        const syncIlvl = this.sheet.ilvlSync;
+        const syncInfo = syncIlvl === undefined ? undefined : this.sheet.ilvlSyncInfo(syncIlvl);
+        this.applyIlvlData(nativeInfo, syncInfo);
     }
 
     export(): CustomItemExport {
@@ -82,6 +97,20 @@ export class CustomItem implements GearItem {
 
     get ilvl() {
         return this._data.ilvl;
+    }
+
+    set ilvl(ilvl: number) {
+        this._data.ilvl = ilvl;
+        this.recheckStats();
+    }
+
+    get respectCaps() {
+        return this._data.respectCaps;
+    }
+
+    set respectCaps(respectCaps: boolean) {
+        this._data.respectCaps = respectCaps;
+        this.recheckStats();
     }
 
     get isUnique() {
@@ -100,8 +129,8 @@ export class CustomItem implements GearItem {
         return DisplayGearSlotInfo[this.displayGearSlotName];
     }
 
-    get stats() {
-        return this._data.stats;
+    get stats(): RawStats {
+        return applyStatCaps(this._data.stats, this.statCaps);
     }
 
     get displayGearSlotName(): DisplayGearSlotKey {
@@ -111,7 +140,11 @@ export class CustomItem implements GearItem {
         return this.occGearSlotName;
     }
 
+    // TODO: this should be read-only
     get materiaSlots(): MateriaSlot[] {
+        if (this.isSyncedDown) {
+            return [];
+        }
         const out: MateriaSlot[] = [];
         for (let i = 0; i < this._data.largeMateriaSlots; i++) {
             out.push({
@@ -134,6 +167,69 @@ export class CustomItem implements GearItem {
 
     get customData(): CustomItemExport {
         return this._data;
+    }
+
+    private applyIlvlData(nativeIlvlInfo: IlvlSyncInfo, syncIlvlInfo?: IlvlSyncInfo) {
+        if (this.respectCaps) {
+            const statCapsNative = {};
+            Object.entries(this.stats).forEach(([stat, _]) => {
+                statCapsNative[stat] = nativeIlvlInfo.substatCap(this.occGearSlotName, stat as RawStatKey);
+            });
+            this.statCaps = statCapsNative;
+            if (syncIlvlInfo && syncIlvlInfo.ilvl < this.ilvl) {
+                this.unsyncedVersion = {
+                    ...this,
+                    stats: {...this.customData.stats}
+                };
+                const statCapsSync = {};
+                Object.entries(this.stats).forEach(([stat, v]) => {
+                    statCapsSync[stat] = syncIlvlInfo.substatCap(this.occGearSlotName, stat as RawStatKey);
+                });
+                this.statCaps = statCapsSync;
+                this.isSyncedDown = true;
+            }
+            else {
+                this.unsyncedVersion = this;
+                this.isSyncedDown = false;
+            }
+        }
+        else {
+            this.statCaps = {};
+            this.unsyncedVersion = this;
+            this.isSyncedDown = false;
+        }
+        this.computeSubstats();
+    }
+
+    private computeSubstats() {
+        const sortedStats = Object.entries({
+            crit: this.customData.stats.crit,
+            dhit: this.customData.stats.dhit,
+            determination: this.customData.stats.determination,
+            spellspeed: this.customData.stats.spellspeed,
+            skillspeed: this.customData.stats.skillspeed,
+            piety: this.customData.stats.piety,
+            tenacity: this.customData.stats.tenacity,
+        })
+            .sort((left, right) => {
+                if (left[1] > right[1]) {
+                    return 1;
+                }
+                else if (left[1] < right[1]) {
+                    return -1;
+                }
+                return 0;
+            })
+            .filter(item => item[1])
+            .reverse();
+        if (sortedStats.length < 2) {
+            this.primarySubstat = null;
+            this.secondarySubstat = null;
+        }
+        else {
+            this.primarySubstat = sortedStats[0][0] as keyof RawStats;
+            this.secondarySubstat = sortedStats[1][0] as keyof RawStats;
+        }
     }
 
 }

--- a/packages/core/src/datamanager.ts
+++ b/packages/core/src/datamanager.ts
@@ -2,6 +2,7 @@ import {JobName, SupportedLevel} from "@xivgear/xivmath/xivconstants";
 import {FoodItem, GearItem, JobMultipliers, Materia, OccGearSlotKey, RawStatKey,} from "@xivgear/xivmath/geartypes";
 // import {XivApiDataManager} from "./datamanager_xivapi";
 import {NewApiDataManager} from "./datamanager_new";
+import {IlvlSyncInfo} from "./datamanager_xivapi";
 
 /**
  * Mapping for BaseParam to BaseParamInfo.
@@ -37,6 +38,8 @@ export interface DataManager {
     loadData(): Promise<void>;
 
     multipliersForJob(job: JobName): JobMultipliers;
+
+    getIlvlSyncInfo(ilvl: number): IlvlSyncInfo | undefined;
 }
 
 export function makeDataManager(classJob: JobName, level: SupportedLevel, ilvlSync?: number | undefined) {

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -101,6 +101,7 @@ export class NewApiDataManager implements DataManager {
     private _jobMultipliers: Map<JobName, JobMultipliers>;
     private _baseParams: BaseParamMap;
     private _isyncPromise: Promise<Map<number, IlvlSyncInfo>>;
+    private _isyncData: Map<number, IlvlSyncInfo>;
 
     private queryBaseParams() {
         return this.apiClient.baseParams.baseParams()
@@ -187,6 +188,7 @@ export class NewApiDataManager implements DataManager {
                     } as const);
 
                 }
+                this._isyncData = outMap;
                 return outMap;
             });
         }
@@ -410,6 +412,10 @@ export class NewApiDataManager implements DataManager {
 
     get classJob(): JobName {
         return this._classJob;
+    }
+
+    getIlvlSyncInfo(ilvl: number): IlvlSyncInfo | undefined {
+        return this._isyncData.get(ilvl);
     }
 }
 

--- a/packages/core/src/datamanager_xivapi.ts
+++ b/packages/core/src/datamanager_xivapi.ts
@@ -100,6 +100,7 @@ export class XivApiDataManager implements DataManager {
     private _jobMultipliers: Map<JobName, JobMultipliers>;
     private _baseParams: BaseParamMap;
     private _isyncPromise: Promise<Map<number, IlvlSyncInfo>>;
+    private _isyncData: Map<number, IlvlSyncInfo>;
 
     async getIlvlSyncData(baseParamPromise: ReturnType<typeof queryBaseParams>, ilvl: number) {
         if (this._isyncPromise === undefined) {
@@ -141,6 +142,7 @@ export class XivApiDataManager implements DataManager {
                     } as const);
 
                 }
+                this._isyncData = outMap;
                 return outMap;
             });
         }
@@ -391,6 +393,10 @@ export class XivApiDataManager implements DataManager {
 
     get classJob(): JobName {
         return this._classJob;
+    }
+
+    getIlvlSyncInfo(ilvl: number): IlvlSyncInfo {
+        return this._isyncData.get(ilvl);
     }
 }
 

--- a/packages/core/src/test/custom_items_test.ts
+++ b/packages/core/src/test/custom_items_test.ts
@@ -4,7 +4,7 @@ import {CharacterGearSet} from "../gear";
 import 'global-jsdom/register';
 
 describe('Custom items support', () => {
-    it('Supports a custom item', async () => {
+    it('Supports a custom item with ignored caps', async () => {
         // Setup
         const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined);
         await sheet.load();
@@ -15,10 +15,13 @@ describe('Custom items support', () => {
 
         // Make custom item
         const custom = sheet.newCustomItem('Weapon2H');
-        custom.stats.wdMag = 200;
-        custom.stats.wdPhys = 200;
-        custom.stats.spellspeed = 500;
-        custom.stats.mind = 1000;
+        const customStats = custom.customData.stats;
+        customStats.wdMag = 200;
+        customStats.wdPhys = 200;
+        customStats.spellspeed = 500;
+        customStats.mind = 1000;
+        custom.respectCaps = false;
+        sheet.recheckCustomItems();
 
         const gearItem = sheet.itemById(custom.id);
         // Should be exactly the same object, there's no cloning going on
@@ -30,6 +33,150 @@ describe('Custom items support', () => {
         set1.setEquip('Weapon', custom);
         set2.setEquip('Weapon', custom);
 
+
+        expect(set1.computedStats.wdPhys).to.eq(200);
+        expect(set1.computedStats.wdMag).to.eq(200);
+
+        expect(set2.computedStats.wdPhys).to.eq(200);
+        expect(set2.computedStats.wdMag).to.eq(200);
+
+        // now make it respect caps and expect it to change
+        custom.respectCaps = true;
+        sheet.recheckCustomItems();
+        expect(set1.computedStats.wdPhys).to.eq(127);
+        expect(set1.computedStats.wdMag).to.eq(127);
+
+        expect(set2.computedStats.wdPhys).to.eq(127);
+        expect(set2.computedStats.wdMag).to.eq(127);
+
+    }).timeout(30_000);
+    it('Supports a custom item with respected caps', async () => {
+        // Setup
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined);
+        await sheet.load();
+
+        // Make one set before adding the custom item to make sure we can still use it.
+        const set1 = new CharacterGearSet(sheet);
+        sheet.addGearSet(set1);
+
+        // Make custom item
+        const custom = sheet.newCustomItem('Weapon2H');
+        const customStats = custom.customData.stats;
+        customStats.wdMag = 200;
+        customStats.wdPhys = 200;
+        customStats.spellspeed = 500;
+        customStats.mind = 1000;
+        sheet.recheckCustomItems();
+
+        const gearItem = sheet.itemById(custom.id);
+        // Should be exactly the same object, there's no cloning going on
+        expect(gearItem).eq(custom);
+
+        const set2 = new CharacterGearSet(sheet);
+        sheet.addGearSet(set2);
+
+        set1.setEquip('Weapon', custom);
+        set2.setEquip('Weapon', custom);
+
+        expect(set1.computedStats.wdPhys).to.eq(127);
+        expect(set1.computedStats.wdMag).to.eq(127);
+
+        expect(set2.computedStats.wdPhys).to.eq(127);
+        expect(set2.computedStats.wdMag).to.eq(127);
+
+        // now make it ignore caps and expect it to change
+        custom.respectCaps = false;
+        sheet.recheckCustomItems();
+        expect(set1.computedStats.wdPhys).to.eq(200);
+        expect(set1.computedStats.wdMag).to.eq(200);
+
+        expect(set2.computedStats.wdPhys).to.eq(200);
+        expect(set2.computedStats.wdMag).to.eq(200);
+    }).timeout(30_000);
+
+    it('Supports a custom item with ignored caps + isync', async () => {
+        // Setup
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, 635);
+        await sheet.load();
+
+        // Make one set before adding the custom item to make sure we can still use it.
+        const set1 = new CharacterGearSet(sheet);
+        sheet.addGearSet(set1);
+
+        // Make custom item
+        const custom = sheet.newCustomItem('Weapon2H');
+        const customStats = custom.customData.stats;
+        customStats.wdMag = 200;
+        customStats.wdPhys = 200;
+        customStats.spellspeed = 500;
+        customStats.mind = 1000;
+        custom.respectCaps = false;
+        sheet.recheckCustomItems();
+
+        const gearItem = sheet.itemById(custom.id);
+        // Should be exactly the same object, there's no cloning going on
+        expect(gearItem).eq(custom);
+
+        const set2 = new CharacterGearSet(sheet);
+        sheet.addGearSet(set2);
+
+        set1.setEquip('Weapon', custom);
+        set2.setEquip('Weapon', custom);
+
+
+        expect(set1.computedStats.wdPhys).to.eq(200);
+        expect(set1.computedStats.wdMag).to.eq(200);
+
+        expect(set2.computedStats.wdPhys).to.eq(200);
+        expect(set2.computedStats.wdMag).to.eq(200);
+
+        // now make it respect caps and expect it to change
+        custom.respectCaps = true;
+        sheet.recheckCustomItems();
+        expect(set1.computedStats.wdPhys).to.eq(126);
+        expect(set1.computedStats.wdMag).to.eq(126);
+
+        expect(set2.computedStats.wdPhys).to.eq(126);
+        expect(set2.computedStats.wdMag).to.eq(126);
+
+    }).timeout(30_000);
+    it('Supports a custom item with respected caps + isync', async () => {
+        // Setup
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, 635);
+        await sheet.load();
+
+        // Make one set before adding the custom item to make sure we can still use it.
+        const set1 = new CharacterGearSet(sheet);
+        sheet.addGearSet(set1);
+
+        // Make custom item
+        const custom = sheet.newCustomItem('Weapon2H');
+        const customStats = custom.customData.stats;
+        customStats.wdMag = 200;
+        customStats.wdPhys = 200;
+        customStats.spellspeed = 500;
+        customStats.mind = 1000;
+        sheet.recheckCustomItems();
+
+        const gearItem = sheet.itemById(custom.id);
+        // Should be exactly the same object, there's no cloning going on
+        expect(gearItem).eq(custom);
+
+        const set2 = new CharacterGearSet(sheet);
+        sheet.addGearSet(set2);
+
+        set1.setEquip('Weapon', custom);
+        set2.setEquip('Weapon', custom);
+
+        expect(set1.computedStats.wdPhys).to.eq(126);
+        expect(set1.computedStats.wdMag).to.eq(126);
+
+        expect(set2.computedStats.wdPhys).to.eq(126);
+        expect(set2.computedStats.wdMag).to.eq(126);
+
+        // now change it to ignore caps and check that the result changes
+        custom.respectCaps = false;
+        sheet.recheckCustomItems();
         expect(set1.computedStats.wdPhys).to.eq(200);
         expect(set1.computedStats.wdMag).to.eq(200);
 
@@ -37,6 +184,8 @@ describe('Custom items support', () => {
         expect(set2.computedStats.wdMag).to.eq(200);
 
     }).timeout(30_000);
+
+
     it('Supports a custom food', async () => {
         const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined);
         await sheet.load();


### PR DESCRIPTION
The item level box has a "cap" checkbox which will cause it to respect item level caps:
![image](https://github.com/user-attachments/assets/40f9977d-12bb-4015-beff-a035db7a51a3)

You will get a validation error (which you can ignore - it does not block saving) if there is no known ilvl data for the chosen item level:

![image](https://github.com/user-attachments/assets/b4171e2a-071c-46ac-977d-8854027812bb)

Existing custom items will default to ignoring caps, while new ones will default to respecting caps.

Closes #259 