### PR TITLE
Fix sim end time

### DIFF
--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -1423,6 +1423,7 @@ export interface CycleSimResult extends SimResult {
     unbuffedPps: number,
     buffTimings: readonly BuffUsage[],
     totalDamage: ValueWithDev,
+    totalTime: number,
     mainDpsFull: ValueWithDev,
     label: string
 }

--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -132,6 +132,7 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
             "Expected +2σ": applyStdDev(result.mainDpsFull, 2),
             "Expected +3σ": applyStdDev(result.mainDpsFull, 3),
             "Unbuffed PPS": result.unbuffedPps,
+            "Time Taken": result.totalTime
         };
         if (includeRotationName) {
             data["Rotation"] = result.label
@@ -221,7 +222,8 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
 
             const used = cp.finalizedRecords.filter(isFinalizedAbilityUse);
             const totalDamage = addValues(...used.map(used => used.totalDamageFull));
-            const dps = multiplyFixed(totalDamage, 1.0 / cp.currentTime);
+            const timeBasis = Math.min(cp.totalTime, cp.currentTime);
+            const dps = multiplyFixed(totalDamage, 1.0 / timeBasis);
             const unbuffedPps = sum(used.map(used => used.totalPotency)) / cp.nextGcdTime;
             const buffTimings = [...cp.buffHistory];
 
@@ -233,6 +235,7 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
                 displayRecords: cp.finalizedRecords,
                 unbuffedPps: unbuffedPps,
                 buffTimings: buffTimings,
+                totalTime: timeBasis,
                 label: rot.name ?? `Unnamed #${index + 1}`,
             } satisfies CycleSimResult as unknown as ResultType;
         });

--- a/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
+++ b/packages/frontend/src/scripts/test/sims/cycle_processor_tests.ts
@@ -401,7 +401,7 @@ describe('Cycle sim processor', () => {
         // Run simulation
         const result = await inst.simulate(set);
         // Assert correct results
-        assertClose(result.mainDpsResult, 10043.635, 0.01);
+        assertClose(result.mainDpsResult, 10184.246, 0.01);
         assertSimAbilityResults(result, expectedAbilities);
     });
 });


### PR DESCRIPTION
Closes #282 

Changes the effective duration to be the smaller of the sim's current time (in case the rotation did not specify any more abilities to use) or the specified time, since it already pro-rates incomplete GCDs.