### PR TITLE
Level 70 + 80 + 90 DRK and level-based ability modification

### DIFF
--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -884,12 +884,41 @@ export class CycleProcessor {
     }
 
     /**
+     * Modifies an ability for the level that is being processed by the cycle sim.
+     *
+     * @param ability the ability to modify
+     * @returns the modified ability
+     */
+    applyLevelModifiers(ability: Ability): Ability {
+        if (!ability || !ability.levelModifiers) {
+            return ability;
+        }
+        const level = this.stats.level;
+        console.log("Applying modifications:", ability.levelModifiers);
+        const relevantModifications = ability.levelModifiers.filter(mod => mod.minLevel <= level && mod.maxLevel >= level);
+        console.log("Relevant modifications:", relevantModifications);
+        if (relevantModifications.length === 0) {
+            return ability;
+        }
+        // Just in case there's multiple, pick the one with the highest min level. There should not be multiple.
+        const modification = relevantModifications.reduce((currentLowest, mod) => currentLowest.minLevel > mod.minLevel ? currentLowest : mod);
+        const modifiedAbility = {
+            ...ability,
+            ...modification,
+            minLevel: undefined,
+            maxLevel: undefined,
+        };
+        return modifiedAbility;
+    }
+
+    /**
      * Use an ability
      *
      * @param ability The ability to use
      */
     use(ability: Ability): AbilityUseResult {
         // noinspection AssignmentToFunctionParameterJS
+        ability = this.applyLevelModifiers(ability);
         ability = this.processCombo(ability);
         const isGcd = this.isGcd(ability);
         // if using a non-prorate mode, then allow oGCDs past the cutoff

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -894,19 +894,16 @@ export class CycleProcessor {
             return ability;
         }
         const level = this.stats.level;
-        console.log("Applying modifications:", ability.levelModifiers);
-        const relevantModifications = ability.levelModifiers.filter(mod => mod.minLevel <= level && mod.maxLevel >= level);
-        console.log("Relevant modifications:", relevantModifications);
+        const relevantModifications = ability.levelModifiers.filter(mod => mod.minLevel <= level);
         if (relevantModifications.length === 0) {
             return ability;
         }
-        // Just in case there's multiple, pick the one with the highest min level. There should not be multiple.
+        // If there's multiple, pick the one with the highest min level.
         const modification = relevantModifications.reduce((currentLowest, mod) => currentLowest.minLevel > mod.minLevel ? currentLowest : mod);
         const modifiedAbility = {
             ...ability,
             ...modification,
             minLevel: undefined,
-            maxLevel: undefined,
         };
         return modifiedAbility;
     }

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -246,7 +246,8 @@ export type DamagingAbility = Readonly<{
 
 /**
  * Represents a set of ability attributes that should be applied
- * between two levels.
+ * above a certain level. Can be used to express e.g. traits increasing
+ * the potency of skills, or granting new buffs.
  */
 export type LevelModifier = ({
     minLevel: number,

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -245,6 +245,15 @@ export type DamagingAbility = Readonly<{
 }>;
 
 /**
+ * Represents a set of ability attributes that should be applied
+ * between two levels.
+ */
+export type LevelModifier = ({
+    minLevel: number,
+    maxLevel: number })
+& Omit<Partial<BaseAbility>, 'levelModifiers'>;
+
+/**
  * Combo mode:
  * start: starts a combo.
  * continue: continue (or finish) a combo. If there is no combo, then this is treated as 'break'.
@@ -309,6 +318,12 @@ export type BaseAbility = Readonly<{
      * Override the default application delay
      */
     appDelay?: number,
+    /**
+     * A list of level modifiers, that can override properties of the ability
+     * at the specified level. Two level modifiers should not overlap, i.e.
+     * you should have 1-50 and 51-100 instead of 1-100 and 51-100.
+     */
+    levelModifiers?: LevelModifier[],
 } & (NonDamagingAbility | DamagingAbility)>;
 
 /**

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -250,7 +250,7 @@ export type DamagingAbility = Readonly<{
  */
 export type LevelModifier = ({
     minLevel: number,
-    maxLevel: number })
+})
 & Omit<Partial<BaseAbility>, 'levelModifiers'>;
 
 /**
@@ -320,8 +320,8 @@ export type BaseAbility = Readonly<{
     appDelay?: number,
     /**
      * A list of level modifiers, that can override properties of the ability
-     * at the specified level. Two level modifiers should not overlap, i.e.
-     * you should have 1-50 and 51-100 instead of 1-100 and 51-100.
+     * at the specified level. An action will have its properties overriden for
+     * the highest `minLevel` specified.
      */
     levelModifiers?: LevelModifier[],
 } & (NonDamagingAbility | DamagingAbility)>;

