### PR TITLE
Fix for Pld SKS Sim near Infinite Loop

### DIFF
--- a/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld/pldsks_sim.ts
@@ -985,6 +985,10 @@ export class PldSKSSheetSim extends BaseMultiCycleSim<PldSKSSheetSimResult, PldS
                             {
                                 enough_time_if_melee = false;
                             }
+
+                            // Fix 'time runs out in middle of burst' infinite loop:
+                            if (cp.remainingGcdTime == 0)
+                                enough_time_if_melee = false;
                         }
 
                         if (!strategy_250)


### PR DESCRIPTION
If the phase was set to end at a particular point, the sim would nearly infinite loop as it found it could fit an 100k+ GCDs into FOF, which would be far more SKS than anyone could reasonably meld...

Since the GCDs took place after time had ended, the sim still calculated DPS correctly. However, opening the sim's table of events would cause the browser to go OOM as it tried to also render 100k comments.