### PR TITLE
Update set sim results gradiants to not be relative to the worst set

### DIFF
--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -656,23 +656,25 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
             }
             for (const [cell, value] of processed) {
                 cell.classList.add('sim-column-valid');
-                const threePercentWorse = 0.97;
+                const fivePercentWorse = 0.95;
                 // This value represents the percent worse this value is, e.g. 0.985 for 98.5% as good.
                 const percentWorseComparedToBest = value / bestValue;
-                // e.g. 1.5 if our value was 0.985
-                const numberToBeComparedToThree = 100 * (percentWorseComparedToBest - threePercentWorse);
-                // This is three percent or more worse than the best rating. Give it the worst rating we can.
-                if (numberToBeComparedToThree <= 0) {
+                // e.g. 2.5 if our value was 0.975
+                const numberToBeProcessed = 100 * (percentWorseComparedToBest - fivePercentWorse);
+
+                // This is five percent or more worse than the best rating. Give it the worst rating we can.
+                if (numberToBeProcessed <= 0) {
                     cell.style.setProperty('--sim-result-relative', '0%');
                     cell.classList.add('sim-column-worst');
                 }
                 else {
-                    // For example, if it's 98.5% when compared to the best value, this will be 50%
-                    const percentageOfThreePercent = (numberToBeComparedToThree / 3) * 100;
-                    if (percentageOfThreePercent > 0) {
-                        cell.style.setProperty('--sim-result-relative', percentageOfThreePercent.toFixed(1) + '%');
-                    }
+                    // Log base 1.017 on our number -- which makes anything just below five or above be considered worst gradient.
+                    // We use a logarithmic scale so that the percentage gets less favourable the further away from the best it is.
+                    const percentageScore = Math.log(numberToBeProcessed + 1) / Math.log(1.018);
+                    const adjustedPercentageScore = Math.min(Math.max(percentageScore, 0), 100);
+                    cell.style.setProperty('--sim-result-relative', adjustedPercentageScore.toFixed(1) + '%');
                     if (value === bestValue) {
+                        cell.style.setProperty('--sim-result-relative', '100%');
                         cell.classList.add('sim-column-best');
                     }
                 }


### PR DESCRIPTION
Preamble: I understand that as with any UX thing, differing opinions exist. As a result, if this is something you don't feel is an improvement, feel free to close this. However, I do believe this makes things better.

Today, gearsets are gradiented based on the difference between the worst and the best. This means that two very similar sets will show 'unfavourable red' even if they are very close. It also means that adding a new set affects the gradients of the others. See examples:
![image](https://github.com/user-attachments/assets/1a107e2d-8ee3-4eb8-9f5d-2b741b5a6504)
![image-1](https://github.com/user-attachments/assets/7ad57a85-1f41-409a-9894-19899ff403cf)

This approach instead uses a gradient based a logarithm so that the further away from best it is, the more it leans towards unfavourable. Anything 5% worse is always considered red. I'm not attached to this logarithm base (I think it could be even lower, but it seemed a good default).

See examples here:
![image](https://github.com/user-attachments/assets/b64552ce-4bfc-47bf-93c6-fab150a22a20)

