### PR TITLE
Resolve ESLint errors

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,7 +11,8 @@ export default [
         languageOptions: {
             // parser: parser,
             parserOptions: {
-                project: './tsconfig.json',
+                // project: ['./tsconfig.json', './packages/*/tsconfig.json'],
+                projectService: true,
             }
         },
         rules: {


### PR DESCRIPTION
Per [https://typescript-eslint.io/packages/parser/#project](https://typescript-eslint.io/packages/parser/#project), 
> If you use project references, TypeScript will not automatically use project references to resolve files. This means that you will have to add each referenced tsconfig to the project field either separately, or via a glob.

Furthermore, per typescript-eslint documentation, 
> [parserOptions.projectService](https://typescript-eslint.io/packages/parser#projectservice) is the recommended parser option to enable typed linting as of typescript-eslint v8. It enforces projects generate type information for typed linting from the same tsconfig.json files used by editors such as VS Code.

This PR enables `parserOptions.projectService`.  Per the typescript-eslint documentation, potential issues are listed here: [https://typescript-eslint.io/troubleshooting/typed-linting/#project-service-issues](https://typescript-eslint.io/troubleshooting/typed-linting/#project-service-issues).