### PR TITLE
Expand materia auto-fill settings

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2939,7 +2939,7 @@ body.modern {
   .gear-sheet-midbar-area {
     background-color: var(--button-color);
 
-    button {
+    button, select {
       --button-color: var(--bg-color);
     }
   }

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -26,12 +26,12 @@ import {
     GearSetResult,
     Materia,
     MateriaAutoFillController,
-    MateriaAutoFillPrio,
+    MateriaAutoFillPrio, MateriaMemoryExport,
     NO_SYNC_STATS,
     RawStatKey,
-    RawStats,
+    RawStats, RelicStatMemoryExport,
     RelicStats,
-    SetDisplaySettingsExport,
+    SetDisplaySettingsExport, SlotMateriaMemoryExport,
     XivCombatItem
 } from "@xivgear/xivmath/geartypes";
 import {Inactivitytimer} from "./util/inactivitytimer";
@@ -71,10 +71,6 @@ export class RelicStatMemory {
         Object.entries(relicStatMemory).every(([rawKey, stats]) => this.memory.set(parseInt(rawKey), stats));
     }
 }
-
-export type RelicStatMemoryExport = {
-    [p: number]: RelicStats;
-};
 
 
 // TODO: this is not yet part of exports
@@ -127,11 +123,11 @@ export class MateriaMemory {
             });
             out[slotKey] = items;
         });
