### PR TITLE
Prevent melds on items based on equip level

### DIFF
--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -304,7 +304,7 @@ export class NewApiDataManager implements DataManager {
                 }
                 const ilvlSyncPromise: Promise<IlvlSyncInfo> = isyncLvl === null ? Promise.resolve(undefined) : this.getIlvlSyncData(baseParamPromise, isyncLvl);
                 extraPromises.push(Promise.all([itemIlvlPromise, ilvlSyncPromise]).then(([native, sync]) => {
-                    item.applyIlvlData(native, sync);
+                    item.applyIlvlData(native, sync, this._level);
                     if (item.isCustomRelic) {
                         console.debug('Applying relic model');
                         item.relicStatModel = getRelicStatModelFor(item, this._baseParams, this._classJob);
@@ -674,13 +674,13 @@ export class DataApiGearInfo implements GearItem {
         }
     }
 
-    applyIlvlData(nativeIlvlInfo: IlvlSyncInfo, syncIlvlInfo?: IlvlSyncInfo) {
+    applyIlvlData(nativeIlvlInfo: IlvlSyncInfo, syncIlvlInfo?: IlvlSyncInfo, level?: number) {
         const statCapsNative = {};
         Object.entries(this.stats).forEach(([stat, _]) => {
             statCapsNative[stat] = nativeIlvlInfo.substatCap(this.occGearSlotName, stat as RawStatKey);
         });
         this.statCaps = statCapsNative;
-        if (syncIlvlInfo && syncIlvlInfo.ilvl < this.ilvl) {
+        if (syncIlvlInfo && (syncIlvlInfo.ilvl < this.ilvl || level < this.equipLvl)) {
             this.unsyncedVersion = {
                 ...this
             };

--- a/packages/core/src/test/datamanager_tests.ts
+++ b/packages/core/src/test/datamanager_tests.ts
@@ -265,6 +265,16 @@ describe('New Datamanager', () => {
                 const item = dm.itemById(40136);
                 expect(item.isSyncedDown).to.eq(false);
             });
+            it('should downsync a lvl93 i660 weapon to 660 (remove melds but not change stats)', () => {
+                const item = dm.itemById(42085);
+                expect(item.isSyncedDown).to.eq(true);
+                expect(item.syncedDownTo).to.eq(660);
+                expect(item.unsyncedVersion.stats.wdMag).to.eq(item.stats.wdMag);
+                expect(item.unsyncedVersion.stats.mind).to.eq(item.stats.mind);
+                expect(item.unsyncedVersion.stats.crit).to.eq(item.stats.crit);
+                expect(item.unsyncedVersion.stats.determination).to.eq(item.stats.determination);
+                expect(item.materiaSlots).to.be.empty;
+            });
             it('should downsync a lvl94 i663 weapon to 660', () => {
                 // Cobalt Tungsten Pendulums
                 const item = dm.itemById(42162);
@@ -322,7 +332,6 @@ describe('New Datamanager', () => {
             //     expect(item.unsyncedVersion.stats.vitality).to.eq(580);
             //     expect(item.stats.vitality).to.eq(411);
             // });
-
         });
     })
 });


### PR DESCRIPTION
Addresses #359 

I will double check if this is appropriate based on in-game instances tomorrow, but I believe this is correct behavior. l94/i663 items lose their melds in game so I believe l94/i660 should as well.