### PR TITLE
Fix a bug with URL encoding

### DIFF
--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -146,15 +146,15 @@ export function buildPreviewServer() {
             return null;
         }
 
-        const path = request.query[HASH_QUERY_PARAM] ?? '';
-        const pathPaths = path.split(PATH_SEPARATOR);
-        const nav = parsePath(pathPaths);
-        request.log.info(pathPaths, 'Path');
         const serverUrl = getFrontendServer();
         const clientUrl = getFrontendPath();
         // Fetch original index.html
         const responsePromise = nonCachedFetch(serverUrl + '/index.html', undefined);
         try {
+            const path = request.query[HASH_QUERY_PARAM] ?? '';
+            const pathPaths = path.split(PATH_SEPARATOR);
+            const nav = parsePath(pathPaths);
+            request.log.info(pathPaths, 'Path');
             const exported: object | null = await resolveNav(nav);
             if (exported !== null) {
                 let name: string = exported['name'] || "";

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -124,7 +124,7 @@ export function parsePath(originalPath: string[]): NavPath | null {
         }
         else {
             const json = path.slice(1).join(PATH_SEPARATOR);
-            const parsed = JSON.parse(decodeURI(json)) as SheetExport;
+            const parsed = JSON.parse(decodeURIComponent(json)) as SheetExport;
             return {
                 type: 'sheetjson',
                 jsonBlob: parsed,
@@ -143,7 +143,7 @@ export function parsePath(originalPath: string[]): NavPath | null {
         }
         else {
             const json = path.slice(1).join(PATH_SEPARATOR);
-            const parsed = JSON.parse(decodeURI(json)) as SetExport;
+            const parsed = JSON.parse(decodeURIComponent(json)) as SetExport;
             const viewOnly = mainNav === VIEW_SET_HASH;
             if (!viewOnly) {
                 embedWarn();

--- a/packages/frontend/src/scripts/components/export_controller.ts
+++ b/packages/frontend/src/scripts/components/export_controller.ts
@@ -357,6 +357,7 @@ class SheetExportModal extends ExportModal<GearPlanSheet> {
     get previewUrl(): string {
         const exported = this.sheet.exportSheet(true);
         const url = makeUrl(VIEW_SET_HASH, JSON.stringify(exported));
+        console.log("Preview url", url);
         return url.toString();
     }
 }
@@ -370,6 +371,7 @@ class SetExportModal extends ExportModal<CharacterGearSet> {
     get previewUrl(): string {
         const exported = this.sheet.exportGearSet(this.item, true);
         const url = makeUrl(VIEW_SET_HASH, JSON.stringify(exported));
+        console.log("Preview url", url);
         return url.toString();
     }
 }


### PR DESCRIPTION
Fix issue that would cause some URLs to not work, if they fell below the URL query-based limit and did not need to fall back to URL hash.

Example of broken link: https://xivgear.app/?page=viewset%7C%257B%2522name%2522%253A%2522Default%2520Set%2520copy%2522%252C%2522sets%2522%253A%255B%257B%2522name%2522%253A%2522Default%2520Set%2522%252C%2522items%2522%253A%257B%2522Weapon%2522%253A%257B%2522id%2522%253A43103%252C%2522materia%2522%253A%255B%257B%2522id%2522%253A-1%257D%252C%257B%2522id%2522%253A-1%257D%255D%257D%257D%252C%2522isSeparator%2522%253Afalse%252C%2522relicStatMemory%2522%253A%257B%257D%252C%2522materiaMemory%2522%253A%257B%257D%257D%255D%252C%2522level%2522%253A100%252C%2522job%2522%253A%2522WAR%2522%252C%2522partyBonus%2522%253A0%252C%2522sims%2522%253A%255B%255D%252C%2522itemDisplaySettings%2522%253A%257B%2522minILvl%2522%253A680%252C%2522maxILvl%2522%253A999%252C%2522minILvlFood%2522%253A610%252C%2522maxILvlFood%2522%253A999%252C%2522higherRelics%2522%253Atrue%257D%252C%2522mfm%2522%253A%2522retain_item%2522%252C%2522mfp%2522%253A%255B%2522skillspeed%2522%252C%2522crit%2522%252C%2522dhit%2522%252C%2522determination%2522%252C%2522tenacity%2522%255D%252C%2522mfMinGcd%2522%253A2.05%252C%2522customItems%2522%253A%255B%255D%252C%2522customFoods%2522%253A%255B%255D%257D