### PR TITLE
Fix the mouseover info in the stat tier display

### DIFF
--- a/packages/frontend/src/scripts/components/stat_tier_display.ts
+++ b/packages/frontend/src/scripts/components/stat_tier_display.ts
@@ -120,7 +120,7 @@ export class SingleStatTierDisplay extends HTMLDivElement {
             if (tieringResult.lower > 0) {
                 lowerLeftDiv.textContent = '-' + tieringResult.lower;
                 div.classList.remove('stat-tiering-perfect');
-                this.lowerLeftDiv.title = `Your ${tiering.fullName} is ${tieringResult.lower} above the next-lowest tier.\nIn other words, you could lose up to ${tieringResult.lower} points without negatively impacting your ${tiering.fullName}.`;
+                lowerLeftDiv.title = `Your ${tiering.fullName} is ${tieringResult.lower} above the next-lowest tier.\nIn other words, you could lose up to ${tieringResult.lower} points without negatively impacting your ${tiering.fullName}.`;
             }
             else {
                 lowerLeftDiv.textContent = '✔';


### PR DESCRIPTION
An accidental "this" appears in stat_tier_display.ts, which overrides the main stat tier div instead of the expansion DIVs
This is inside the loop that generates the different remove/add materia variations for the stat tiers

It causes 2 issues:
1. The popup info for the lowerLeftDiv is wrong
2. There's no popup info for the any of the expansion lowerLeftDivs

### This is the "wrong info" issue:
![image](https://github.com/user-attachments/assets/efd3e6c4-a29b-4df7-aedb-1289015f9906)

### For reference, this is from the /math page
![image](https://github.com/user-attachments/assets/51768d66-1fe3-42a0-b177-7e68c6b85198)

### This is how it should look like:
![image](https://github.com/user-attachments/assets/65fe2c1b-309b-4a04-b3e8-271663e06c16)

Removing the "this" fixes both of those issues