### PR TITLE
[DRK Sim] Improve Living Shadow, add Prepull TBN, misc improvements/fixes

### DIFF
--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -140,26 +140,12 @@ export const SaltAndDarkness: DrkOgcdAbility = {
     },
 };
 
-export const LivingShadow: DrkOgcdAbility = {
-    type: 'ogcd',
-    name: "Living Shadow",
-    id: 16472,
-    // Not really, but it's a WIP
-    potency: 2450,
-    attackType: "Ability",
-    activatesBuffs: [ScornBuff],
-    cooldown: {
-        time: 120,
-        charges: 1,
-    },
-};
-
 export const Disesteem: DrkGcdAbility = {
     type: 'gcd',
     name: "Disesteem",
     id: 36932,
     potency: 1000,
-    attackType: "Spell",
+    attackType: "Weaponskill",
     gcd: 2.5,
 };
 
@@ -210,4 +196,91 @@ export const Shadowbringer: DrkOgcdAbility = {
         time: 60,
         charges: 2,
     },
+};
+
+// While Living Shadow abilities are actually Weaponskills in some cases,
+// they've all been programmed to be abilities so that it doesn't roll GCD. 
+//
+// This shouldn't change anything damage wise.
+//
+// Living Shadow's rotation is the following:
+// Abyssal Drain (AoE)
+// Shadowstride (no damage)
+// Flood of Shadow (Shadowbringer at level 90+)(AoE)
+// Edge of Shadow
+// Bloodspiller
+// Carve and Spit (Disesteem(AoE) at level 100)
+
+// Esteem has the same stats as the player but ignores skill speed, Tank Mastery, and party strength bonus. 
+// It also substitutes Midlander racial strength bonus regardless of the player's race.
+// It has an alternate strength scaling.
+
+// Esteem updates buffs/debuffs in real time. It is NOT affected by Darkside or by Weakness, 
+// but mirrors all other statuses on the player (including tincture, AST cards, DNC partner buffs, and Damage Down).
+export const LivingShadow: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "Living Shadow",
+    id: 16472,
+    // Total potency of its abilities is 2450.
+    potency: 0,
+    attackType: "Ability",
+    activatesBuffs: [ScornBuff],
+    cooldown: {
+        time: 120,
+        charges: 1,
+    },
+};
+
+export const LivingShadowShadowstride: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Shadowstride",
+    animationLock: 0,
+    id: 38512,
+    potency: 0,
+    attackType: "Ability",
+};
+
+export const LivingShadowAbyssalDrain: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Abyssal Drain",
+    animationLock: 0,
+    id: 17904,
+    potency: 420,
+    attackType: "Ability",
+};
+
+export const LivingShadowShadowbringer: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Shadowbringer",
+    animationLock: 0,
+    id: 25881,
+    potency: 570,
+    attackType: "Ability",
+};
+
+export const LivingShadowEdgeOfShadow: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Edge of Shadow",
+    animationLock: 0,
+    id: 17908,
+    potency: 420,
+    attackType: "Ability",
+};
+
+export const LivingShadowBloodspiller: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Bloodspiller",
+    animationLock: 0,
+    id: 17909,
+    potency: 420,
+    attackType: "Ability",
+};
+
+export const LivingShadowDisesteem: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Disesteem",
+    animationLock: 0,
+    id: 36933,
+    potency: 620,
+    attackType: "Ability",
 };

