### PR TITLE
Refactor ComputedSetStats

### DIFF
--- a/packages/core/src/datamanager_xivapi.ts
+++ b/packages/core/src/datamanager_xivapi.ts
@@ -235,9 +235,9 @@ export class XivApiDataManager implements DataManager {
                     extraPromises.push(Promise.all([itemIlvlPromise, ilvlSyncPromise]).then(([native, sync]) => {
                         item.applyIlvlData(native, sync);
                         if (item.isCustomRelic) {
-                            console.debug('Applying relic model');
+                            // console.debug('Applying relic model');
                             item.relicStatModel = getRelicStatModelFor(item, this._baseParams, this._classJob);
-                            console.debug('Applied', item.relicStatModel)
+                            // console.debug('Applied', item.relicStatModel)
                         }
                     }));
                 }
@@ -245,9 +245,9 @@ export class XivApiDataManager implements DataManager {
                     extraPromises.push(itemIlvlPromise.then(native => {
                         item.applyIlvlData(native);
                         if (item.isCustomRelic) {
-                            console.debug('Applying relic model');
+                            // console.debug('Applying relic model');
                             item.relicStatModel = getRelicStatModelFor(item, this._baseParams, this._classJob);
-                            console.debug('Applied', item.relicStatModel)
+                            // console.debug('Applied', item.relicStatModel)
                         }
                     }));
                 }

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -46,6 +46,7 @@ import {getNextSheetInternalName} from "./persistence/saved_sheets";
 import {CustomItem} from "./customgear/custom_item";
 import {CustomFood} from "./customgear/custom_food";
 import {IlvlSyncInfo} from "./datamanager_xivapi";
+import {toSerializableForm} from "@xivgear/xivmath/xivstats";
 
 export type SheetCtorArgs = ConstructorParameters<typeof GearPlanSheet>
 export type SheetContstructor<SheetType extends GearPlanSheet> = (...values: SheetCtorArgs) => SheetType;
