### PR TITLE
More feexes

### DIFF
--- a/packages/core/src/solving/gearset_generation.ts
+++ b/packages/core/src/solving/gearset_generation.ts
@@ -151,26 +151,22 @@ export class GearsetGenerator {
             const newGearset: CharacterGearSet = new CharacterGearSet(this._sheet);
             newGearset.food = settings.gearset.food;
             newGearset.equipment = combination.set;
+            if (newGearset.equipment.Weapon) {
+                newGearset.equipment.Weapon.relicStats = settings.gearset.equipment.Weapon.relicStats ?? undefined;
+            }
             
             newGearset.forceRecalc();
             const gcd = useSks ? newGearset.computedStats.gcdPhys(NORMAL_GCD, haste)
                                 : newGearset.computedStats.gcdMag(NORMAL_GCD, haste);
             
             if (settings.useTargetGcd && gcd !== settings.targetGcd) {
-                //console.log(`skipping, gcd=${gcd}`);
                 continue;
             }
             
             generatedGearsets[i] = newGearset;
             i++;
-            /*
-            const speedStat = useSks ? newGearset.computedStats.skillspeed : newGearset.computedStats.spellspeed;
-            if (!generatedGearsets.has(speedStat)) {
-                generatedGearsets.set(speedStat, new Set);
-            }
-            generatedGearsets.get(speedStat).add(newGearset);
-            */
         }
+        generatedGearsets.length = i; // Cull empty objects
 
         return generatedGearsets;
     }

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -183,7 +183,21 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
     private readonly disableables = [];
     constructor(sheet: GearPlanSheetGui, set: CharacterGearSet) {
         super();
-        this.gearsetGenSettings = new GearsetGenerationSettings(set, false, false, 2.50);
+
+        let gcd = 2.5;
+        const override = sheet.classJobStats.gcdDisplayOverrides?.(sheet.level);
+        if (override && override.length >= 1) {
+            const haste = set.computedStats.haste(override[0].attackType) + (override[0].haste ?? 0);
+            switch (override[0].basis) {
+                case "sks":
+                    gcd = set.computedStats.gcdPhys(2.5, haste);
+                    break;
+                case "sps":
+                    gcd = set.computedStats.gcdMag(2.5, haste);
+                    break;
+            }
+        }
+        this.gearsetGenSettings = new GearsetGenerationSettings(set, false, false, gcd);
         this.simSettings = {
             sim: sheet.sims.at(0),
             sets: undefined, // Not referenced in UI

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -269,6 +269,7 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
                 item.disabled = !enabled;
             }
         }
+        this.targetGcdInput.disabled = !this.gearsetGenSettings.useTargetGcd;
     }
 }
 

--- a/packages/frontend/src/scripts/workers/meld_generation_worker.ts
+++ b/packages/frontend/src/scripts/workers/meld_generation_worker.ts
@@ -27,7 +27,7 @@ export class GearsetGenerationWorker extends WorkerBehavior<GearsetGenerationJob
         const setGenerator = new GearsetGenerator(this.sheet, gearsetGenSettings);
         const allGearsets = setGenerator.getMeldPossibilitiesForGearset(gearsetGenSettings);
 
-        const setsToExport: SetExport[] = allGearsets.map(set => this.sheet.exportGearSet(set)).filter(set => Object.keys(set).length !== 0);
+        const setsToExport: SetExport[] = allGearsets.map(set => this.sheet.exportGearSet(set));
 
         this.postResult(setsToExport);
     }


### PR DESCRIPTION
Fixed:
- target gcd text box being disabled wrong
- meld solver not including relic stats in generated sets
Added:
- auto-fills the current GCD of the set for the target GCD