### PR TITLE
Reducegradient for miniscule differences in DPS

### DIFF
--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -643,11 +643,19 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
             processed.sort((cellA, cellB) => (cellA[1] - cellB[1]));
             const worst = processed[0];
             const best = processed[processed.length - 1];
-            const worstValue = worst[1];
+            let worstValue = worst[1];
             const bestValue = best[1];
-            const delta = bestValue - worstValue;
+            let delta = bestValue - worstValue;
             if (delta === 0) {
                 return;
+            }
+            if (bestValue > 0) {
+                // If less than 0.5% difference
+                const minDeltaRelative = 0.001;
+                if (delta / bestValue < minDeltaRelative) {
+                    delta = bestValue * minDeltaRelative;
+                    worstValue = bestValue - delta;
+                }
             }
             for (const [cell, value] of processed) {
                 cell.classList.add('sim-column-valid');


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c2b7cdb4-a420-40db-a486-ae49cf0cc9f6)

Causes the green-red gradient to cut off for tiny differences, rather than making one set bright green and one bright red when they have an ignorable difference  between them.

Currently, the threshold for using the full gradient is 0.1%. That is, if the worst set is only 0.07% lower DPS than the best set, then the worst set will only be "70% red" rather than 100% red like it was before. If the difference is greater than 0.1%, then the behavior should be the same as before.

Closes #315 