### PR TITLE
Make materia selection respect ilvl

### DIFF
--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -149,13 +149,15 @@ export class CustomItem implements GearItem {
         for (let i = 0; i < this._data.largeMateriaSlots; i++) {
             out.push({
                 maxGrade: this._data.materiaGrade,
-                allowsHighGrade: true
+                allowsHighGrade: true,
+                ilvl: this.ilvl
             });
         }
         for (let i = 0; i < this._data.smallMateriaSlots; i++) {
             out.push({
                 maxGrade: this._data.materiaGrade - 1,
-                allowsHighGrade: false
+                allowsHighGrade: false,
+                ilvl: this.ilvl
             });
         }
         return out;

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -63,8 +63,8 @@ async function retryFetch(...params: Parameters<typeof fetch>): Promise<Response
 }
 
 const apiClient = new DataApiClient<never>({
-    baseUrl: "https://data.xivgear.app",
-    // baseUrl: "http://localhost:8085",
+    // baseUrl: "https://data.xivgear.app",
+    baseUrl: "http://localhost:8085",
     customFetch: retryFetch
 });
 
@@ -548,7 +548,8 @@ export class DataApiGearInfo implements GearItem {
                 // TODO: figure out grade automatically
                 this.materiaSlots.push({
                     maxGrade: MATERIA_LEVEL_MAX_NORMAL,
-                    allowsHighGrade: true
+                    allowsHighGrade: true,
+                    ilvl: data.ilvl
                 });
             }
             if (overmeld) {
@@ -556,12 +557,14 @@ export class DataApiGearInfo implements GearItem {
                 // small materia.
                 this.materiaSlots.push({
                     maxGrade: MATERIA_LEVEL_MAX_NORMAL,
-                    allowsHighGrade: true
+                    allowsHighGrade: true,
+                    ilvl: data.ilvl
                 });
                 for (let i = this.materiaSlots.length; i < MATERIA_SLOTS_MAX; i++) {
                     this.materiaSlots.push({
                         maxGrade: MATERIA_LEVEL_MAX_OVERMELD,
-                        allowsHighGrade: false
+                        allowsHighGrade: false,
+                        ilvl: data.ilvl
                     });
                 }
             }
@@ -740,7 +743,7 @@ export function processRawMateriaInfo(data: MateriaType): Materia[] {
             primaryStatValue: stats[stat],
             materiaGrade: grade,
             isHighGrade: (grade % 2) === 0,
-            ilvl: itemData.ilvl
+            ilvl: itemData.ilvl ?? 0
         });
     }
     return out;

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -63,8 +63,9 @@ async function retryFetch(...params: Parameters<typeof fetch>): Promise<Response
 }
 
 const apiClient = new DataApiClient<never>({
-    // baseUrl: "https://data.xivgear.app",
-    baseUrl: "http://localhost:8085",
+    baseUrl: "https://data.xivgear.app",
+    // baseUrl: "https://betadata.xivgear.app",
+    // baseUrl: "http://localhost:8085",
     customFetch: retryFetch
 });
 

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -734,12 +734,13 @@ export function processRawMateriaInfo(data: MateriaType): Materia[] {
         out.push({
             name: itemName,
             id: itemId,
-            iconUrl: new URL(data.item[i].icon.pngIconUrl),
+            iconUrl: new URL(itemData.icon.pngIconUrl),
             stats: stats,
             primaryStat: stat,
             primaryStatValue: stats[stat],
             materiaGrade: grade,
-            isHighGrade: (grade % 2) === 0
+            isHighGrade: (grade % 2) === 0,
+            ilvl: itemData.ilvl
         });
     }
     return out;

--- a/packages/core/src/datamanager_xivapi.ts
+++ b/packages/core/src/datamanager_xivapi.ts
@@ -45,7 +45,7 @@ const itemColsExtra = [
 ] as const;
 export type XivApiItemDataRaw = XivApiResultSingle<typeof itemColumns, typeof itemColsExtra>;
 // 'Item' is only there because I need to figure out how to keep the type checking happy
-const matCols = ['Item[].Name', 'Item[].Icon', 'BaseParam.nonexistent', 'Value'] as const;
+const matCols = ['Item[].Name', 'Item[].Icon', 'Item[].LevelItem@as(raw)', 'BaseParam.nonexistent', 'Value'] as const;
 // TODO: make a better way of doing this. matColsTrn represents the columns that are transitively included by way of
 // including a sub-column.
 const matColsTrn = ['Item', 'BaseParam'] as const;
@@ -805,7 +805,8 @@ export function processRawMateriaInfo(data: XivApiMateriaDataRaw): Materia[] {
             primaryStat: stat,
             primaryStatValue: stats[stat],
             materiaGrade: grade,
-            isHighGrade: (grade % 2) === 0
+            isHighGrade: (grade % 2) === 0,
+            ilvl: itemFields['LevelItem'] ?? 0
         });
     }
     return out;