--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -77,6 +77,7 @@ export const Torcleaver: DrkGcdAbility = {
 export const Unmend: DrkGcdAbility = {
     type: 'gcd',
     name: "Unmend",
+    appDelay: 1,
     id: 3624,
     potency: 150,
     attackType: "Spell",
@@ -172,7 +173,7 @@ export const TheBlackestNight: DrkOgcdAbility = {
     type: 'ogcd',
     name: "The Blackest Night",
     id: 7393,
-    potency: 0,
+    potency: null,
     attackType: "Ability",
     cooldown: {
         time: 15,

--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -223,7 +223,7 @@ export const LivingShadow: DrkOgcdAbility = {
     name: "Living Shadow",
     id: 16472,
     // Total potency of its abilities is 2450.
-    potency: 0,
+    potency: null,
     attackType: "Ability",
     activatesBuffs: [ScornBuff],
     cooldown: {

--- a/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
+++ b/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
@@ -6,7 +6,7 @@ import { CharacterGearSet } from "@xivgear/core/gear";
 import { formatDuration } from "@xivgear/core/util/strutils";
 import { STANDARD_ANIMATION_LOCK } from "@xivgear/xivmath/xivconstants";
 import { DrkGauge } from "./drk_gauge";
-import { DrkExtraData, DrkAbility, DrkRotationData } from "./drk_types";
+import { DrkExtraData, DrkAbility } from "./drk_types";
 import { sum } from "@xivgear/core/util/array_utils";
 import * as Drk250 from './rotations/drk_lv100_250';
 import * as Drk246 from './rotations/drk_lv100_246';

--- a/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
+++ b/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
@@ -20,7 +20,8 @@ export interface DrkSimResult extends CycleSimResult {
 
 export interface DrkSettings extends SimSettings {
     usePotion: boolean;
-    prepullTBN: boolean; // If we use a pre-pull TBN. Currently doesn't fully support 'false', but could in the future.
+    // If we use a pre-pull TBN. This should be exposed and more fully tested as 'false' once the computationally created rotation is implemented.
+    prepullTBN: boolean; 
     fightTime: number; // the length of the fight in seconds
     // TODO: should we add a prepull Shadowstride option? Would be nice to compare on differing killtimes
 }
@@ -299,7 +300,7 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
         }
 
         // Only use potion if enabled in settings
-        if (!this.settings.usePotion && ability.name.includes("of strength")) {
+        if (!this.settings.usePotion && ability.name.includes("of Strength")) {
             return null;
         }
 
@@ -341,6 +342,8 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
             cp.advanceTo(3 - STANDARD_ANIMATION_LOCK);
             // Hacky out of combat mana tick.
             cp.gauge.magicPoints += 600
+        } else {
+            cp.advanceTo(1 - STANDARD_ANIMATION_LOCK);
         }
         this.use(cp, Actions.Unmend)        
         cp.advanceForLateWeave([potionMaxStr]);
@@ -392,6 +395,7 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
         const rotation = DrkSim.getRotationForGcd(gcd);
 
         console.log(`[DRK Sim] Running Rotation for ${gcd} GCD...`);
+        console.log(`[DRK Sim] Settings configured: ${JSON.stringify(settings)}`)
         return [{
             cycleTime: 120,
             apply(cp: DrkCycleProcessor) {

--- a/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
+++ b/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
@@ -74,8 +74,8 @@ class DrkCycleProcessor extends CycleProcessor {
     }
 
     fightEndingSoon(): boolean {
-        // If the fight is ending within the next 10 seconds (to dump resources)
-        return this.currentTime > (this.totalTime - 10);
+        // If the fight is ending within the next 12 seconds (to dump resources)
+        return this.currentTime > (this.totalTime - 12);
     }
 
     // Gets the DRK ability with Blood Weapon's blood and MP additions
@@ -237,7 +237,7 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
         }
 
         // If we try to use Living Shadow, do it properly
-        if (ability.id === 16472) {
+        if (ability.id === Actions.LivingShadow.id) {
             // After 6.8 delay, it does the following rotation with
             // 2.18 seconds between each.
             // Abyssal Drain
@@ -285,7 +285,7 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
         this.applyLivingShadowAbilities(cp)
 
         // Log when we try to use more gauge than what we currently have
-        if (drkAbility.id === 7392 && cp.gauge.bloodGauge < 50) {
+        if (drkAbility.id === Actions.Bloodspiller.id && cp.gauge.bloodGauge < 50) {
             console.warn(`[${formatDuration(cp.currentTime)}][DRK Sim] Attempted to use Bloodspiller when you only have ${cp.gauge.bloodGauge} blood`);
             return null;
         }

--- a/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
+++ b/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
@@ -106,11 +106,9 @@ class DrkCycleProcessor extends CycleProcessor {
         // Get what the the Darkside duration would be at this
         // point of time, for visualization in the UI
         const darkside = buffs.find(buff => buff.name === "Darkside")
-        if (darkside) {
-            const buffData = this.getActiveBuffData(darkside, abilityUsage.usageTime)
-            if (buffData) {
-                darksideDuration = Math.round(buffData.end - abilityUsage.usageTime)
-            }
+        const buffData = darkside && this.getActiveBuffData(darkside, abilityUsage.usageTime)
+        if (buffData) {
+            darksideDuration = Math.round(buffData.end - abilityUsage.usageTime)
         }
 
         // However, Darkside does not apply to Living Shadow abilities, so
@@ -144,11 +142,9 @@ class DrkCycleProcessor extends CycleProcessor {
         };
         
         const darkside = usedAbility.buffs.find(buff => buff.name === "Darkside")
-        if (darkside) {
-            const buffData = this.getActiveBuffData(darkside, usedAbility.usedAt)
-            if (buffData) {
-                extraData.darksideDuration = Math.round(buffData.end - usedAbility.usedAt)
-            }
+        const buffData = darkside && this.getActiveBuffData(darkside, usedAbility.usedAt)
+        if (buffData) {
+            extraData.darksideDuration = Math.round(buffData.end - usedAbility.usedAt)
         }
 
         const modified: PreDmgAbilityUseRecordUnf = {
@@ -342,6 +338,7 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
             this.use(cp, Actions.TheBlackestNight)
             cp.advanceTo(3 - STANDARD_ANIMATION_LOCK);
             // Hacky out of combat mana tick.
+            // TODO: Refactor this once MP is handled in a more core way
             cp.gauge.magicPoints += 600
         } else {
             cp.advanceTo(1 - STANDARD_ANIMATION_LOCK);

--- a/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
+++ b/packages/core/src/sims/tank/drk/drk_lv100_sim.ts
@@ -169,6 +169,7 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
         totalTime: this.settings.fightTime,
         cycles: 0,
         which: 'totalTime',
+        cutoffMode: 'prorate-gcd',
     }
     mpTicks = 0
     // livingShadowAbilityUsages tracks which remaining Living Shadow abilities we have

--- a/packages/core/src/sims/tank/drk/drk_types.ts
+++ b/packages/core/src/sims/tank/drk/drk_types.ts
@@ -114,16 +114,3 @@ export const DeliriumBuff: Buff = {
     },
     statusId: 3836,
 };
-
-/** Represents the Rotation data based on GCD. */
-export type DrkRotationData = {
-    /** The name of the rotation selected */
-    name: string,
-    /** The actual rotations selected */
-    rotation: {
-        /** The opener for the rotation */
-        opener: DrkAbility[],
-        /** The optional rotation loop */
-        loop: DrkAbility[],
-    }
-};

--- a/packages/core/src/sims/tank/drk/rotations/drk_lv100_246.ts
+++ b/packages/core/src/sims/tank/drk/rotations/drk_lv100_246.ts
@@ -2,35 +2,11 @@ import { potionMaxStr } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../drk_actions';
 import { DrkAbility } from "../drk_types";
 
-export const Opener: DrkAbility[] = [
-    Actions.Unmend,
-    potionMaxStr,
-    Actions.HardSlash,
-    Actions.EdgeOfShadow,
-    Actions.LivingShadow,
-    Actions.SyphonStrike,
-    Actions.Souleater,
-    Actions.Delirium,
-    Actions.Disesteem,
-    Actions.SaltedEarth,
-    Actions.EdgeOfShadow,
-    Actions.ScarletDelirium,
-    Actions.EdgeOfShadow,
-    Actions.Comeuppance,
-    Actions.CarveAndSpit,
-    Actions.EdgeOfShadow,
-    Actions.Torcleaver,
-    Actions.Shadowbringer,
-    Actions.EdgeOfShadow,
-    Actions.Bloodspiller,
-    Actions.SaltAndDarkness,
-];
-
 // This is transcribed from https://www.youtube.com/watch?v=-qDvEZQU9dQ with: 
 // - an additional Edge in every two minute burst, assuming we have Dark Arts.
 // - a 6m pot added
 // - an extra GCD combo and bloodspiller added
-export const Loop: DrkAbility[] = [
+export const Rotation: DrkAbility[] = [
     Actions.HardSlash,
     Actions.SyphonStrike,
     Actions.Souleater,

--- a/packages/core/src/sims/tank/drk/rotations/drk_lv100_246.ts
+++ b/packages/core/src/sims/tank/drk/rotations/drk_lv100_246.ts
@@ -212,8 +212,8 @@ export const Loop: DrkAbility[] = [
     Actions.Souleater,
     Actions.HardSlash,
     Actions.SyphonStrike,
-    potionMaxStr, //6m pot -- TODO this should optimally be slightly later once Living Shadow delay is implemented
     Actions.LivingShadow,
+    potionMaxStr, //6m pot
     Actions.Souleater,
     Actions.HardSlash,
     Actions.Delirium,

--- a/packages/core/src/sims/tank/drk/rotations/drk_lv100_250.ts
+++ b/packages/core/src/sims/tank/drk/rotations/drk_lv100_250.ts
@@ -206,9 +206,9 @@ export const Loop: DrkAbility[] = [
     Actions.HardSlash,
     Actions.SyphonStrike,
     Actions.Souleater,
-    potionMaxStr, //6m pot -- TODO this should optimally be slightly later once Living Shadow delay is implemented
     Actions.LivingShadow,
     Actions.HardSlash,
+    potionMaxStr, //6m pot
     Actions.Bloodspiller,
     Actions.Delirium,
     Actions.Disesteem,

--- a/packages/core/src/sims/tank/drk/rotations/drk_lv100_250.ts
+++ b/packages/core/src/sims/tank/drk/rotations/drk_lv100_250.ts
@@ -2,32 +2,8 @@ import { potionMaxStr } from "@xivgear/core/sims/common/potion";
 import * as Actions from '../drk_actions';
 import { DrkAbility } from "../drk_types";
 
-export const Opener: DrkAbility[] = [
-    Actions.Unmend,
-    potionMaxStr,
-    Actions.HardSlash,
-    Actions.EdgeOfShadow,
-    Actions.LivingShadow,
-    Actions.SyphonStrike,
-    Actions.Souleater,
-    Actions.Delirium,
-    Actions.Disesteem,
-    Actions.SaltedEarth,
-    Actions.EdgeOfShadow,
-    Actions.ScarletDelirium,
-    Actions.EdgeOfShadow,
-    Actions.Comeuppance,
-    Actions.CarveAndSpit,
-    Actions.EdgeOfShadow,
-    Actions.Torcleaver,
-    Actions.Shadowbringer,
-    Actions.EdgeOfShadow,
-    Actions.Bloodspiller,
-    Actions.SaltAndDarkness,
-];
-
 // This is transcribed from a spreadsheeted 2.50 rotation.
-export const Loop: DrkAbility[] = [
+export const Rotation: DrkAbility[] = [
     Actions.HardSlash,
     Actions.SyphonStrike,
     Actions.Souleater,
@@ -211,6 +187,7 @@ export const Loop: DrkAbility[] = [
     potionMaxStr, //6m pot
     Actions.Bloodspiller,
     Actions.Delirium,
+    Actions.EdgeOfShadow,
     Actions.Disesteem,
     Actions.SaltedEarth,
     Actions.EdgeOfShadow,
@@ -221,13 +198,11 @@ export const Loop: DrkAbility[] = [
     Actions.CarveAndSpit,
     Actions.EdgeOfShadow,
     Actions.Torcleaver,
-    Actions.TheBlackestNight,
     Actions.Shadowbringer,
     Actions.EdgeOfShadow,
     Actions.Bloodspiller,
     Actions.SaltAndDarkness,
     Actions.SyphonStrike,
-    Actions.EdgeOfShadow,
     Actions.Souleater,
     Actions.Bloodspiller,
     Actions.HardSlash,
@@ -253,6 +228,7 @@ export const Loop: DrkAbility[] = [
     Actions.EdgeOfShadow,
     Actions.Comeuppance,
     Actions.Torcleaver,
+    Actions.TheBlackestNight,
     Actions.Bloodspiller,
     Actions.SyphonStrike,
     Actions.Souleater,


### PR DESCRIPTION
Living Shadow now works correctly:
- Damage is applied when it should be applied
- Darkside no longer applies
- It still needs to get the correct stats, but that will come later, as it requires a deeper change

Prepull TBN is added

Some extra pre-work has been done in advance of adding the computationally created rotation

![image](https://github.com/user-attachments/assets/ea82e0fe-99de-4576-8225-2267f8038460)
