### PR TITLE
Fix preloads

### DIFF
--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -11,11 +11,11 @@
     <script src="//cdn.jsdelivr.net/npm/@ungap/custom-elements"></script>
     <script async src="https://um.xivgear.app/umami" data-website-id="bc3fc7a6-b0ac-4a30-b737-031b59a9810f"></script>
     <link rel="stylesheet" href="./style.css"/>
-    <link rel="preload" href="https://data.xivgear.app/BaseParams" as="fetch"/>
-    <link rel="preload" href="https://data.xivgear.app/Materia" as="fetch"/>
-    <link rel="preload" href="https://data.xivgear.app/Food" as="fetch"/>
-    <link rel="preload" href="https://data.xivgear.app/Jobs" as="fetch"/>
-    <link rel="preload" href="https://data.xivgear.app/ItemLevel" as="fetch"/>
+    <link rel="preload" href="https://data.xivgear.app/BaseParams" as="fetch" crossorigin/>
+    <link rel="preload" href="https://data.xivgear.app/Materia" as="fetch" crossorigin/>
+    <link rel="preload" href="https://data.xivgear.app/Food" as="fetch" crossorigin/>
+    <link rel="preload" href="https://data.xivgear.app/Jobs" as="fetch" crossorigin/>
+    <link rel="preload" href="https://data.xivgear.app/ItemLevel" as="fetch" crossorigin/>
     <!--    <script src="https://kit.fontawesome.com/87e2708a80.js" crossorigin="anonymous"></script>-->
 </head>
 <body class="modern">
@@ -33,7 +33,8 @@
         <a href="./math/">Math</a><!--    <a href="." id="dev-menu-button">Dev Menu</a>-->
         <a href="https://github.com/xiv-gear-planner/gear-planner/" id="github-button" target="_blank">GitHub</a>
         <a href="https://ko-fi.com/wynnxiv" id="kofi-button" target="_blank">Ko-Fi</a>
-        <a href="https://patreon.com/xivgearapp?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink" id="patreon-button" target="_blank">Patreon</a>
+        <a href="https://patreon.com/xivgearapp?utm_medium=unknown&utm_source=join_link&utm_campaign=creatorshare_creator&utm_content=copyLink"
+           id="patreon-button" target="_blank">Patreon</a>
     </div>
 </div>
 <div id="content-area"></div>


### PR DESCRIPTION
Fix missing crossorigin attribute on preloads

Without the `crossorigin` attribute, preloads don't actually work.