### PR TITLE
Fix Error! appearing for Separator descriptions

### DIFF
--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1822,7 +1822,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
     refreshToolbar() {
         if (this._editorItem instanceof CharacterGearSet) {
-            if (this.toolbarHolder !== undefined && 'refresh' in this.toolbarNode && typeof this.toolbarNode.refresh === 'function') {
+            if (this.toolbarNode !== undefined && 'refresh' in this.toolbarNode && typeof this.toolbarNode.refresh === 'function') {
                 this.toolbarNode.refresh(this._editorItem);
             }
         }


### PR DESCRIPTION
Just a little typo

Before:
![image](https://github.com/user-attachments/assets/0cc5ef9e-5fec-4fca-ba57-eff492c9bc63)

After:
![image](https://github.com/user-attachments/assets/9128074a-0b83-4e4a-a140-f8c9134e23ed)

![image](https://github.com/user-attachments/assets/22bd6bc7-ef1c-407e-97ae-7ce977a8f036)