@@ -410,7 +411,7 @@ export class GearPlanSheet {
             if (fullStats) {
                 const augGs: SetStatsExport = {
                     ...rawExport,
-                    computedStats: set.computedStats
+                    computedStats: toSerializableForm(set.computedStats)
                 };
                 return augGs;
             }

--- a/packages/core/src/sims/common/potion.ts
+++ b/packages/core/src/sims/common/potion.ts
@@ -3,9 +3,8 @@ import {fl, mainStatMulti} from "@xivgear/xivmath/xivmath";
 import {RawStatKey} from "@xivgear/xivmath/geartypes";
 import {camel2title} from "@xivgear/core/util/strutils";
 
-function applyPotionBuff(initialValue: number, bonus: number, cap: number): number {
-    const effectiveBonus = Math.min(fl(initialValue * bonus), cap);
-    return initialValue + effectiveBonus;
+function potionBonus(initialValue: number, bonus: number, cap: number): number {
+    return Math.min(fl(initialValue * bonus), cap);
 }
 
 function makePotion(name: string, stat: RawStatKey, itemId: number, bonus: number, cap: number): Readonly<OgcdAbility> {
@@ -26,14 +25,8 @@ function makePotion(name: string, stat: RawStatKey, itemId: number, bonus: numbe
                 duration: 30,
                 statusId: 0x31,
                 effects: {
-                    modifyStats: original => {
-                        const stats = {...original};
-                        stats[stat] = applyPotionBuff(stats[stat], bonus, cap);
-                        if (stat === stats.jobStats.mainStat) {
-                            stats.mainStatMulti = mainStatMulti(stats.levelStats, stats.jobStats, stats[stats.jobStats.mainStat]);
-                            stats.aaStatMulti = mainStatMulti(stats.levelStats, stats.jobStats, stats[stats.jobStats.autoAttackStat]);
-                        }
-                        return stats;
+                    modifyStats: (stats, bonuses) => {
+                        bonuses[stat] = potionBonus(stats[stat], bonus, cap);
                     }
                 }
             }

--- a/packages/core/src/sims/common/potion.ts
+++ b/packages/core/src/sims/common/potion.ts
@@ -1,5 +1,5 @@
 import {OgcdAbility} from "../sim_types";
-import {fl, mainStatMulti} from "@xivgear/xivmath/xivmath";
+import {fl} from "@xivgear/xivmath/xivmath";
 import {RawStatKey} from "@xivgear/xivmath/geartypes";
 import {camel2title} from "@xivgear/core/util/strutils";
 

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -3,7 +3,7 @@ import {CharacterGearSet} from "../gear";
 import {JobName, SupportedLevel} from "@xivgear/xivmath/xivconstants";
 import {AttackType, ComputedSetStats} from "@xivgear/xivmath/geartypes";
 import {ValueWithDev} from "@xivgear/xivmath/deviation";
-import {RawBonusStats, StatModification} from "@xivgear/xivmath/xivstats";
+import {StatModification} from "@xivgear/xivmath/xivstats";
 
 /**
  * Represents the final result of a simulation run. Sim implementors should extend this type with

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -3,6 +3,7 @@ import {CharacterGearSet} from "../gear";
 import {JobName, SupportedLevel} from "@xivgear/xivmath/xivconstants";
 import {AttackType, ComputedSetStats} from "@xivgear/xivmath/geartypes";
 import {ValueWithDev} from "@xivgear/xivmath/deviation";
+import {RawBonusStats, StatModification} from "@xivgear/xivmath/xivstats";
 
 /**
  * Represents the final result of a simulation run. Sim implementors should extend this type with
@@ -534,7 +535,7 @@ export type BuffEffects = {
     /**
      * Modify stats directly
      */
-    modifyStats?: (stats: ComputedSetStats) => ComputedSetStats;
+    modifyStats?: StatModification;
 };
 
 export type BuffController = {

--- a/packages/frontend/src/scripts/sims/healer/sge_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/healer/sge_sheet_sim.ts
@@ -102,9 +102,10 @@ export class SgeSheetSim implements Simulation<SgeSheetSimResult, SgeSheetSettin
     }
 
     async simulate(set: CharacterGearSet): Promise<SgeSheetSimResult> {
-        const buffedStats = {...set.computedStats};
-        buffedStats.dhitChance += this.extraDhRate();
-        buffedStats.critChance += this.extraCritRate();
+        const buffedStats = set.computedStats.withModifications((stats, bonuses) => {
+            bonuses.dhitChance += this.extraDhRate();
+            bonuses.critChance += this.extraCritRate();
+        });
         const ppsFinalResult = this.pps(buffedStats);
         const resultWithoutDhCrit = baseDamage(buffedStats, ppsFinalResult);
         const result = applyDhCrit(resultWithoutDhCrit, buffedStats);

--- a/packages/frontend/src/scripts/sims/healer/whm_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/healer/whm_sheet_sim.ts
@@ -142,9 +142,10 @@ export class WhmSheetSim implements Simulation<WhmSheetSimResult, WhmSheetSettin
     }
 
     async simulate(set: CharacterGearSet): Promise<WhmSheetSimResult> {
-        const buffedStats = {...set.computedStats};
-        buffedStats.dhitChance += this.extraDhRate();
-        buffedStats.critChance += this.extraCritRate();
+        const buffedStats = set.computedStats.withModifications((stats, bonuses) => {
+            bonuses.dhitChance += this.extraDhRate();
+            bonuses.critChance += this.extraCritRate();
+        });
         const ppsFinalResult = this.pps(buffedStats);
         // const ppsFinalResult = pps(buffedStats.spellspeed, buffedStats.gcdMag, this.settings.c3PerMin, this.settings.m2PerMin, this.settings.rezPerMin);
         // console.log(ppsFinalResult);

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -10,7 +10,7 @@ import {
 
 import {CustomItemExport} from "@xivgear/core/customgear/custom_item";
 import {CustomFoodExport} from "@xivgear/core/customgear/custom_food";
-import {ComputedSetStatsImpl, RawBonusStats, StatModification} from "./xivstats";
+import {RawBonusStats, StatModification} from "./xivstats";
 
 export interface DisplayGearSlot {
 

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -10,6 +10,7 @@ import {
 
 import {CustomItemExport} from "@xivgear/core/customgear/custom_item";
 import {CustomFoodExport} from "@xivgear/core/customgear/custom_food";
+import {ComputedSetStatsImpl, RawBonusStats, StatModification} from "./xivstats";
 
 export interface DisplayGearSlot {
 
@@ -229,20 +230,19 @@ export interface ComputedSetStats extends RawStats {
     /**
      * Current level
      */
-    level: number,
+    readonly level: number,
     /**
      * Current level stats modifier
      */
-    levelStats: LevelStats,
+    readonly levelStats: LevelStats,
     /**
      * Current class/job
      */
-    job: JobName,
+    readonly job: JobName,
     /**
      * Job modifier data
      */
-    jobStats: JobData,
-
+    readonly jobStats: JobData,
     /**
      * Physical GCD time
      */
@@ -261,74 +261,74 @@ export interface ComputedSetStats extends RawStats {
     /**
      * Crit chance. Ranges from 0 to 1.
      */
-    critChance: number,
+    readonly critChance: number,
     /**
      * Crit multiplier. 1.0 would be the base, e.g. +50% would be 1.5.
      */
-    critMulti: number,
+    readonly critMulti: number,
     /**
      * Direct hit chance. Ranges from 0 to 1.
      */
-    dhitChance: number,
+    readonly dhitChance: number,
     /**
      * Direct hit multiplier. Fixed at 1.25.
      */
-    dhitMulti: number,
+    readonly dhitMulti: number,
     /**
      * Multiplier from determination stat.
      */
-    detMulti: number,
+    readonly detMulti: number,
     /**
      * Spell Speed DoT multiplier.
      */
-    spsDotMulti: number,
+    readonly spsDotMulti: number,
     /**
      * Skill Speed DoT multiplier.
      */
-    sksDotMulti: number,
+    readonly sksDotMulti: number,
     /**
      * Tenacity Multiplier
      */
-    tncMulti: number,
+    readonly tncMulti: number,
     /**
      * Tenacity incoming multiplier. e.g. 0.95 => 5% damage reduction.
      */
-    tncIncomingMulti: number,
+    readonly tncIncomingMulti: number,
     /**
      * Multiplier from weapon damage.
      */
-    wdMulti: number,
+    readonly wdMulti: number,
     /**
      * Multiplier from main stat.
      */
-    mainStatMulti: number
+    readonly mainStatMulti: number
     /**
      * Like mainStatMulti, but for auto-attacks (since healers and casters use STR for autos but MND/INT for everything
      * else).
      */
-    aaStatMulti: number
-
+    readonly aaStatMulti: number
     /**
      * Trait multiplier
      */
     traitMulti(attackType: AttackType): number;
-
     /**
      * Bonus added to det multiplier for automatic direct hits
      */
-    autoDhBonus: number;
+    readonly autoDhBonus: number;
     /**
      * MP Per Tick
      */
-    mpPerTick: number;
+    readonly mpPerTick: number;
     /**
      * Like wdMulti, but for auto-attacks
      */
-    aaMulti: number;
+    readonly aaMulti: number;
     /**
      * Auto-attack delay
      */
-    aaDelay: number;
+    readonly aaDelay: number;
+
+    withModifications(modifications: StatModification): ComputedSetStats;
 }
 
 export interface MeldableMateriaSlot {
@@ -537,7 +537,7 @@ export interface JobData extends JobDataConst {
 export interface JobTrait {
     minLevel?: number,
     maxLevel?: number,
-    apply: (stats: ComputedSetStats) => void;
+    apply: (stats: RawBonusStats) => void;
 }
 
 export class GearSlotItem {

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -206,11 +206,10 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
         ...STANDARD_MELEE,
         traits: [{
             apply: stats => {
-                const oldHaste = stats.haste;
-                stats.haste = attackType => oldHaste(attackType)
-                    + ((attackType === 'Weaponskill'
-                        || attackType === 'Spell'
-                        || attackType === 'Auto-attack')
+                stats.bonusHaste.push(attackType =>
+                    attackType === 'Weaponskill'
+                    || attackType === 'Spell'
+                    || attackType === 'Auto-attack'
                         ? 20 : 0);
             }
         }]
@@ -221,9 +220,8 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
         autoAttackStat: "dexterity",
         traits: [{
             apply: stats => {
-                const oldHaste = stats.haste;
-                stats.haste = attackType => oldHaste(attackType)
-                    + ((attackType === 'Weaponskill' || attackType === 'Auto-attack') ? 15 : 0);
+                stats.bonusHaste.push(attackType =>
+                    attackType === 'Weaponskill' || attackType === 'Auto-attack' ? 15 : 0);
             }
         }
         ]

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -1,4 +1,5 @@
 import {
+    AttackType,
     ComputedSetStats,
     FoodBonuses,
     FoodStatBonus,
@@ -28,6 +29,7 @@ import {
     wdMulti
 } from "./xivmath";
 import {JobName, SupportedLevel} from "./xivconstants";
+import {sum} from "@xivgear/core/util/array_utils";
 
 /**
  * Adds the stats of 'addedStats' into 'baseStats'.
@@ -44,7 +46,349 @@ export function addStats(baseStats: RawStats, addedStats: RawStats): void {
     }
 }
 
+/**
+ * Function from an attack type to a haste amount. Haste amount is percentage, e.g. 20 haste = 20% faster.
+ */
+export type HasteBonus = (attackType: AttackType) => number;
+
+/**
+ * Represents a post-computation stat modification (e.g. a crit chance buff).
+ *
+ * The modifier should modify the 'bonuses' object in-place.
+ */
+export type StatModification = (stats: ComputedSetStats, bonuses: RawBonusStats) => void;
+
+/**
+ * Represents post-computation stat modifications.
+ */
+export class RawBonusStats extends RawStats {
+    critChance: number = 0;
+    critDmg: number = 0;
+    dhitChance: number = 0;
+    dhitDmg: number = 0;
+    detMulti: number = 0;
+    bonusHaste: HasteBonus[] = [];
+    forceCrit: boolean = false;
+    forceDh: boolean = false;
+}
+
+function clamp(min: number, max: number, value: number) {
+    return Math.max(Math.min(value, max), min);
+}
+
+/**
+ * Transform a ComputedSetStats into a form that serializes properly. That is, it serializes the getters rather
+ * than only the backing data. This is realistically what you would want out of the fulldata API endpoint.
+ *
+ * @param stats
+ */
+export function toSerializableForm(stats: ComputedSetStats): ComputedSetStats {
+    // The purpose of this is that the fullstats API won't correctly serialize the ComputedSetStatsImpl normally.
+    // We care about the
+    return new Proxy(stats, {
+        get(target, prop, receiver) {
+            // Check if the property is a getter on the prototype chain
+            let descriptor = Object.getOwnPropertyDescriptor(target, prop as string);
+            let proto = Object.getPrototypeOf(target);
+
+            while (!descriptor && proto) {
+                descriptor = Object.getOwnPropertyDescriptor(proto, prop as string);
+                proto = Object.getPrototypeOf(proto);
+            }
+
+            if (descriptor && typeof descriptor.get === 'function') {
+                return descriptor.get.call(target);
+            }
+
+            return Reflect.get(target, prop, receiver);
+        },
+        ownKeys(target) {
+            const keys = new Set<string | symbol>();
+
+            let obj: object = target;
+            while (obj) {
+                Reflect.ownKeys(obj).forEach((key) => {
+                    if (typeof key === 'string' && !key.startsWith('_')) {
+                        const descriptor = Object.getOwnPropertyDescriptor(obj, key);
+                        if (descriptor && typeof descriptor.get === 'function') {
+                            keys.add(key);
+                        }
+                    }
+                });
+                obj = Object.getPrototypeOf(obj);
+            }
+
+            return Array.from(keys);
+        },
+        getOwnPropertyDescriptor(target, prop) {
+            const descriptor = Object.getOwnPropertyDescriptor(target, prop) ||
+                Object.getOwnPropertyDescriptor(Object.getPrototypeOf(target), prop);
+
+            if (
+                descriptor &&
+                typeof descriptor.get === 'function' &&
+                typeof prop === 'string' &&
+                !prop.startsWith('_')
+            ) {
+                return {
+                    enumerable: true,
+                    configurable: true,
+                };
+            }
+            return undefined;
+        },
+    });
+}
+
+/**
+ * ComputedSetStats implementation.
+ *
+ * Unlike the old ComputedSetStats, this should not be modified. Rather, if a modified version is required,
+ * then the {@link #withModifications} method should be used, which will apply the allowable modifications and
+ * return a new object. Derived values do not need to be explicitly recomputed, e.g. if you apply a main stat bonus,
+ * the main stat multiplier will take effect automatically.
+ */
+export class ComputedSetStatsImpl implements ComputedSetStats {
+
+    protected readonly finalBonusStats: RawBonusStats;
+    private currentStats: RawStats;
+
+    constructor(
+        private readonly gearStats: RawStats,
+        private readonly foodStats: FoodBonuses,
+        readonly level: SupportedLevel,
+        readonly levelStats: LevelStats,
+        private readonly classJob: JobName,
+        private readonly classJobStats: JobData,
+        private readonly partyBonus: PartyBonusAmount,
+    ) {
+        this.finalBonusStats = new RawBonusStats();
+        // TODO: order of operations here
+        this.recalc();
+        if (classJobStats.traits) {
+            classJobStats.traits.forEach(trait => {
+                if (trait.minLevel && trait.minLevel > level) {
+                    return;
+                }
+                if (trait.maxLevel && trait.maxLevel < level) {
+                    return;
+                }
+                trait.apply(this.finalBonusStats);
+            });
+        }
+    }
+
+    private recalc() {
+        this.currentStats = finalizeStatsInt(
+            this.gearStats,
+            this.foodStats,
+            this.level,
+            this.levelStats,
+            this.classJob,
+            this.classJobStats,
+            this.partyBonus,
+        )
+    }
+
+    withModifications(modifications: StatModification): ComputedSetStatsImpl {
+        const out = new ComputedSetStatsImpl(
+            this.gearStats,
+            this.foodStats,
+            this.level,
+            this.levelStats,
+            this.classJob,
+            this.classJobStats,
+            this.partyBonus
+        );
+        modifications(out, out.finalBonusStats);
+        return out;
+    }
+
+    gcdPhys(baseGcd: number, haste?: number): number {
+        return sksToGcd(baseGcd, this.levelStats, this.skillspeed, haste);
+    }
+
+    gcdMag(baseGcd: number, haste?: number): number {
+        return spsToGcd(baseGcd, this.levelStats, this.spellspeed, haste);
+    }
+
+    haste(attackType: AttackType): number {
+        return sum(this.finalBonusStats.bonusHaste.map(hb => hb(attackType)));
+    }
+
+    traitMulti(attackType: AttackType): number {
+        return this.classJobStats.traitMulti(this.level, attackType);
+    }
+
+    get hp(): number {
+        return this.currentStats.hp + this.finalBonusStats.hp + vitToHp(this.levelStats, this.classJobStats, this.vitality);
+    }
+
+    get vitality(): number {
+        return this.currentStats.vitality + this.finalBonusStats.vitality;
+    }
+
+    get strength(): number {
+        return this.currentStats.strength + this.finalBonusStats.strength;
+    }
+
+    get dexterity(): number {
+        return this.currentStats.dexterity + this.finalBonusStats.dexterity;
+    }
+
+    get intelligence(): number {
+        return this.currentStats.intelligence + this.finalBonusStats.intelligence;
+    }
+
+    get mind(): number {
+        return this.currentStats.mind + this.finalBonusStats.mind;
+    }
+
+    get piety(): number {
+        return this.currentStats.piety + this.finalBonusStats.piety;
+    }
+
+    get crit(): number {
+        return this.currentStats.crit + this.finalBonusStats.crit;
+    }
+
+    get dhit(): number {
+        return this.currentStats.dhit + this.finalBonusStats.dhit;
+    }
+
+    get determination(): number {
+        return this.currentStats.determination + this.finalBonusStats.determination;
+    }
+
+    get tenacity(): number {
+        return this.currentStats.tenacity + this.finalBonusStats.tenacity;
+    }
+
+    get skillspeed(): number {
+        return this.currentStats.skillspeed + this.finalBonusStats.skillspeed;
+    }
+
+    get spellspeed(): number {
+        return this.currentStats.spellspeed + this.finalBonusStats.spellspeed;
+    }
+
+    get wdPhys(): number {
+        return this.currentStats.wdPhys + this.finalBonusStats.wdPhys;
+    }
+
+    get wdMag(): number {
+        return this.currentStats.wdMag + this.finalBonusStats.wdMag;
+    }
+
+    get weaponDelay(): number {
+        const result = this.currentStats.weaponDelay + this.finalBonusStats.weaponDelay;
+        if (result <= 0) {
+            // Return large value since that's better than trying to divide by zero
+            return 100_000;
+        }
+        return result;
+    }
+
+    get job(): JobName {
+        return this.classJob;
+    }
+
+    get jobStats(): JobData {
+        return this.classJobStats;
+    }
+
+    get critChance(): number {
+        if (this.finalBonusStats.forceCrit) {
+            return 1;
+        }
+        return clamp(0, 1, critChance(this.levelStats, this.crit) + this.finalBonusStats.critChance);
+    }
+
+    get critMulti(): number {
+        return critDmg(this.levelStats, this.crit) + this.finalBonusStats.critDmg;
+    };
+
+    get dhitChance(): number {
+        if (this.finalBonusStats.forceDh) {
+            return 1;
+        }
+        return clamp(0, 1, dhitChance(this.levelStats, this.dhit) + this.finalBonusStats.dhitChance);
+    };
+
+    get dhitMulti(): number {
+        return dhitDmg(this.levelStats, this.dhit) + this.finalBonusStats.dhitDmg;
+    };
+
+    get detMulti(): number {
+        return detDmg(this.levelStats, this.determination) + this.finalBonusStats.detMulti;
+    };
+
+    get spsDotMulti(): number {
+        return spsTickMulti(this.levelStats, this.spellspeed);
+    };
+
+    get sksDotMulti(): number {
+        return sksTickMulti(this.levelStats, this.skillspeed);
+    };
+
+    get tncMulti(): number {
+        return tenacityDmg(this.levelStats, this.tenacity);
+    };
+
+    get tncIncomingMulti(): number {
+        return tenacityIncomingDmg(this.levelStats, this.tenacity);
+    };
+
+    get wdMulti(): number {
+        const wdEffective = Math.max(this.wdMag, this.wdPhys);
+        return wdMulti(this.levelStats, this.classJobStats, wdEffective);
+    };
+
+    get mainStatValue(): number {
+        return this[this.classJobStats.mainStat];
+    }
+
+    get mainStatMulti(): number {
+        return mainStatMulti(this.levelStats, this.classJobStats, this.mainStatValue);
+    };
+
+    get aaStatMulti(): number {
+        return mainStatMulti(this.levelStats, this.classJobStats, this[this.classJobStats.autoAttackStat]);
+    };
+
+    get autoDhBonus(): number {
+        return autoDhBonusDmg(this.levelStats, this.dhit);
+    };
+
+    get mpPerTick(): number {
+        return mpTick(this.levelStats, this.piety);
+    };
+
+    get aaMulti(): number {
+        return autoAttackModifier(this.levelStats, this.classJobStats, this.weaponDelay, this.wdPhys);
+    };
+
+    get aaDelay(): number {
+        return this.weaponDelay;
+    };
+
+}
+
 export function finalizeStats(
+    gearStats: RawStats,
+    foodStats: FoodBonuses,
+    level: SupportedLevel,
+    levelStats: LevelStats,
+    classJob: JobName,
+    classJobStats: JobData,
+    partyBonus: PartyBonusAmount,
+) {
+    return new ComputedSetStatsImpl(
+        gearStats, foodStats, level, levelStats, classJob, classJobStats, partyBonus);
+
+}
+
+function finalizeStatsInt(
     // TODO: gearStats is currently gear + race/job base stuff. Separate these out.
     gearStats: RawStats,
     foodStats: FoodBonuses,
@@ -52,8 +396,8 @@ export function finalizeStats(
     levelStats: LevelStats,
     classJob: JobName,
     classJobStats: JobData,
-    partyBonus: PartyBonusAmount
-): ComputedSetStats {
+    partyBonus: PartyBonusAmount,
+): RawStats {
     const combinedStats: RawStats = {...gearStats};
     const mainStatKey = classJobStats.mainStat;
     const aaStatKey = classJobStats.autoAttackStat;
@@ -70,57 +414,5 @@ export function finalizeStats(
         const extraValue = Math.min(bonus.max, Math.floor(startingValue * (bonus.percentage / 100)));
         combinedStats[stat] += extraValue;
     }
-    const wdEffective = Math.max(combinedStats.wdMag, combinedStats.wdPhys);
-    const hp = combinedStats.hp + vitToHp(levelStats, classJobStats, combinedStats.vitality);
-    const mainStat = combinedStats[mainStatKey];
-    const aaStat = combinedStats[aaStatKey];
-    const computedStats: ComputedSetStats = {
-        ...combinedStats,
-        vitality: combinedStats.vitality,
-        level: level,
-        levelStats: levelStats,
-        job: classJob,
-        jobStats: classJobStats,
-        gcdPhys: (base, haste = 0) => sksToGcd(base, levelStats, combinedStats.skillspeed, haste),
-        gcdMag: (base, haste = 0) => spsToGcd(base, levelStats, combinedStats.spellspeed, haste),
-        haste: () => 0,
-        hp: hp,
-        critChance: critChance(levelStats, combinedStats.crit),
-        critMulti: critDmg(levelStats, combinedStats.crit),
-        dhitChance: dhitChance(levelStats, combinedStats.dhit),
-        dhitMulti: dhitDmg(levelStats, combinedStats.dhit),
-        detMulti: detDmg(levelStats, combinedStats.determination),
-        spsDotMulti: spsTickMulti(levelStats, combinedStats.spellspeed),
-        sksDotMulti: sksTickMulti(levelStats, combinedStats.skillspeed),
-        tncMulti: classJobStats.role === 'Tank' ? tenacityDmg(levelStats, combinedStats.tenacity) : 1,
-        tncIncomingMulti: classJobStats.role === 'Tank' ? tenacityIncomingDmg(levelStats, combinedStats.tenacity) : 1,
-        // TODO: does this need to be phys/magic split?
-        wdMulti: wdMulti(levelStats, classJobStats, wdEffective),
-        mainStatMulti: mainStatMulti(levelStats, classJobStats, mainStat),
-        aaStatMulti: mainStatMulti(levelStats, classJobStats, aaStat),
-        traitMulti: classJobStats.traitMulti ? (type) => classJobStats.traitMulti(level, type) : () => 1,
-        autoDhBonus: autoDhBonusDmg(levelStats, combinedStats.dhit),
-        mpPerTick: mpTick(levelStats, combinedStats.piety),
-        aaMulti: autoAttackModifier(levelStats, classJobStats, combinedStats.weaponDelay, combinedStats.wdPhys),
-        aaDelay: combinedStats.weaponDelay
-    };
-    // TODO: should this just apply to all main stats, even ones that are irrelevant to the class?
-    // computedStats[mainStatKey] = mainStat;
-    // computedStats[aaStatKey] = aaStat;
-    if (classJobStats.traits) {
-        classJobStats.traits.forEach(trait => {
-            if (trait.minLevel && trait.minLevel > level) {
-                return;
-            }
-            if (trait.maxLevel && trait.maxLevel < level) {
-                return;
-            }
-            trait.apply(computedStats);
-        });
-    }
-    if (computedStats.weaponDelay <= 0) {
-        computedStats.weaponDelay = 100_000;
-    }
-    return computedStats;
-
+    return combinedStats;
 }


### PR DESCRIPTION
Refactors ComputedSetStats to have a new class `ComputedSetStatsImpl` handle most of the logic.

`ComputedSetStats` is now immutable, but has a `withModifications` method that returns a clone with the given modifications. Only "safe" modifications are allowed, but more modification points can be added later. 

This keeps ComputedSetStats objects in a consistent state. Take potions for example. Previously, the potion would apply its buff to the main stat, but then the potion logic had to recompute the main stat multiplier and AA multiplier manually. Now, this should happen automatically.

Closes #132 