--- a/packages/core/src/datamanager_xivapi.ts
+++ b/packages/core/src/datamanager_xivapi.ts
@@ -557,7 +557,8 @@ export class XivApiGearInfo implements GearItem {
                 // TODO: figure out grade automatically
                 this.materiaSlots.push({
                     maxGrade: MATERIA_LEVEL_MAX_NORMAL,
-                    allowsHighGrade: true
+                    allowsHighGrade: true,
+                    ilvl: this.ilvl
                 });
             }
             if (overmeld) {
@@ -565,12 +566,14 @@ export class XivApiGearInfo implements GearItem {
                 // small materia.
                 this.materiaSlots.push({
                     maxGrade: MATERIA_LEVEL_MAX_NORMAL,
-                    allowsHighGrade: true
+                    allowsHighGrade: true,
+                    ilvl: this.ilvl
                 });
                 for (let i = this.materiaSlots.length; i < MATERIA_SLOTS_MAX; i++) {
                     this.materiaSlots.push({
                         maxGrade: MATERIA_LEVEL_MAX_OVERMELD,
-                        allowsHighGrade: false
+                        allowsHighGrade: false,
+                        ilvl: this.ilvl
                     });
                 }
             }

--- a/packages/core/src/materia/materia_utils.ts
+++ b/packages/core/src/materia/materia_utils.ts
@@ -6,6 +6,9 @@ export function isMateriaAllowed(materia: Materia, materiaSlot: MateriaSlot) {
     if (materia.isHighGrade && !highGradeAllowed) {
         return false;
     }
+    if (materia.ilvl > materiaSlot.ilvl) {
+        return false;
+    }
     const maxGradeAllowed = materiaSlot.maxGrade;
     return materia.materiaGrade <= maxGradeAllowed;
 }

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -771,6 +771,10 @@ export class GearPlanSheet {
         return this._relevantMateria;
     }
 
+    getRelevantMateriaFor(item: GearItem) {
+        return this._relevantMateria.filter(mat => mat.ilvl <= item.ilvl);
+    }
+
     get partyBonus(): PartyBonusAmount {
         return this._partyBonus;
     }

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -771,8 +771,8 @@ export class GearPlanSheet {
         return this._relevantMateria;
     }
 
-    getRelevantMateriaFor(item: GearItem) {
-        return this._relevantMateria.filter(mat => mat.ilvl <= item.ilvl);
+    getRelevantMateriaFor(slot: MeldableMateriaSlot) {
+        return this._relevantMateria.filter(mat => mat.ilvl <= slot.materiaSlot.ilvl);
     }
 
     get partyBonus(): PartyBonusAmount {

--- a/packages/core/src/test/materia_memory_test.ts
+++ b/packages/core/src/test/materia_memory_test.ts
@@ -10,7 +10,8 @@ describe("Materia Memory", () => {
         } as GearItem;
         const slot: MateriaSlot = {
             allowsHighGrade: true,
-            maxGrade: 12
+            maxGrade: 12,
+            ilvl: 999
         };
         const mat1: Materia = {
             iconUrl: undefined,
@@ -22,7 +23,8 @@ describe("Materia Memory", () => {
             primaryStatValue: 50,
             stats: new RawStats({
                 determination: 50
-            })
+            }),
+            ilvl: 690
         };
         const mat2: Materia = {
             iconUrl: undefined,
@@ -34,7 +36,8 @@ describe("Materia Memory", () => {
             primaryStatValue: 10,
             stats: new RawStats({
                 dhit: 10
-            })
+            }),
+            ilvl: 690
         };
         const slots1: MeldableMateriaSlot[] = [
             {
@@ -78,5 +81,5 @@ describe("Materia Memory", () => {
         expect(imported.get("RingLeft", eq1.gearItem)).to.deep.equal([mat1.id, mat2.id]);
         expect(imported.get("RingRight", eq2.gearItem)).to.deep.equal([-1, mat1.id]);
 
-    })
+    });
 });

--- a/packages/data-api-client/src/dataapi.ts
+++ b/packages/data-api-client/src/dataapi.ts
@@ -255,6 +255,8 @@ export type MateriaItem = XivApiObject &
   XivApiBase & {
     name?: string;
     icon?: Icon;
+    /** @format int32 */
+    ilvl?: number;
   };
 
 export interface XivApiBase {

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -271,7 +271,7 @@ export class SlotMateriaManagerPopup extends HTMLElement {
     }
 
     show() {
-        const allMateria = this.sheet.relevantMateria;
+        const allMateria = this.sheet.getRelevantMateriaFor(this.materiaSlot);
         const typeMap: { [K in RawStatKey]?: Materia[] } = {};
         const stats: RawStatKey[] = [];
         const grades: number[] = [];

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -570,7 +570,8 @@ export class EquipmentSet {
 
 export interface MateriaSlot {
     maxGrade: number,
-    allowsHighGrade: boolean
+    allowsHighGrade: boolean,
+    ilvl: number
 }
 
 

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -223,7 +223,11 @@ export interface Materia extends XivCombatItem {
      * If the materia cannot be overmelded into all of the slots,
      * i.e. true for 6/8/10, false for 5/7/9 etc.
      */
-    isHighGrade: boolean
+    isHighGrade: boolean,
+    /**
+     * Materia can only be equipped to gear where the gear's ilvl >= the materia' ilvl.
+     */
+    ilvl: number
 }
 
 export interface ComputedSetStats extends RawStats {


### PR DESCRIPTION
Currently, maximum materia level is only determined by sheet level. Instead, it should be determined by the ilvl of the item it is being equipped into. This affects both manual picking and auto-fill.