### PR TITLE
Show equivalent alt items

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -19,7 +19,7 @@
     <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myValues">
         <value>
-          <list size="44">
+          <list size="45">
             <item index="0" class="java.lang.String" itemvalue="nobr" />
             <item index="1" class="java.lang.String" itemvalue="noembed" />
             <item index="2" class="java.lang.String" itemvalue="comment" />
@@ -64,6 +64,7 @@
             <item index="41" class="java.lang.String" itemvalue="save-as-modal" />
             <item index="42" class="java.lang.String" itemvalue="custom-item-popup" />
             <item index="43" class="java.lang.String" itemvalue="custom-food-popup" />
+            <item index="44" class="java.lang.String" itemvalue="alt-items-modal" />
           </list>
         </value>
       </option>

--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -1,4 +1,4 @@
-import 'global-jsdom/register'
+import 'global-jsdom/register';
 import './polyfills';
 import Fastify, {FastifyRequest} from "fastify";
 import {getShortLink} from "@xivgear/core/external/shortlink_server";

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1280,7 +1280,7 @@ table.gear-items-table, table.food-items-table {
 
       &:hover {
         &[is-selected="true"] {
-          .remove-item-button, .remove-food-button{
+          .remove-item-button, .remove-food-button {
             background: none;
             display: block;
             .borderless-button;
@@ -1707,6 +1707,7 @@ div.gear-sheet-toolbar-holder {
     margin-right: -3px;
     align-items: center;
     gap: 10px;
+
     button {
       line-height: 0;
       width: 40px;
@@ -1716,12 +1717,14 @@ div.gear-sheet-toolbar-holder {
       display: flex;
       justify-content: center;
       padding: 2px;
+
       svg {
         margin: auto;
         width: 100%;
         height: 100%;
       }
     }
+
     @media screen and (max-width: 630px) {
       flex-direction: column;
       gap: 2px;
@@ -2438,23 +2441,38 @@ gear-set-viewer {
       }
     }
 
-    .item-name-holder-view {
+    .gear-items-view-item-header {
       display: flex;
       flex-direction: row;
+      gap: 10px;
+      align-items: center;
 
-      span.item-name {
-        flex-basis: 1px;
-        flex-grow: 99;
-        overflow: hidden;
-        text-overflow: ellipsis;
+      > * {
+        display: inline-block;
       }
 
-      span.item-alts {
-        flex-basis: fit-content;
-        flex-shrink: 0;
-        flex-grow: 0;
+      > button {
+        .invert-input-colors;
       }
     }
+
+    //.item-name-holder-view {
+    //  display: flex;
+    //  flex-direction: row;
+    //
+    //  span.item-name {
+    //    flex-basis: 1px;
+    //    flex-grow: 99;
+    //    overflow: hidden;
+    //    text-overflow: ellipsis;
+    //  }
+    //
+    //  span.item-alts {
+    //    flex-basis: fit-content;
+    //    flex-shrink: 0;
+    //    flex-grow: 0;
+    //  }
+    //}
   }
 
   .food-view-table {
@@ -3298,6 +3316,31 @@ gear-set-issues-modal {
 .sim-basic-result-table {
   .round-table;
   .shadow-big;
+}
+
+alt-items-modal {
+  .modal-content-area {
+    width: min-content;
+  }
+  table tr {
+    td, th {
+      padding-left: 15px;
+      padding-right: 15px;
+    }
+    *[col-id="icon"] {
+      height: 25px;
+      width: 23px;
+      min-width: 23px;
+      max-width: 23px;
+      padding-right: 0;
+      img {
+        height: 100%;
+      }
+    }
+    *[col-id="itemname"] {
+      padding-left: 0;
+    }
+  }
 }
 
 .formula-top-level {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2437,6 +2437,24 @@ gear-set-viewer {
         //box-shadow: 0 0 3px 3px var(--stat-color) inset;
       }
     }
+
+    .item-name-holder-view {
+      display: flex;
+      flex-direction: row;
+
+      span.item-name {
+        flex-basis: 1px;
+        flex-grow: 99;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      span.item-alts {
+        flex-basis: fit-content;
+        flex-shrink: 0;
+        flex-grow: 0;
+      }
+    }
   }
 
   .food-view-table {

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -944,3 +944,50 @@ export type ItemSingleStatDetail = {
 };
 
 
+/**
+ * Returns true if 'candidateItem' has identical or better stats than 'baseItem'.
+ *
+ * In order to be true, every stat must be identical or greater.
+ *
+ * @param candidateItem
+ * @param baseItem
+ */
+export function isSameOrBetterItem(candidateItem: GearItem, baseItem: GearItem): boolean {
+    // TODO: consider materia slots
+    // Ultimate weapons are equivalent to savage raid but with an extra materia slot. So an ultimate weapon should
+    // be considered an acceptable replacement for a savage weapon, but not the other way around.
+
+
+    // Phase 1: Raw stats
+    const candidateStats = candidateItem.stats;
+    const baseStats = baseItem.stats;
+    for (const [statKey, baseValue] of Object.entries(baseStats)) {
+        const candidateValue = candidateStats[statKey] as number;
+        if (candidateValue < baseValue) {
+            return false;
+        }
+    }
+    // Phase 2: Materia
+    // The logic here is to just check that every materia slot in the base item:
+    // 1. Exists in the candidate item,
+    // 2. is at least the same grade, and
+    // 3. is high grade if the source slot is also high grade
+    for (const baseSlot of baseItem.materiaSlots) {
+        const index = baseItem.materiaSlots.indexOf(baseSlot);
+        if (index in candidateItem.materiaSlots) {
+            const candidateSlot = candidateItem.materiaSlots[index];
+            if (candidateSlot.maxGrade < baseSlot.maxGrade) {
+                return false;
+            }
+            else if (baseSlot.allowsHighGrade && !candidateSlot.allowsHighGrade) {
+                return false;
+            }
+        }
+        else {
+            // Not enough slots
+            return false;
+        }
+    }
+
+    return true;
+}

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */                                                                                                                                                                                                                                                                // TODO: get back to fixing this at some point
+/* eslint-disable @typescript-eslint/no-explicit-any */                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                // TODO: get back to fixing this at some point
 import {
     CURRENT_MAX_LEVEL,
     defaultItemDisplaySettings,
@@ -36,7 +36,7 @@ import {
     SimExport,
     Substat
 } from "@xivgear/xivmath/geartypes";
-import {CharacterGearSet} from "./gear";
+import {CharacterGearSet, isSameOrBetterItem} from "./gear";
 import {DataManager, makeDataManager} from "./datamanager";
 import {Inactivitytimer} from "./util/inactivitytimer";
 import {writeProxy} from "./util/proxies";
@@ -836,5 +836,26 @@ export class GearPlanSheet {
             customItem.recheckStats();
         }
         this._sets.forEach(set => set.forceRecalc());
+    }
+
+    /**
+     * Get items that could replace the given item - either identical or better.
+     *
+     * @param thisItem
+     */
+    getAltItemsFor(thisItem: GearItem): GearItem[] {
+        // Ignore this for relics - consider them to be incompatible until we can
+        // figure out a good way to do this.
+        if (thisItem.isCustomRelic) {
+            return [];
+        }
+        return this.dataManager.allItems.filter(otherItem => {
+            // Cannot be the same item
+            return otherItem.id !== thisItem.id
+                // Must be same slot
+                && otherItem.occGearSlotName === thisItem.occGearSlotName
+                // Must be better or same stats
+                && isSameOrBetterItem(otherItem, thisItem);
+        });
     }
 }

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -744,7 +744,8 @@ export class GearItemsViewTable extends CustomTable<GearSlotItem, EquipmentSet> 
                 const item = {
                     slot: slot,
                     item: equippedItem,
-                    slotId: slotId
+                    slotId: slotId,
+                    alts: sheet.getAltItemsFor(equippedItem)
                 };
                 slotItem = equippedItem;
                 data.push(item);
@@ -786,10 +787,20 @@ export class GearItemsViewTable extends CustomTable<GearSlotItem, EquipmentSet> 
                 shortName: "itemname",
                 displayName: headingText,
                 getter: item => {
-                    return item.item.name;
+                    return item;
                 },
-                renderer: (name: string) => {
-                    return document.createTextNode(shortenItemName(name));
+                renderer: (item) => {
+                    const name = item.item.name;
+                    const itemNameSpan = quickElement('span', ['item-name'], [shortenItemName(name)]);
+                    const out = quickElement('div', ['item-name-holder-view'], [itemNameSpan]);
+                    if (item.alts.length > 0) {
+                        const altSpan = quickElement('span', ['item-alts'], [`(+${item.alts.length} others)`]);
+                        altSpan.addEventListener('click', () => {
+                            console.log("Alts", item.alts);
+                        });
+                        out.appendChild(altSpan);
+                    }
+                    return out;
                 },
                 // initialWidth: 300,
             },

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -44,7 +44,6 @@ import {GearPlanSheet} from "@xivgear/core/sheet";
 import {makeRelicStatEditor} from "./relic_stats";
 import {ShowHideButton} from "@xivgear/common-ui/components/show_hide_chevron";
 import {BaseModal} from "@xivgear/common-ui/components/modal";
-import {CustomItem} from "@xivgear/core/customgear/custom_item";
 
 function statCellStylerRemover(cell: CustomCell<GearSlotItem, unknown>) {
     cell.classList.remove("secondary");


### PR DESCRIPTION
When there are items that could be replaced by another item and provide a pure upgrade or exact same stats, this will be indicated on the UI:

![image](https://github.com/user-attachments/assets/73ba8532-d035-4cf8-ac77-656a4978ba21)

Clicking the button opens this dialog:

![image](https://github.com/user-attachments/assets/49e919a0-147c-45ae-9daa-1b544a67e1d5)
