### PR TITLE
Cosmetic fixes

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -3019,6 +3019,11 @@ body.modern {
     button, select {
       --button-color: var(--bg-color);
     }
+
+    input {
+      background: var(--bg-color) !important;
+      border: none !important;
+    }
   }
 
   gear-set-editor {
@@ -3321,24 +3326,33 @@ gear-set-issues-modal {
 alt-items-modal {
   .modal-content-area {
     width: min-content;
+    max-width: 100%;
   }
-  table tr {
-    td, th {
-      padding-left: 15px;
-      padding-right: 15px;
-    }
-    *[col-id="icon"] {
-      height: 25px;
-      width: 23px;
-      min-width: 23px;
-      max-width: 23px;
-      padding-right: 0;
-      img {
-        height: 100%;
+
+  table {
+    width: max-content;
+
+    tr {
+      td, th {
+        padding-left: 15px;
+        padding-right: 15px;
       }
-    }
-    *[col-id="itemname"] {
-      padding-left: 0;
+
+      *[col-id="icon"] {
+        height: 25px;
+        width: 23px;
+        min-width: 23px;
+        max-width: 23px;
+        padding-right: 0;
+
+        img {
+          height: 100%;
+        }
+      }
+
+      *[col-id="itemname"] {
+        padding-left: 0;
+      }
     }
   }
 }

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -873,7 +873,7 @@ export class AltItemsModal extends BaseModal {
 
         const text = document.createElement('p');
         text.textContent = `The item ${baseItem.name} can be replaced by all of the following items, which have equivalent or better effective stats:`;
-        this.contentArea.appendChild(text);
+        this.contentArea.appendChild(quickElement('div', ['alt-items-text-holder'], [text]));
 
         const table : CustomTable<GearItem> = new CustomTable<GearItem>();
         table.columns = [


### PR DESCRIPTION
1. Make input colors consistent on toolbar

![image](https://github.com/user-attachments/assets/784d8975-a197-45c1-b083-29b8a882625f)
![image](https://github.com/user-attachments/assets/a0743dfa-3148-4427-b1d2-b68e75c85a84)
![image](https://github.com/user-attachments/assets/f8a8b943-a21d-4a62-a086-fc93113e0c7d)
![image](https://github.com/user-attachments/assets/8f842ca1-656d-4448-8b7e-d00e32260c44)

2. Fix the width of the alt-items modal (it has enough width to fit the final column on one row)

![image](https://github.com/user-attachments/assets/dcc67135-951b-4ae4-a9e4-49a66d135c8c)