-        return Object.fromEntries(this.memory) as unknown as MateriaMemoryExport;
+        return out;
     }
 
     import(memory: MateriaMemoryExport) {
-        Object.entries(memory).every(([slotKey, itemMemory]) => {
+        Object.entries(memory).forEach(([slotKey, itemMemory]) => {
             const slotMap: Map<number, number[]> = new Map();
             for (const itemMemoryElement of itemMemory) {
                 slotMap.set(itemMemoryElement[0], itemMemoryElement[1]);
@@ -140,12 +136,6 @@ export class MateriaMemory {
         });
     }
 }
-
-export type SlotMateriaMemoryExport = [item: number, materiaIds: number[]];
-
-export type MateriaMemoryExport = {
-    [slot in EquipSlotKey]?: SlotMateriaMemoryExport[]
-};
 
 
 export class SetDisplaySettings {

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -289,7 +289,6 @@ export class CharacterGearSet {
     }
 
     setEquip(slot: EquipSlotKey, item: GearItem, materiaAutoFillController?: MateriaAutoFillController) {
-        // TODO: this is also a good place to implement temporary persistent materia entry
         if (this.equipment[slot]?.gearItem === item) {
             return;
         }

--- a/packages/core/src/materia/materia_utils.ts
+++ b/packages/core/src/materia/materia_utils.ts
@@ -1,0 +1,11 @@
+import {Materia, MateriaSlot} from "@xivgear/xivmath/geartypes";
+
+
+export function isMateriaAllowed(materia: Materia, materiaSlot: MateriaSlot) {
+    const highGradeAllowed = materiaSlot.allowsHighGrade;
+    if (materia.isHighGrade && !highGradeAllowed) {
+        return false;
+    }
+    const maxGradeAllowed = materiaSlot.maxGrade;
+    return materia.materiaGrade <= maxGradeAllowed;
+}

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -218,7 +218,7 @@ export class GearPlanSheet {
             // Just picking a bogus value so the user understands what it is
             minGcd: importedData.mfMinGcd ?? 2.05
         };
-        this.materiaFillMode = importedData.mfm ?? 'leave_empty';
+        this.materiaFillMode = importedData.mfm ?? 'retain_item';
 
         if (importedData.customItems) {
             importedData.customItems.forEach(ci => {

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -527,6 +527,9 @@ export class GearPlanSheet {
             if (set.relicStatMemory) {
                 out.relicStatMemory = set.relicStatMemory.export();
             }
+            if (set.materiaMemory) {
+                out.materiaMemory = set.materiaMemory.export();
+            }
         }
         return out;
     }
@@ -651,6 +654,9 @@ export class GearPlanSheet {
             }
             if (importedSet.relicStatMemory) {
                 set.relicStatMemory.import(importedSet.relicStatMemory);
+            }
+            if (importedSet.materiaMemory) {
+                set.materiaMemory.import(importedSet.materiaMemory);
             }
         }
         return set;

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -48,6 +48,7 @@ import {CustomItem} from "./customgear/custom_item";
 import {CustomFood} from "./customgear/custom_food";
 import {IlvlSyncInfo} from "./datamanager_xivapi";
 import {toSerializableForm} from "@xivgear/xivmath/xivstats";
+import {isMateriaAllowed} from "./materia/materia_utils";
 
 export type SheetCtorArgs = ConstructorParameters<typeof GearPlanSheet>
 export type SheetContstructor<SheetType extends GearPlanSheet> = (...values: SheetCtorArgs) => SheetType;
@@ -797,13 +798,8 @@ export class GearPlanSheet {
     }
 
     getBestMateria(stat: MateriaSubstat, meldSlot: MeldableMateriaSlot): Materia | undefined {
-        const highGradeAllowed = meldSlot.materiaSlot.allowsHighGrade;
-        const maxGradeAllowed = meldSlot.materiaSlot.maxGrade;
         const materiaFilter = (materia: Materia) => {
-            if (materia.isHighGrade && !highGradeAllowed) {
-                return false;
-            }
-            return materia.materiaGrade <= maxGradeAllowed && materia.primaryStat == stat;
+            return isMateriaAllowed(materia, meldSlot.materiaSlot) && materia.primaryStat == stat;
         };
         const sortedOptions = this.relevantMateria.filter(materiaFilter).sort((first, second) => second.primaryStatValue - first.primaryStatValue);
         return sortedOptions.length >= 1 ? sortedOptions[0] : undefined;

--- a/packages/core/src/test/materia_memory_test.ts
+++ b/packages/core/src/test/materia_memory_test.ts
@@ -1,0 +1,82 @@
+import {MateriaMemory} from "../gear";
+import {EquippedItem, GearItem, Materia, MateriaSlot, MeldableMateriaSlot, RawStats} from "@xivgear/xivmath/geartypes";
+import {expect} from "chai";
+
+describe("Materia Memory", () => {
+    it("can save and restore", () => {
+        const mem = new MateriaMemory();
+        const gi1: GearItem = {
+            id: 1234
+        } as GearItem;
+        const slot: MateriaSlot = {
+            allowsHighGrade: true,
+            maxGrade: 12
+        };
+        const mat1: Materia = {
+            iconUrl: undefined,
+            id: 1001,
+            isHighGrade: true,
+            materiaGrade: 12,
+            name: "Test Materia",
+            primaryStat: 'determination',
+            primaryStatValue: 50,
+            stats: new RawStats({
+                determination: 50
+            })
+        };
+        const mat2: Materia = {
+            iconUrl: undefined,
+            id: 1002,
+            isHighGrade: true,
+            materiaGrade: 11,
+            name: "Test Materia",
+            primaryStat: 'dhit',
+            primaryStatValue: 10,
+            stats: new RawStats({
+                dhit: 10
+            })
+        };
+        const slots1: MeldableMateriaSlot[] = [
+            {
+                materiaSlot: slot,
+                equippedMateria: mat1
+            },
+            {
+                materiaSlot: slot,
+                equippedMateria: mat2
+            }
+        ];
+        const slots2: MeldableMateriaSlot[] = [
+            {
+                materiaSlot: slot,
+                equippedMateria: undefined
+            },
+            {
+                materiaSlot: slot,
+                equippedMateria: mat1
+            }
+        ];
+        // Equip the same item in both slots
+        const eq1: EquippedItem = new EquippedItem(gi1, slots1);
+        const eq2: EquippedItem = new EquippedItem(gi1, slots2);
+        mem.set("RingLeft", eq1);
+        mem.set("RingRight", eq2);
+
+        // Verify behavior
+        expect(mem.get("RingLeft", eq1.gearItem)).to.deep.equal([mat1.id, mat2.id]);
+        expect(mem.get("RingRight", eq2.gearItem)).to.deep.equal([-1, mat1.id]);
+
+        const exported = mem.export();
+
+        expect(exported.RingLeft).to.deep.equal([[1234, [mat1.id, mat2.id]]]);
+        expect(exported.RingRight).to.deep.equal([[1234, [-1, mat1.id]]]);
+
+        const imported = new MateriaMemory();
+        // serialize and deserialize to check that it isn't dependent on anything else
+        imported.import(JSON.parse(JSON.stringify(exported)));
+
+        expect(imported.get("RingLeft", eq1.gearItem)).to.deep.equal([mat1.id, mat2.id]);
+        expect(imported.get("RingRight", eq2.gearItem)).to.deep.equal([-1, mat1.id]);
+
+    })
+});

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -852,7 +852,7 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
         });
         const upperBoundControl = new FieldBoundIntField(obj, maxField, {
             postValidators: [(ctx) => {
-                if (ctx.newValue <= (obj[minField] as number)) {
+                if (ctx.newValue < (obj[minField] as number)) {
                     ctx.failValidation('Maximum level must be greater than the minimum level');
                 }
             }]

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -646,7 +646,7 @@ export class GearItemsTable extends CustomTable<GearSlotItem, EquipmentSet> {
                 gearSet.setEquip(newSelection.dataItem.slotId, newSelection.dataItem.item, sheet.materiaAutoFillController);
                 const matMgr = slotMateriaManagers.get(newSelection.dataItem.slotId);
                 if (matMgr) {
-                    matMgr.refresh();
+                    matMgr.refreshFull();
                 }
                 const oldSelection = selectionTracker.get(newSelection.dataItem.slotId);
                 if (oldSelection) {
@@ -678,13 +678,19 @@ export class GearItemsTable extends CustomTable<GearSlotItem, EquipmentSet> {
     }
 
     refreshMateria() {
-        this.materiaManagers.forEach(mgr => mgr.refresh());
+        this.materiaManagers.forEach(mgr => {
+            mgr.refresh();
+        });
         for (const equipSlot of EquipSlots) {
             const selection = this.selectionTracker.get(equipSlot);
             if (selection) {
                 this.refreshRowData(selection);
             }
         }
+        // setTimeout(() => mgr.updateColors());
+        this.materiaManagers.forEach(mgr => {
+            mgr.updateDisplay();
+        });
 
     }
 

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -372,13 +372,13 @@ export class MateriaPriorityPicker extends HTMLElement {
                     case "autofill":
                         return "Prio Fill";
                     case "retain_slot_else_prio":
-                        return "Keep Slot, else Prio";
+                        return "Keep Slot > Prio";
                     case "retain_item_else_prio":
-                        return "Keep Item, else Prio";
+                        return "Keep Item > Prio";
                     case "retain_slot":
-                        return "Keep Slot, else None";
+                        return "Keep Slot > None";
                     case "retain_item":
-                        return "Keep Item, else None";
+                        return "Keep Item > None";
                     default:
                         return "?";
                 }

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -1,9 +1,12 @@
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {
-    EquipmentSet, EquippedItem,
+    EquipmentSet,
+    EquippedItem,
     EquipSlots,
     Materia,
+    MATERIA_FILL_MODES,
     MateriaAutoFillController,
+    MateriaFillMode,
     MeldableMateriaSlot,
     RawStatKey
 } from "@xivgear/xivmath/geartypes";
@@ -11,9 +14,9 @@ import {MateriaSubstat, MAX_GCD, STAT_ABBREVIATIONS, STAT_FULL_NAMES} from "@xiv
 import {closeModal, setModal} from "@xivgear/common-ui/modalcontrol";
 import {
     faIcon,
-    FieldBoundCheckBox,
+    FieldBoundDataSelect,
     FieldBoundFloatField,
-    labeledCheckbox,
+    labelFor,
     makeActionButton,
     quickElement
 } from "@xivgear/common-ui/components/util";
@@ -33,16 +36,16 @@ export class AllSlotMateriaManager extends HTMLElement {
         super();
         this.refresh();
         this.classList.add("all-slots-materia-manager");
-        this.updateColors();
+        this.updateDisplay();
     }
 
     notifyChange() {
         this.gearSet.forceRecalc();
         this.extraCallback();
-        this.updateColors();
+        this.updateDisplay();
     }
 
-    updateColors() {
+    updateDisplay() {
         const children = [...this._children];
         if (children.length === 0) {
             return;
@@ -104,6 +107,11 @@ export class AllSlotMateriaManager extends HTMLElement {
             this.classList.remove("materia-manager-equipped");
             this._children = [];
         }
+    }
+
+    refreshFull(): void {
+        this.refresh();
+        this.updateDisplay();
     }
 }
 
@@ -356,8 +364,29 @@ export class MateriaPriorityPicker extends HTMLElement {
         // this.appendChild(document.createTextNode('Materia Prio Thing Here'));
         const header = document.createElement('span');
         header.textContent = 'Mat Prio: ';
-        const cb = labeledCheckbox('Fill When Selecting Items', new FieldBoundCheckBox(prioController, 'autoFillNewItem'));
-        cb.title = 'When an item is selected, fill its materia slots according to the chosen priority.';
+        const fillModeDropdown = new FieldBoundDataSelect<MateriaAutoFillController, MateriaFillMode>(prioController, 'autoFillMode',
+            (val: MateriaFillMode) => {
+                switch (val) {
+                    case "leave_empty":
+                        return "Leave Empty";
+                    case "autofill":
+                        return "Prio Fill";
+                    case "retain_slot_else_prio":
+                        return "Keep Slot, else Prio";
+                    case "retain_item_else_prio":
+                        return "Keep Item, else Prio";
+                    case "retain_slot":
+                        return "Keep Slot, else None";
+                    case "retain_item":
+                        return "Keep Item, else None";
+                    default:
+                        return "?";
+                }
+            }, [...MATERIA_FILL_MODES]);
+        // const cb = labeledCheckbox('Fill When Selecting Items', new FieldBoundCheckBox(prioController, 'autoFillNewItem'));
+        // cb.title = 'When an item is selected, fill its materia slots according to the chosen priority.';
+        const fillModeLabel = labelFor("Fill Mode:", fillModeDropdown);
+
         const fillEmptyNow = makeActionButton('Fill Empty', () => prioController.fillEmpty(), 'Fill all empty materia slots according to the chosen priority.');
         const fillAllNow = makeActionButton('Fill All', () => prioController.fillAll(), 'Empty out and re-fill all materia slots according to the chosen priority.');
         const drag = new MateriaDragList(prioController);
@@ -383,7 +412,7 @@ export class MateriaPriorityPicker extends HTMLElement {
         minGcdInput.pattern = '\\d\\.\\d\\d?';
         minGcdInput.title = 'Enter the minimum desired GCD in the form x.yz.\nSkS/SpS materia will be de-prioritized once this target GCD is met.';
         minGcdInput.classList.add('min-gcd-input');
-        this.replaceChildren(header, drag, minGcdText, minGcdInput, document.createElement('br'), fillEmptyNow, fillAllNow, cb);
+        this.replaceChildren(header, drag, minGcdText, minGcdInput, document.createElement('br'), fillEmptyNow, fillAllNow, fillModeLabel, fillModeDropdown);
     }
 }
 

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -383,8 +383,13 @@ export class MateriaPriorityPicker extends HTMLElement {
                         return "?";
                 }
             }, [...MATERIA_FILL_MODES]);
-        // const cb = labeledCheckbox('Fill When Selecting Items', new FieldBoundCheckBox(prioController, 'autoFillNewItem'));
-        // cb.title = 'When an item is selected, fill its materia slots according to the chosen priority.';
+        fillModeDropdown.title = 'Control what happens when an item is selected.\n' +
+            'Leave Empty: Do not fill any materia when selecting an item.\n' +
+            'Prio Fill: Fill materia slots according to the priority above.\n' +
+            'Keep Slot, else Prio: Keep the same materia as the previously item in that slot. If none equipped, use priority.\n' +
+            'Keep Item, else Prio: Remember what materia was equipped to each item. If none equipped, use priority.\n' +
+            'Keep Slot, else None: Keep the same materia as the previously item in that slot. If none equipped, leave empty.\n' +
+            'Keep Item, else None: Remember what materia was equipped to each item. If none equipped, leave empty.';
         const fillModeLabel = labelFor("Fill Mode:", fillModeDropdown);
 
         const fillEmptyNow = makeActionButton('Fill Empty', () => prioController.fillEmpty(), 'Fill all empty materia slots according to the chosen priority.');

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -31,7 +31,7 @@ import {
     EquipSlots,
     GearItem,
     MateriaAutoFillController,
-    MateriaAutoFillPrio,
+    MateriaAutoFillPrio, MateriaFillMode,
     MultiplierMitStat,
     MultiplierStat,
     PartyBonusAmount,
@@ -1556,11 +1556,11 @@ export class GearPlanSheetGui extends GearPlanSheet {
         const outer = this;
         const matFillCtrl: MateriaAutoFillController = {
 
-            get autoFillNewItem() {
-                return outer.materiaAutoFillSelectedItems;
+            get autoFillMode() {
+                return outer.materiaFillMode;
             },
-            set autoFillNewItem(enabled: boolean) {
-                outer.materiaAutoFillSelectedItems = enabled;
+            set autoFillMode(mode: MateriaFillMode) {
+                outer.materiaFillMode = mode;
                 outer.requestSave();
             },
             get prio() {
@@ -1585,6 +1585,12 @@ export class GearPlanSheetGui extends GearPlanSheet {
                     if (outer._editorAreaNode instanceof GearSetEditor) {
                         outer._editorAreaNode.refreshMateria();
                     }
+                }
+            },
+            // TODO: remove?
+            refreshOnly() {
+                if (outer._editorAreaNode instanceof GearSetEditor) {
+                    // outer._editorAreaNode.refreshMateria();
                 }
             }
 

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -243,6 +243,7 @@ export interface ComputedSetStats extends RawStats {
      * Job modifier data
      */
     readonly jobStats: JobData,
+
     /**
      * Physical GCD time
      */
@@ -307,10 +308,12 @@ export interface ComputedSetStats extends RawStats {
      * else).
      */
     readonly aaStatMulti: number
+
     /**
      * Trait multiplier
      */
     traitMulti(attackType: AttackType): number;
+
     /**
      * Bonus added to det multiplier for automatic direct hits
      */
@@ -623,10 +626,14 @@ export interface SheetExport {
      */
     itemDisplaySettings?: ItemDisplaySettings,
     // Keeping these abbreviated so exports don't become unnecessarily large
+    // /**
+    //  * Whether to auto-fill materia into newly selected items (Materia Fill New Items).
+    //  */
+    // mfni?: boolean,
     /**
-     * Whether to auto-fill materia into newly selected items (Materia Fill New Items).
+     * What to do with materia slots on newly-selected items
      */
-    mfni?: boolean,
+    mfm?: MateriaFillMode,
     /**
      * The materia auto-fill priority
      */
@@ -768,19 +775,24 @@ export type PartyBonusAmount = 0 | 1 | 2 | 3 | 4 | 5;
 
 export interface MateriaAutoFillController {
     readonly prio: MateriaAutoFillPrio;
-    autoFillNewItem: boolean;
+    autoFillMode: MateriaFillMode;
 
     callback(): void;
 
     fillEmpty(): void;
 
     fillAll(): void;
+
+    refreshOnly(): void;
 }
 
 export interface MateriaAutoFillPrio {
     statPrio: (MateriaSubstat)[];
     minGcd: number;
 }
+
+export const MATERIA_FILL_MODES = ['leave_empty', 'autofill', 'retain_slot_else_prio', 'retain_item_else_prio', 'retain_slot', 'retain_item'] as const;
+export type MateriaFillMode = typeof MATERIA_FILL_MODES[number];
 
 export interface ItemDisplaySettings {
     minILvl: number,

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -656,6 +656,17 @@ export interface SheetExport {
     customFoods?: CustomFoodExport[],
 }
 
+export type RelicStatMemoryExport = {
+    [p: number]: RelicStats;
+};
+
+
+export type SlotMateriaMemoryExport = [item: number, materiaIds: number[]];
+
+export type MateriaMemoryExport = {
+    [slot in EquipSlotKey]?: SlotMateriaMemoryExport[]
+};
+
 export interface SheetStatsExport extends SheetExport {
     sets: SetStatsExport[],
 }
@@ -712,9 +723,13 @@ export interface SetExport {
      * When a relic is de-selected, its former stats are remembered here so that they can be recalled if the
      * relic is selected again. They keys are item IDs, and the values are {@link RelicStats}.
      */
-    relicStatMemory?: {
-        [p: number]: RelicStats
-    };
+    relicStatMemory?: RelicStatMemoryExport;
+    /**
+     * When an item is de-selected, its former materia are remembered so that they can later be automatically
+     * re-equipped based on settings. They keys are slot names (so that left/right ring can be differentiated),
+     * and the values are lists of tuples of [item ID, [materia 0, materia 1, ... materia n]]
+     */
+    materiaMemory?: MateriaMemoryExport;
     /**
      * Only for standalone use - Custom items
      */


### PR DESCRIPTION
Adds new materia fill options (names TBD):

![image](https://github.com/user-attachments/assets/26e5376a-27cd-493d-8e00-6cb77d12a7fe)

TODO: 
- [X] validate that the materia actually fits in the new slot when using "Keep Slot" mode. e.g. if you equip grade X to an i640 Ornate crafted item, then switch to the non-ornate version, it should not keep that materia.
- [x] include materia memory in export like how relic stats are persistent

Closes #254 