--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -195,6 +195,26 @@ export const Disesteem: DrkGcdAbility = {
     gcd: 2.5,
 };
 
+export const EdgeOfDarkness: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "Edge of Darkness",
+    id: 16467,
+    potency: 300,
+    attackType: "Ability",
+    cooldown: {
+        time: 1,
+    },
+    activatesBuffs: [Darkside],
+    updateMP: (gauge: DrkGauge) => {
+        if (gauge.darkArts) {
+            gauge.darkArts = false;
+        }
+        else {
+            gauge.magicPoints -= 3000;
+        }
+    },
+};
+
 export const EdgeOfShadow: DrkOgcdAbility = {
     type: 'ogcd',
     name: "Edge of Shadow",

--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -9,6 +9,18 @@ export const HardSlash: DrkGcdAbility = {
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 83,
+            potency: 150,
+        },
+        {
+            minLevel: 84,
+            maxLevel: 93,
+            potency: 180,
+        },
+    ],
 };
 
 export const SyphonStrike: DrkGcdAbility = {
@@ -20,6 +32,18 @@ export const SyphonStrike: DrkGcdAbility = {
     gcd: 2.5,
     cast: 0,
     updateMP: gauge => gauge.magicPoints += 600,
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 83,
+            potency: 240,
+        },
+        {
+            minLevel: 84,
+            maxLevel: 93,
+            potency: 260,
+        },
+    ],
 };
 
 export const Souleater: DrkGcdAbility = {
@@ -31,6 +55,18 @@ export const Souleater: DrkGcdAbility = {
     gcd: 2.5,
     cast: 0,
     updateBloodGauge: gauge => gauge.bloodGauge += 20,
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 83,
+            potency: 320,
+        },
+        {
+            minLevel: 84,
+            maxLevel: 93,
+            potency: 360,
+        },
+    ],
 };
 
 export const Bloodspiller: DrkGcdAbility = {
@@ -42,6 +78,13 @@ export const Bloodspiller: DrkGcdAbility = {
     gcd: 2.5,
     bloodCost: 50,
     updateBloodGauge: gauge => gauge.bloodGauge -= 50,
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 93,
+            potency: 500,
+        },
+    ],
 };
 
 export const ScarletDelirium: DrkGcdAbility = {
@@ -51,7 +94,6 @@ export const ScarletDelirium: DrkGcdAbility = {
     potency: 600,
     attackType: "Weaponskill",
     gcd: 2.5,
-    updateMP: gauge => gauge.magicPoints += 200,
 };
 
 export const Comeuppance: DrkGcdAbility = {
@@ -61,7 +103,6 @@ export const Comeuppance: DrkGcdAbility = {
     potency: 700,
     attackType: "Weaponskill",
     gcd: 2.5,
-    updateMP: gauge => gauge.magicPoints += 200,
 };
 
 export const Torcleaver: DrkGcdAbility = {
@@ -71,7 +112,6 @@ export const Torcleaver: DrkGcdAbility = {
     potency: 800,
     attackType: "Weaponskill",
     gcd: 2.5,
-    updateMP: gauge => gauge.magicPoints += 200,
 };
 
 export const Unmend: DrkGcdAbility = {
@@ -108,6 +148,13 @@ export const CarveAndSpit: DrkOgcdAbility = {
         charges: 1,
     },
     updateMP: gauge => gauge.magicPoints += 600,
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 93,
+            potency: 510,
+        },
+    ],
 };
 
 export const SaltedEarth: DrkOgcdAbility = {
@@ -128,6 +175,13 @@ export const SaltedEarth: DrkOgcdAbility = {
         time: 90,
         charges: 1,
     },
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 85,
+            activatesBuffs: [],
+        },
+    ],
 };
 
 export const SaltAndDarkness: DrkOgcdAbility = {
@@ -204,14 +258,6 @@ export const Shadowbringer: DrkOgcdAbility = {
 // they've all been programmed to be abilities so that it doesn't roll GCD.
 //
 // This shouldn't change anything damage wise.
-//
-// Living Shadow's rotation is the following:
-// Abyssal Drain (AoE)
-// Shadowstride (no damage)
-// Flood of Shadow (Shadowbringer at level 90+)(AoE)
-// Edge of Shadow
-// Bloodspiller
-// Carve and Spit (Disesteem(AoE) at level 100)
 
 // Esteem has the same stats as the player but ignores skill speed, Tank Mastery, and party strength bonus.
 // It also substitutes Midlander racial strength bonus regardless of the player's race.
@@ -231,6 +277,13 @@ export const LivingShadow: DrkOgcdAbility = {
         time: 120,
         charges: 1,
     },
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 99,
+            activatesBuffs: [],
+        },
+    ],
 };
 
 export const LivingShadowShadowstride: DrkOgcdAbility = {
@@ -249,6 +302,13 @@ export const LivingShadowAbyssalDrain: DrkOgcdAbility = {
     id: 17904,
     potency: 420,
     attackType: "Ability",
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 87,
+            potency: 340,
+        },
+    ],
 };
 
 export const LivingShadowShadowbringer: DrkOgcdAbility = {
@@ -267,6 +327,23 @@ export const LivingShadowEdgeOfShadow: DrkOgcdAbility = {
     id: 17908,
     potency: 420,
     attackType: "Ability",
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 87,
+            potency: 340,
+        },
+    ],
+};
+
+// Level 80 only, upgraded to Shadowbringer at level 90+
+export const LivingShadowFloodOfShadow: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Flood of Shadow",
+    animationLock: 0,
+    id: 17907,
+    potency: 340,
+    attackType: "Ability",
 };
 
 export const LivingShadowBloodspiller: DrkOgcdAbility = {
@@ -276,6 +353,30 @@ export const LivingShadowBloodspiller: DrkOgcdAbility = {
     id: 17909,
     potency: 420,
     attackType: "Ability",
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 87,
+            potency: 340,
+        },
+    ],
+};
+
+// Upgraded to Disesteem at level 100+
+export const LivingShadowCarveAndSpit: DrkOgcdAbility = {
+    type: 'ogcd',
+    name: "(Living Shadow) Carve And Spit",
+    animationLock: 0,
+    id: 17915,
+    potency: 420,
+    attackType: "Ability",
+    levelModifiers: [
+        {
+            minLevel: 1,
+            maxLevel: 87,
+            potency: 340,
+        },
+    ],
 };
 
 export const LivingShadowDisesteem: DrkOgcdAbility = {

--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -8,6 +8,7 @@ export const HardSlash: DrkGcdAbility = {
     potency: 150,
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 0.58,
     cast: 0,
     levelModifiers: [
         {
@@ -28,6 +29,7 @@ export const SyphonStrike: DrkGcdAbility = {
     potency: 240, //380
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 0.62,
     cast: 0,
     updateMP: gauge => gauge.magicPoints += 600,
     levelModifiers: [
@@ -49,6 +51,7 @@ export const Souleater: DrkGcdAbility = {
     potency: 320,
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 0.62,
     cast: 0,
     updateBloodGauge: gauge => gauge.bloodGauge += 20,
     levelModifiers: [
@@ -70,6 +73,7 @@ export const Bloodspiller: DrkGcdAbility = {
     potency: 500,
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 0.80,
     bloodCost: 50,
     updateBloodGauge: gauge => gauge.bloodGauge -= 50,
     levelModifiers: [
@@ -87,6 +91,7 @@ export const ScarletDelirium: DrkGcdAbility = {
     potency: 600,
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 0.62,
 };
 
 export const Comeuppance: DrkGcdAbility = {
@@ -96,6 +101,7 @@ export const Comeuppance: DrkGcdAbility = {
     potency: 700,
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 0.67,
 };
 
 export const Torcleaver: DrkGcdAbility = {
@@ -105,16 +111,17 @@ export const Torcleaver: DrkGcdAbility = {
     potency: 800,
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 0.62,
 };
 
 export const Unmend: DrkGcdAbility = {
     type: 'gcd',
     name: "Unmend",
-    appDelay: 1,
     id: 3624,
     potency: 150,
     attackType: "Spell",
     gcd: 2.5,
+    appDelay: 1,
 };
 
 export const Delirium: DrkOgcdAbility = {
@@ -128,6 +135,7 @@ export const Delirium: DrkOgcdAbility = {
         time: 60,
         charges: 1,
     },
+    appDelay: 0,
 };
 
 export const CarveAndSpit: DrkOgcdAbility = {
@@ -140,6 +148,7 @@ export const CarveAndSpit: DrkOgcdAbility = {
         time: 60,
         charges: 1,
     },
+    appDelay: 1.47,
     updateMP: gauge => gauge.magicPoints += 600,
     levelModifiers: [
         {
@@ -167,6 +176,7 @@ export const SaltedEarth: DrkOgcdAbility = {
         time: 90,
         charges: 1,
     },
+    appDelay: 0.76,
     levelModifiers: [
         {
             minLevel: 86,
@@ -184,6 +194,7 @@ export const SaltAndDarkness: DrkOgcdAbility = {
     cooldown: {
         time: 30,
     },
+    appDelay: 0.76,
 };
 
 export const Disesteem: DrkGcdAbility = {
@@ -193,6 +204,7 @@ export const Disesteem: DrkGcdAbility = {
     potency: 1000,
     attackType: "Weaponskill",
     gcd: 2.5,
+    appDelay: 1.65,
 };
 
 export const EdgeOfDarkness: DrkOgcdAbility = {
@@ -204,6 +216,7 @@ export const EdgeOfDarkness: DrkOgcdAbility = {
     cooldown: {
         time: 1,
     },
+    appDelay: 0.62,
     activatesBuffs: [Darkside],
     updateMP: (gauge: DrkGauge) => {
         if (gauge.darkArts) {
@@ -224,6 +237,7 @@ export const EdgeOfShadow: DrkOgcdAbility = {
     cooldown: {
         time: 1,
     },
+    appDelay: 0.62,
     activatesBuffs: [Darkside],
     updateMP: (gauge: DrkGauge) => {
         if (gauge.darkArts) {
@@ -263,6 +277,7 @@ export const Shadowbringer: DrkOgcdAbility = {
         time: 60,
         charges: 2,
     },
+    appDelay: 0.62,
 };
 
 // While Living Shadow abilities are actually Weaponskills in some cases,

--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -5,20 +5,18 @@ export const HardSlash: DrkGcdAbility = {
     type: 'gcd',
     name: "Hard Slash",
     id: 3617,
-    potency: 300,
+    potency: 150,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 83,
-            potency: 150,
+            minLevel: 84,
+            potency: 180,
         },
         {
-            minLevel: 84,
-            maxLevel: 93,
-            potency: 180,
+            minLevel: 94,
+            potency: 300,
         },
     ],
 };
@@ -27,21 +25,19 @@ export const SyphonStrike: DrkGcdAbility = {
     type: 'gcd',
     name: "Syphon Strike",
     id: 3623,
-    potency: 380,
+    potency: 240, //380
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
     updateMP: gauge => gauge.magicPoints += 600,
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 83,
-            potency: 240,
+            minLevel: 84,
+            potency: 260,
         },
         {
-            minLevel: 84,
-            maxLevel: 93,
-            potency: 260,
+            minLevel: 94,
+            potency: 380,
         },
     ],
 };
@@ -50,21 +46,19 @@ export const Souleater: DrkGcdAbility = {
     type: 'gcd',
     name: "Souleater",
     id: 3632,
-    potency: 480,
+    potency: 320,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
     updateBloodGauge: gauge => gauge.bloodGauge += 20,
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 83,
-            potency: 320,
+            minLevel: 84,
+            potency: 360,
         },
         {
-            minLevel: 84,
-            maxLevel: 93,
-            potency: 360,
+            minLevel: 94,
+            potency: 480,
         },
     ],
 };
@@ -73,16 +67,15 @@ export const Bloodspiller: DrkGcdAbility = {
     type: 'gcd',
     name: "Bloodspiller",
     id: 7392,
-    potency: 580,
+    potency: 500,
     attackType: "Weaponskill",
     gcd: 2.5,
     bloodCost: 50,
     updateBloodGauge: gauge => gauge.bloodGauge -= 50,
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 93,
-            potency: 500,
+            minLevel: 94,
+            potency: 580,
         },
     ],
 };
@@ -141,7 +134,7 @@ export const CarveAndSpit: DrkOgcdAbility = {
     type: 'ogcd',
     name: "Carve and Spit",
     id: 3643,
-    potency: 540,
+    potency: 510,
     attackType: "Ability",
     cooldown: {
         time: 60,
@@ -150,9 +143,8 @@ export const CarveAndSpit: DrkOgcdAbility = {
     updateMP: gauge => gauge.magicPoints += 600,
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 93,
-            potency: 510,
+            minLevel: 94,
+            potency: 540,
         },
     ],
 };
@@ -162,7 +154,7 @@ export const SaltedEarth: DrkOgcdAbility = {
     name: "Salted Earth",
     id: 3639,
     attackType: "Ability",
-    activatesBuffs: [SaltedEarthBuff],
+    activatesBuffs: [],
     potency: 50,
     dot: {
         // This is technically just the ID of the salted earth buff, but
@@ -177,9 +169,8 @@ export const SaltedEarth: DrkOgcdAbility = {
     },
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 85,
-            activatesBuffs: [],
+            minLevel: 86,
+            activatesBuffs: [SaltedEarthBuff],
         },
     ],
 };
@@ -272,16 +263,15 @@ export const LivingShadow: DrkOgcdAbility = {
     // Total potency of its abilities is 2450.
     potency: null,
     attackType: "Ability",
-    activatesBuffs: [ScornBuff],
+    activatesBuffs: [],
     cooldown: {
         time: 120,
         charges: 1,
     },
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 99,
-            activatesBuffs: [],
+            minLevel: 100,
+            activatesBuffs: [ScornBuff],
         },
     ],
 };
@@ -300,13 +290,12 @@ export const LivingShadowAbyssalDrain: DrkOgcdAbility = {
     name: "(Living Shadow) Abyssal Drain",
     animationLock: 0,
     id: 17904,
-    potency: 420,
+    potency: 340,
     attackType: "Ability",
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 87,
-            potency: 340,
+            minLevel: 88,
+            potency: 420,
         },
     ],
 };
@@ -325,13 +314,12 @@ export const LivingShadowEdgeOfShadow: DrkOgcdAbility = {
     name: "(Living Shadow) Edge of Shadow",
     animationLock: 0,
     id: 17908,
-    potency: 420,
+    potency: 340,
     attackType: "Ability",
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 87,
-            potency: 340,
+            minLevel: 88,
+            potency: 420,
         },
     ],
 };
@@ -351,13 +339,12 @@ export const LivingShadowBloodspiller: DrkOgcdAbility = {
     name: "(Living Shadow) Bloodspiller",
     animationLock: 0,
     id: 17909,
-    potency: 420,
+    potency: 340,
     attackType: "Ability",
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 87,
-            potency: 340,
+            minLevel: 88,
+            potency: 420,
         },
     ],
 };
@@ -368,13 +355,12 @@ export const LivingShadowCarveAndSpit: DrkOgcdAbility = {
     name: "(Living Shadow) Carve And Spit",
     animationLock: 0,
     id: 17915,
-    potency: 420,
+    potency: 340,
     attackType: "Ability",
     levelModifiers: [
         {
-            minLevel: 1,
-            maxLevel: 87,
-            potency: 340,
+            minLevel: 88,
+            potency: 420,
         },
     ],
 };

--- a/packages/core/src/sims/tank/drk/drk_sheet_sim.ts
+++ b/packages/core/src/sims/tank/drk/drk_sheet_sim.ts
@@ -33,7 +33,7 @@ export interface DrkSettingsExternal extends ExternalCycleSettings<DrkSettings> 
 export const drkSpec: SimSpec<DrkSim, DrkSettingsExternal> = {
     stub: "drk-sheet-sim",
     displayName: "DRK Sim",
-    description: `Simulates a DRK rotation for level 100/90/80.
+    description: `Simulates a DRK rotation for level 100/90/80/70.
 If potions are enabled, pots in the burst window every 6m (i.e. 0m, 6m, 12m, etc).
 Defaults to simulating a killtime of 8m 30s (510s).`,
     makeNewSimInstance: function (): DrkSim {

--- a/packages/core/src/sims/tank/drk/drk_types.ts
+++ b/packages/core/src/sims/tank/drk/drk_types.ts
@@ -107,7 +107,19 @@ export const DeliriumBuff: Buff = {
         // Allows usage of Delirium combo
     },
     stacks: 3,
-    appliesTo: ability => ability.name === "Scarlet Delirium" || ability.name === "Comeuppance" || ability.name === "Torcleaver",
+    appliesTo: ability => ability.name === "Scarlet Delirium" || ability.name === "Comeuppance" || ability.name === "Torcleaver" || ability.name === "Bloodspiller",
+    beforeAbility<X extends DrkAbility>(buffController: BuffController, ability: X): X {
+        const oldUpdateMP = ability.updateMP;
+        return {
+            ...ability,
+            updateMP: gauge => {
+                gauge.magicPoints += 200;
+                if (oldUpdateMP) {
+                    oldUpdateMP(gauge);
+                }
+            },
+        };
+    },
     beforeSnapshot<X extends Ability>(buffController: BuffController, ability: X): X {
         buffController.subtractStacksSelf(1);
         return ability;


### PR DESCRIPTION
This adds a framework for abilities being different at different levels, and adds support for level 70 + 80 + 90 DRK. It all seems to work! There's no overcap, even for e.g. 2.40 at level 70.

![image](https://github.com/user-attachments/assets/79bc91fa-9c48-4449-9d08-ac75a27db11c)

In reworking the way burst worked to no longer reference Living Shadow, I also found a minor optimization for level 100 2.50.