### PR TITLE
Re-enable gear acqusition source (partial)

### DIFF
--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -63,8 +63,8 @@ async function retryFetch(...params: Parameters<typeof fetch>): Promise<Response
 }
 
 const apiClient = new DataApiClient<never>({
-    // baseUrl: "https://data.xivgear.app",
-    baseUrl: "http://localhost:8085",
+    baseUrl: "https://data.xivgear.app",
+    // baseUrl: "http://localhost:8085",
     customFetch: retryFetch
 });
 

--- a/packages/data-api-client/src/dataapi.ts
+++ b/packages/data-api-client/src/dataapi.ts
@@ -123,6 +123,25 @@ export interface FoodStatBonus {
   max: number;
 }
 
+export enum GearAcquisitionSource {
+  NormalRaid = "NormalRaid",
+  SavageRaid = "SavageRaid",
+  Tome = "Tome",
+  AugTome = "AugTome",
+  Crafted = "Crafted",
+  AugCrafted = "AugCrafted",
+  Relic = "Relic",
+  Dungeon = "Dungeon",
+  ExtremeTrial = "ExtremeTrial",
+  Ultimate = "Ultimate",
+  Artifact = "Artifact",
+  AllianceRaid = "AllianceRaid",
+  Criterion = "Criterion",
+  Other = "Other",
+  Custom = "Custom",
+  Unknown = "Unknown",
+}
+
 export type Icon = XivApiStruct &
   XivApiBase & {
     /** @format int32 */
@@ -143,6 +162,7 @@ export type Item = ItemBase &
     damageMagHQ?: number;
     /** @format int32 */
     damagePhysHQ?: number;
+    acquisitionSource?: GearAcquisitionSource;
   };
 
 export type ItemBase = XivApiObject &

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -854,6 +854,7 @@ export type GearAcquisitionSource =
     | 'ultimate'
     | 'artifact'
     | 'alliance'
+    | 'criterion'
     | 'other'
     | 'custom';
 


### PR DESCRIPTION
Depends on https://github.com/xiv-gear-planner/xivgear-data-api/pull/2

Mostly closes #302 - it works for the most common gear sources.

Also adds Criterion as a source.

Can't finish with this because SpecialShop is the worst sheet in the game and there is no performant way to query it.