### PR TITLE
Place cloned sets prior to the next separator

### DIFF
--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                // TODO: get back to fixing this at some point
+/* eslint-disable @typescript-eslint/no-explicit-any */                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                // TODO: get back to fixing this at some point
 import {
     CURRENT_MAX_LEVEL,
     defaultItemDisplaySettings,
@@ -453,8 +453,13 @@ export class GearPlanSheet {
 
     }
 
-    addGearSet(gearSet: CharacterGearSet) {
-        this._sets.push(gearSet);
+    addGearSet(gearSet: CharacterGearSet, index?: number) {
+        if (index === undefined) {
+            this._sets.push(gearSet);
+        }
+        else {
+            this._sets.splice(index, 0, gearSet);
+        }
         gearSet.addListener(() => {
             this.requestSave();
         });
@@ -480,10 +485,33 @@ export class GearPlanSheet {
         this._sets = sets;
     }
 
+    /**
+     * Clones the given gear set and adds it as a new gear set.
+     *
+     * This will add it prior to the next separator, since separators are typically used to delineate categories
+     * of sets.
+     *
+     * @param gearSet
+     */
     cloneAndAddGearSet(gearSet: CharacterGearSet) {
         const cloned = this.importGearSet(this.exportGearSet(gearSet));
-        cloned.name = cloned.name + ' copy';
-        this.addGearSet(cloned);
+        cloned.name += ' copy';
+        const toIndex: number | undefined = this.clonedSetPlacement(gearSet);
+        this.addGearSet(cloned, toIndex);
+    }
+
+    protected clonedSetPlacement(originalSet: CharacterGearSet): number | undefined {
+        const originalIndex = this.sets.indexOf(originalSet);
+        if (originalIndex >= 0) {
+            for (let i = originalIndex + 1; i < this.sets.length; i++) {
+                if (this.sets[i].isSeparator) {
+                    return i;
+                }
+            }
+        }
+        // fall back
+        return undefined;
+
     }
 
     /**

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1411,7 +1411,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
             const addRowButton = makeActionButton("New Gear Set", () => {
                 const newSet = new CharacterGearSet(this);
                 newSet.name = "New Set";
-                this.addGearSet(newSet, true);
+                this.addGearSet(newSet, undefined, true);
             });
             buttonsArea.appendChild(addRowButton);
 
@@ -1801,8 +1801,8 @@ export class GearPlanSheetGui extends GearPlanSheet {
         }
     }
 
-    addGearSet(gearSet: CharacterGearSet, select: boolean = false) {
-        super.addGearSet(gearSet);
+    addGearSet(gearSet: CharacterGearSet, index?: number, select: boolean = false) {
+        super.addGearSet(gearSet, index);
         this._gearPlanTable?.dataChanged();
         gearSet.addListener(() => {
             if (this._gearPlanTable) {
@@ -1850,8 +1850,9 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
     cloneAndAddGearSet(gearSet: CharacterGearSet, select: boolean = true) {
         const cloned = this.importGearSet(this.exportGearSet(gearSet));
-        cloned.name = cloned.name + ' copy';
-        this.addGearSet(cloned, select);
+        cloned.name += ' copy';
+        const toIndex: number | undefined = this.clonedSetPlacement(gearSet);
+        this.addGearSet(cloned, toIndex, select);
     }
 
 
@@ -2012,7 +2013,7 @@ export class ImportSetsModal extends BaseModal {
                             return;
                         }
                         sets.forEach(set => {
-                            this.sheet.addGearSet(this.sheet.importGearSet(set), true);
+                            this.sheet.addGearSet(this.sheet.importGearSet(set), undefined, true);
                         });
                         console.log("Imported set(s) from Etro");
                         this.close();
@@ -2056,7 +2057,7 @@ export class ImportSetsModal extends BaseModal {
                 for (let i = 0; i < imports.length; i++) {
                     // Select the first imported set
                     const set = imports[i];
-                    this.sheet.addGearSet(set, i === 0);
+                    this.sheet.addGearSet(set, undefined, i === 0);
                 }
             }
             closeModal();
@@ -2065,7 +2066,7 @@ export class ImportSetsModal extends BaseModal {
             if (!this.checkJob(false, rawImport.job)) {
                 return;
             }
-            this.sheet.addGearSet(this.sheet.importGearSet(rawImport), true);
+            this.sheet.addGearSet(this.sheet.importGearSet(rawImport), undefined, true);
             closeModal();
         }
         else {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3cd53f58-053d-44fb-a8cc-344de597a7df)

Instead of always placing cloned sets at the bottom, they will now be placed immediately prior to the next separator if one exists. Since separators are typically used to delineate categories or sections, this keeps cloned sets in the same logical section.

Fixes #362 