### PR TITLE
Split rotations and damage new

### DIFF
--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -379,7 +379,7 @@ export class CycleProcessor {
     /**
      * The stats of the set currently being simulated
      */
-    readonly stats: ComputedSetStats;
+    stats: ComputedSetStats;
     /**
      * Map from DoT effect ID to an object which tracks, among other things, when it was used.
      */

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -702,7 +702,10 @@ export class CycleProcessor {
                 return {
                     ...record,
                     directDamage: dmgInfo.directDamage ?? fixedValue(0),
-                    dot: dmgInfo.dot,
+                    dot: record.dot ? {
+                        ...record.dot,
+                        damagePerTick: dmgInfo.dot.damagePerTick,
+                    } : null,
                 }
             }
         })
@@ -820,7 +823,7 @@ export class CycleProcessor {
         ability = this.beforeSnapshot(ability, buffs);
         // Enough time for entire GCD
         // if (gcdFinishedAt <= this.totalTime) {
-        //const dmgInfo = this.modifyDamage(abilityToDamageNew(this.stats, ability, combinedEffects), ability, buffs);
+        const dmgInfo = this.modifyDamage(abilityToDamageNew(this.stats, ability, combinedEffects), ability, buffs);
         const appDelayFromSnapshot = appDelay(ability);
         const appDelayFromStart = appDelayFromSnapshot + snapshotDelayFromStart;
         const finalBuffs: Buff[] = Array.from(new Set<Buff>([
@@ -842,8 +845,7 @@ export class CycleProcessor {
             },
             buffs: finalBuffs,
             usedAt: gcdStartsAt,
-            //directDamage: dmgInfo.directDamage ?? fixedValue(0),
-            //dot: dmgInfo.dot,
+            dot: dmgInfo.dot,
             appDelay: appDelayFromSnapshot,
             appDelayFromStart: appDelayFromStart,
             totalTimeTaken: Math.max(effectiveAnimLock, abilityGcd),

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -11,7 +11,6 @@ import {
     FinalizedAbility,
     GcdAbility,
     OgcdAbility,
-    PartiallyUsedAbility,
     PartyBuff,
     SimResult,
     SimSettings,
@@ -697,8 +696,7 @@ export class CycleProcessor {
                 return record;
             }
             else {
-                let dmgInfo = this.modifyDamage(abilityToDamageNew(this.stats, record.ability, record.combinedEffects), record.ability, record.buffs);
-                //console.log(`${record.ability.name}: ${dmgInfo.directDamage.expected}`);
+                const dmgInfo = this.modifyDamage(abilityToDamageNew(this.stats, record.ability, record.combinedEffects), record.ability, record.buffs);
                 return {
                     ...record,
                     directDamage: dmgInfo.directDamage ?? fixedValue(0),
@@ -1010,7 +1008,6 @@ export class CycleProcessor {
             buffs,
             combinedEffects
         } = this.getCombinedEffectsFor(this.aaAbility);
-        const dmgInfo = abilityToDamageNew(this.stats, this.aaAbility, combinedEffects);
         const appDelay = AUTOATTACK_APPLICATION_DELAY;
         this.addAbilityUse({
             usedAt: this.currentTime,

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -417,7 +417,7 @@ export type ComputedDamage = ValueWithDev;
 /**
  * Represents an ability actually being used
  */
-export type UsedAbility = {
+export type PreDmgUsedAbility = {
     /**
      * The ability that was used
      */
@@ -441,7 +441,7 @@ export type UsedAbility = {
     /**
      * The direct damage of the ability
      */
-    directDamage: ComputedDamage,
+    //directDamage: ComputedDamage,
     /**
      * If a DoT, the DoT damage
      */
@@ -478,6 +478,10 @@ export type UsedAbility = {
     extraData?: object
 };
 
+export type PostDmgUsedAbility = PreDmgUsedAbility & {
+    directDamage: ComputedDamage,
+    dot?: DotDamageUnf
+}
 /**
  * Represents a pseudo-ability used to round out a cycle to exactly 120s.
  *
@@ -485,13 +489,13 @@ export type UsedAbility = {
  * remaining for an entire GCD. Thus, we would have a PartialAbility with portion = (1.1s / 2.5s)
  *
  */
-export type PartiallyUsedAbility = UsedAbility & {
+export type PartiallyUsedAbility = PreDmgUsedAbility & {
     portion: number
 };
 
 export type FinalizedAbility = {
     usedAt: number,
-    original: UsedAbility,
+    original: PreDmgUsedAbility,
     totalDamage: number,
     totalDamageFull: ComputedDamage
     totalPotency: number,

--- a/packages/core/src/sims/sim_utils.ts
+++ b/packages/core/src/sims/sim_utils.ts
@@ -62,7 +62,6 @@ export function abilityToDamageNew(stats: ComputedSetStats, ability: Ability, co
             damagePerTick: dotPotencyToDamage(stats, ability.dot.tickPotency, ability, combinedBuffEffects),
         } : null,
     }
-
 }
 
 /**

--- a/packages/core/src/test/test_utils.ts
+++ b/packages/core/src/test/test_utils.ts
@@ -1,5 +1,5 @@
 // import assert from "node:assert";
-import {ComputedSetStats, EquipmentSet, GearItem} from "@xivgear/xivmath/geartypes";
+import {ComputedSetStats, EquipmentSet, GearItem, RawStatKey} from "@xivgear/xivmath/geartypes";
 import {CharacterGearSet} from "../gear";
 
 /**
@@ -41,6 +41,9 @@ export function makeFakeSet(stats: ComputedSetStats): CharacterGearSet {
             else {
                 return null;
             }
+        },
+        isStatRelevant(stat: RawStatKey): boolean {
+            return ['piety', 'crit', 'dhit', 'spellspeed', 'determination'].includes(stat);
         }
     } as CharacterGearSet;
 }

--- a/packages/frontend/src/scripts/sims/healer/ast_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/healer/ast_sheet_sim.ts
@@ -1,7 +1,7 @@
 import {Divination} from "@xivgear/core/sims/buffs";
-import {Ability, BuffController, GcdAbility, OgcdAbility, PersonalBuff, SimSettings, SimSpec, UsedAbility} from "@xivgear/core/sims/sim_types";
+import {Ability, BuffController, GcdAbility, OgcdAbility, PersonalBuff, SimSettings, SimSpec, PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation, DisplayRecordFinalized,
-    isFinalizedAbilityUse, AbilityUseRecordUnf, AbilityUseResult} from "@xivgear/core/sims/cycle_sim";
+    isFinalizedAbilityUse, PreDmgAbilityUseRecordUnf, AbilityUseResult} from "@xivgear/core/sims/cycle_sim";
 import {BaseMultiCycleSim} from "../sim_processors";
 import {rangeInc} from "@xivgear/core/util/array_utils";
 //import {potionMaxMind} from "@xivgear/core/sims/common/potion";
@@ -244,7 +244,7 @@ class AstGauge {
             shortName: 'cards',
             displayName: 'Cards',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const cards = (usedAbility.extraData as AstExtraData).gauge.cards;
 
@@ -355,13 +355,13 @@ class AstCycleProcessor extends CycleProcessor {
         this.gauge.addCard("Lord");
     }
 
-    override addAbilityUse(usedAbility: AbilityUseRecordUnf) {
+    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
         // Add gauge data to this record for the UI
         const extraData: AstExtraData = {
             gauge: this.gauge.getGaugeState(),
         };
 
-        const modified: AbilityUseRecordUnf = {
+        const modified: PreDmgAbilityUseRecordUnf = {
             ...usedAbility,
             extraData,
         };

--- a/packages/frontend/src/scripts/sims/healer/sch_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/healer/sch_sheet_sim.ts
@@ -1,7 +1,7 @@
 import {Chain} from "@xivgear/core/sims/buffs";
-import {Ability, BuffController, GcdAbility, OgcdAbility, PersonalBuff, SimSettings, SimSpec, UsedAbility} from "@xivgear/core/sims/sim_types";
+import {Ability, BuffController, GcdAbility, OgcdAbility, PersonalBuff, SimSettings, SimSpec, PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation, DisplayRecordFinalized,
-    isFinalizedAbilityUse, AbilityUseRecordUnf, AbilityUseResult} from "@xivgear/core/sims/cycle_sim";
+    isFinalizedAbilityUse, PreDmgAbilityUseRecordUnf, AbilityUseResult} from "@xivgear/core/sims/cycle_sim";
 import {BaseMultiCycleSim} from "../sim_processors";
 import {rangeInc} from "@xivgear/core/util/array_utils";
 //import {potionMaxMind} from "@xivgear/core/sims/common/potion";
@@ -163,7 +163,7 @@ class SchGauge {
             shortName: 'aetherflow',
             displayName: 'Aetherflow',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const aetherflow = (usedAbility.extraData as SchExtraData).gauge.aetherflow;
 
@@ -232,13 +232,13 @@ class ScholarCycleProcessor extends CycleProcessor {
         this.gauge = new SchGauge();
     }
 
-    override addAbilityUse(usedAbility: AbilityUseRecordUnf) {
+    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
         // Add gauge data to this record for the UI
         const extraData: SchExtraData = {
             gauge: this.gauge.getGaugeState(),
         };
 
-        const modified: AbilityUseRecordUnf = {
+        const modified: PreDmgAbilityUseRecordUnf = {
             ...usedAbility,
             extraData,
         };

--- a/packages/frontend/src/scripts/sims/healer/whm_new_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/healer/whm_new_sheet_sim.ts
@@ -1,6 +1,6 @@
-import {Ability, BuffController, GcdAbility, OgcdAbility, PersonalBuff, SimSettings, SimSpec, UsedAbility} from "@xivgear/core/sims/sim_types";
+import {Ability, BuffController, GcdAbility, OgcdAbility, PersonalBuff, SimSettings, SimSpec, PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation, DisplayRecordFinalized,
-    isFinalizedAbilityUse, AbilityUseRecordUnf, AbilityUseResult} from "@xivgear/core/sims/cycle_sim";
+    isFinalizedAbilityUse, PreDmgAbilityUseRecordUnf, AbilityUseResult} from "@xivgear/core/sims/cycle_sim";
 import {BaseMultiCycleSim} from "../sim_processors";
 import {rangeInc} from "@xivgear/core/util/array_utils";
 //import {potionMaxMind} from "@xivgear/core/sims/common/potion";
@@ -172,7 +172,7 @@ class WhmGauge {
             shortName: 'lilies',
             displayName: 'Lilies',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const blueLilies = (usedAbility.extraData as WhmExtraData).gauge.blueLilies;
                     const redLilies = (usedAbility.extraData as WhmExtraData).gauge.redLilies;
@@ -259,13 +259,13 @@ class WhmCycleProcessor extends CycleProcessor {
         this.gauge = new WhmGauge();
     }
 
-    override addAbilityUse(usedAbility: AbilityUseRecordUnf) {
+    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
         // Add gauge data to this record for the UI
         const extraData: WhmExtraData = {
             gauge: this.gauge.getGaugeState(),
         };
 
-        const modified: AbilityUseRecordUnf = {
+        const modified: PreDmgAbilityUseRecordUnf = {
             ...usedAbility,
             extraData,
         };

--- a/packages/frontend/src/scripts/sims/melee/nin/nin_gauge.ts
+++ b/packages/frontend/src/scripts/sims/melee/nin/nin_gauge.ts
@@ -1,5 +1,5 @@
 import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from '@xivgear/core/sims/cycle_sim';
-import {UsedAbility} from "@xivgear/core/sims/sim_types";
+import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {NINExtraData, NINGaugeState, NinkiAbility} from './nin_types';
 import {CustomColumnSpec} from '../../../tables';
 
@@ -60,7 +60,7 @@ class NINGauge {
             shortName: 'ninkiGauge',
             displayName: 'Ninki',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const ninki = (usedAbility.extraData as NINExtraData).gauge.ninki;
 
@@ -101,7 +101,7 @@ class NINGauge {
             shortName: 'kazematoi',
             displayName: 'Kazematoi',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 let textContent = "";
                 if (usedAbility?.extraData !== undefined) {
                     const gauge = (usedAbility.extraData as NINExtraData).gauge;

--- a/packages/frontend/src/scripts/sims/melee/nin/nin_lv100_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/nin/nin_lv100_sim.ts
@@ -1,5 +1,5 @@
 import {Ability, OgcdAbility, Buff, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
-import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, AbilityUseResult, Rotation, AbilityUseRecordUnf} from "@xivgear/core/sims/cycle_sim";
+import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, AbilityUseResult, Rotation, PreDmgAbilityUseRecordUnf} from "@xivgear/core/sims/cycle_sim";
 import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
 import {STANDARD_ANIMATION_LOCK} from "@xivgear/xivmath/xivconstants";
 import {BaseMultiCycleSim} from "../../sim_processors";
@@ -81,13 +81,13 @@ class NINCycleProcessor extends CycleProcessor {
         super.activateBuffWithDelay(buff, delay);
     }
 
-    override addAbilityUse(usedAbility: AbilityUseRecordUnf) {
+    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
         // Add gauge data to this record for the UI
         const extraData: NINExtraData = {
             gauge: this.gauge.getGaugeState(),
         };
 
-        const modified: AbilityUseRecordUnf = {
+        const modified: PreDmgAbilityUseRecordUnf = {
             ...usedAbility,
             extraData,
         };

--- a/packages/frontend/src/scripts/sims/melee/rpr/rpr_gauge.ts
+++ b/packages/frontend/src/scripts/sims/melee/rpr/rpr_gauge.ts
@@ -1,6 +1,6 @@
 import { CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse } from "@xivgear/core/sims/cycle_sim";
 import { CustomColumnSpec } from "../../../tables";
-import { UsedAbility } from "@xivgear/core/sims/sim_types";
+import { PreDmgUsedAbility } from "@xivgear/core/sims/sim_types";
 import { RprExtraData, RprGaugeState } from "./rpr_types";
 
 export class RprGauge {
@@ -46,7 +46,7 @@ export class RprGauge {
             shortName: 'soulGauge',
             displayName: 'Soul',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const soul = (usedAbility.extraData as RprExtraData).gauge.soul;
 
@@ -88,7 +88,7 @@ export class RprGauge {
             shortName: 'shroudGauge',
             displayName: 'Shroud',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const shroud = (usedAbility.extraData as RprExtraData).gauge.shroud;
 

--- a/packages/frontend/src/scripts/sims/melee/rpr/rpr_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/rpr/rpr_sheet_sim.ts
@@ -1,6 +1,6 @@
 import {ArcaneCircleBuff} from "@xivgear/core/sims/buffs";
 import {Ability, Buff, OgcdAbility, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
-import {AbilityUseRecordUnf, AbilityUseResult, CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation} from "@xivgear/core/sims/cycle_sim";
+import {PreDmgAbilityUseRecordUnf, AbilityUseResult, CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation} from "@xivgear/core/sims/cycle_sim";
 import {BaseMultiCycleSim} from "../../sim_processors";
 import { potionMaxStr } from "@xivgear/core/sims/common/potion";
 import * as Actions from "./rpr_actions"
@@ -154,14 +154,14 @@ class RprCycleProcessor extends CycleProcessor {
         return this.cdTracker.canUse(ability) ? super.useOgcd(ability) : null;
     }
 
-    override addAbilityUse(usedAbility: AbilityUseRecordUnf) {
+    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
 
         // Add gauge data to this record for the UI
         const extraData: RprExtraData = {
             gauge: this.gauge.getGaugeState(),
         };
 
-        const modified: AbilityUseRecordUnf = {
+        const modified: PreDmgAbilityUseRecordUnf = {
             ...usedAbility,
             extraData,
         };

--- a/packages/frontend/src/scripts/sims/melee/sam/sam_gauge.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/sam_gauge.ts
@@ -1,5 +1,5 @@
 import { CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse } from '@xivgear/core/sims/cycle_sim';
-import { UsedAbility } from "@xivgear/core/sims/sim_types";
+import { PreDmgUsedAbility } from "@xivgear/core/sims/sim_types";
 import { SAMExtraData, SAMGaugeState, KenkiAbility } from './sam_types';
 import { CustomColumnSpec } from '../../../tables';
 
@@ -69,7 +69,7 @@ class SAMGauge {
             shortName: 'kenkiGauge',
             displayName: 'Kenki',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const kenki = (usedAbility.extraData as SAMExtraData).gauge.kenki;
 
@@ -110,7 +110,7 @@ class SAMGauge {
             shortName: 'meditation',
             displayName: 'Meditation',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const meditation = (usedAbility.extraData as SAMExtraData).gauge.meditation;
 
@@ -145,7 +145,7 @@ class SAMGauge {
             shortName: 'sen',
             displayName: 'Sen',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const sen = (usedAbility.extraData as SAMExtraData).gauge.sen;
 

--- a/packages/frontend/src/scripts/sims/melee/sam/sam_lv100_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/sam_lv100_sim.ts
@@ -1,5 +1,5 @@
 import { Ability, SimSettings, SimSpec } from "@xivgear/core/sims/sim_types";
-import { CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, AbilityUseResult, Rotation, AbilityUseRecordUnf } from "@xivgear/core/sims/cycle_sim";
+import { CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, AbilityUseResult, Rotation, PreDmgAbilityUseRecordUnf } from "@xivgear/core/sims/cycle_sim";
 import { CycleSettings } from "@xivgear/core/sims/cycle_settings";
 import { CharacterGearSet } from "@xivgear/core/gear";
 import { formatDuration } from "@xivgear/core/util/strutils";
@@ -71,13 +71,13 @@ class SAMCycleProcessor extends CycleProcessor {
         return this.currentTime > (this.totalTime - 5) && this.gauge.kenkiGauge >= 25;
     }
 
-    override addAbilityUse(usedAbility: AbilityUseRecordUnf) {
+    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
         // Add gauge data to this record for the UI
         const extraData: SAMExtraData = {
             gauge: this.gauge.getGaugeState(),
         };
 
-        const modified: AbilityUseRecordUnf = {
+        const modified: PreDmgAbilityUseRecordUnf = {
             ...usedAbility,
             extraData,
         };

--- a/packages/frontend/src/scripts/sims/melee/vpr/vpr_gauge.ts
+++ b/packages/frontend/src/scripts/sims/melee/vpr/vpr_gauge.ts
@@ -1,6 +1,6 @@
 import { CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse } from "@xivgear/core/sims/cycle_sim";
 import { CustomColumnSpec } from "../../../tables";
-import { UsedAbility } from "@xivgear/core/sims/sim_types";
+import { PreDmgUsedAbility } from "@xivgear/core/sims/sim_types";
 import { VprExtraData, VprGaugeState } from "./vpr_types";
 
 export class VprGauge {
@@ -48,7 +48,7 @@ export class VprGauge {
             shortName: 'serpentOfferings',
             displayName: 'Serpent Offerings',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const serpentOfferings = (usedAbility.extraData as VprExtraData).gauge.serpentOfferings;
 
@@ -90,7 +90,7 @@ export class VprGauge {
             shortName: 'rattlingCoils',
             displayName: 'Rattling Coils',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: UsedAbility) => {
+            renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const rattlingCoils = (usedAbility.extraData as VprExtraData).gauge.rattlingCoils;
 

--- a/packages/frontend/src/scripts/sims/melee/vpr/vpr_sheet_sim.ts
+++ b/packages/frontend/src/scripts/sims/melee/vpr/vpr_sheet_sim.ts
@@ -1,4 +1,4 @@
-import { AbilityUseRecordUnf, AbilityUseResult, CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation } from "@xivgear/core/sims/cycle_sim";
+import { PreDmgAbilityUseRecordUnf, AbilityUseResult, CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation } from "@xivgear/core/sims/cycle_sim";
 import { Ability, Buff, OgcdAbility, SimSettings, SimSpec } from "@xivgear/core/sims/sim_types";
 import { BaseMultiCycleSim } from "../../sim_processors";
 import { VprGauge } from "./vpr_gauge";
@@ -74,14 +74,14 @@ export class VprCycleProcessor extends CycleProcessor {
         this.rotationState = new RotationState();
     }
 
-    override addAbilityUse(usedAbility: AbilityUseRecordUnf) {
+    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
 
         // Add gauge data to this record for the UI
         const extraData: VprExtraData = {
             gauge: this.gauge.getGaugeState(),
         };
 
-        const modified: AbilityUseRecordUnf = {
+        const modified: PreDmgAbilityUseRecordUnf = {
             ...usedAbility,
             extraData,
         };

--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -266,7 +266,7 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
 
     async simulate(set: CharacterGearSet): Promise<FullResultType> {
         console.debug("Sim start");
-        let setGcd = set.isStatRelevant('spellspeed') ? set.computedStats.gcdMag(2.5) : set.computedStats.gcdPhys(2.5);
+        let setGcd = set.isStatRelevant('spellspeed') ? set.computedStats.spellspeed : set.computedStats.skillspeed;
         if (setGcd != this.cachedGcd) {
             this.cachedCycleProcessors = this.generateRotations(set);
             this.cachedGcd = setGcd;

--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -57,6 +57,8 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
 
     readonly manualRun = false;
 
+    private cachedCycleProcessors: [string, CycleProcessor][];
+    private cachedGcd: number;
     protected constructor(public readonly job: JobName, settings?: ExternalCycleSettings<InternalSettingsType>) {
         this.settings = this.makeDefaultSettings();
         if (settings !== undefined) {
@@ -205,11 +207,12 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
     };
 
 
-    async simulate(set: CharacterGearSet): Promise<FullResultType> {
-        console.debug("Sim start");
+    generateRotations(set: CharacterGearSet): [string, CycleProcessor][] {
+
         const allBuffs = this.buffManager.enabledBuffs;
         const rotations = this.getRotationsToSimulate(set);
-        const allResults = rotations.map((rot, index) => {
+        return rotations.map((rot, index) => {
+        
             const cp = this.createCycleProcessor({
                 stats: set.computedStats,
                 totalTime: this.cycleSettings.totalTime,
@@ -219,7 +222,15 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
                 useAutos: (this.cycleSettings.useAutos ?? true) && set.getItemInSlot('Weapon') !== null
             });
             rot.apply(cp);
+            return [rot.name ?? `Unnamed #${index + 1}`, cp];
+        });
+    }
 
+    calcDamage(set: CharacterGearSet): FullResultType {
+        let allResults = this.cachedCycleProcessors.map(item => {
+            let [label, cp] = item;
+
+            cp.stats = set.computedStats;
             const used = cp.finalizedRecords.filter(isFinalizedAbilityUse);
             const totalDamage = addValues(...used.map(used => used.totalDamageFull));
             const timeBasis = Math.min(cp.totalTime, cp.currentTime);
@@ -236,12 +247,13 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
                 unbuffedPps: unbuffedPps,
                 buffTimings: buffTimings,
                 totalTime: timeBasis,
-                label: rot.name ?? `Unnamed #${index + 1}`,
+                label: label,
             } satisfies CycleSimResult as unknown as ResultType;
         });
         const sorted = [...allResults];
         sorted.sort((a, b) => b.mainDpsResult - a.mainDpsResult);
         console.debug("Sim end");
+        console.log(`Num: ${sorted.length}`);
         const best = sorted[0];
         // @ts-expect-error Developer will need to override this method if they want to use a custom type for the
         // full result type.
@@ -250,6 +262,16 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
             all: sorted,
             best: best
         };
+    }
+
+    async simulate(set: CharacterGearSet): Promise<FullResultType> {
+        console.debug("Sim start");
+        let setGcd = set.isStatRelevant('spellspeed') ? set.computedStats.gcdMag(2.5) : set.computedStats.gcdPhys(2.5);
+        if (setGcd != this.cachedGcd) {
+            this.cachedCycleProcessors = this.generateRotations(set);
+            this.cachedGcd = setGcd;
+        }
+        return this.calcDamage(set);
     };
 
 }

--- a/packages/frontend/src/scripts/sims/sim_processors.ts
+++ b/packages/frontend/src/scripts/sims/sim_processors.ts
@@ -58,7 +58,7 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
     readonly manualRun = false;
 
     private cachedCycleProcessors: [string, CycleProcessor][];
-    private cachedGcd: number;
+    private cachedSpeed: number;
     protected constructor(public readonly job: JobName, settings?: ExternalCycleSettings<InternalSettingsType>) {
         this.settings = this.makeDefaultSettings();
         if (settings !== undefined) {
@@ -227,8 +227,8 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
     }
 
     calcDamage(set: CharacterGearSet): FullResultType {
-        let allResults = this.cachedCycleProcessors.map(item => {
-            let [label, cp] = item;
+        const allResults = this.cachedCycleProcessors.map(item => {
+            const [label, cp] = item;
 
             cp.stats = set.computedStats;
             const used = cp.finalizedRecords.filter(isFinalizedAbilityUse);
@@ -266,10 +266,10 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
 
     async simulate(set: CharacterGearSet): Promise<FullResultType> {
         console.debug("Sim start");
-        let setGcd = set.isStatRelevant('spellspeed') ? set.computedStats.spellspeed : set.computedStats.skillspeed;
-        if (setGcd != this.cachedGcd) {
+        const setSpeed = set.isStatRelevant('spellspeed') ? set.computedStats.spellspeed : set.computedStats.skillspeed;
+        if (setSpeed != this.cachedSpeed) {
             this.cachedCycleProcessors = this.generateRotations(set);
-            this.cachedGcd = setGcd;
+            this.cachedSpeed = setSpeed;
         }
         return this.calcDamage(set);
     };


### PR DESCRIPTION
Splits up the rotation-generating step and the calculating-damage step of `BaseMultiCycleSim` and `CycleProcessor`.

`BaseMultiCycleSim` now caches the most recent rotation and only re-generates it when speed stat changes, instead of generating the rotation with every call to `simulate()