### PR TITLE
Fix bug relating to auto-attacks not applying by changing cache key for sims

### DIFF
--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -1192,7 +1192,6 @@ export class CycleProcessor {
         this.addAbilityUse({
             usedAt: this.currentTime,
             ability: this.aaAbility,
-            //directDamage: dmgInfo.directDamage,
             buffs: buffs,
             combinedEffects: combinedEffects,
             totalTimeTaken: 0,


### PR DESCRIPTION
Since the decision to use autos is decided by:
`useAutos: (this.cycleSettings.useAutos ?? true) && set.getItemInSlot('Weapon') !== null,`
and we can't use autos without a weapon, this causes an issue when you make a new set and then add a weapon, as the sim won't use autos since it was created without a weapon (as all sets are). 

Without considering this a new set for the cache, the old rotation will be used, which won't include auto-attacks (we don't know how to do auto-attacks without a weapon).