### PR TITLE
Fix sim caching

### DIFF
--- a/packages/core/src/sims/processors/sim_processors.ts
+++ b/packages/core/src/sims/processors/sim_processors.ts
@@ -1,7 +1,7 @@
 import { JOB_DATA, JobName } from "@xivgear/xivmath/xivconstants";
 import { CycleSettings } from "@xivgear/core/sims/cycle_settings";
 import { CharacterGearSet } from "@xivgear/core/gear";
-import { sum } from "@xivgear/core/util/array_utils";
+import { arrayEq, sum } from "@xivgear/core/util/array_utils";
 import { addValues, applyStdDev, multiplyFixed } from "@xivgear/xivmath/deviation";
 import { PartyBuff, SimSettings, SimSpec, Simulation } from "@xivgear/core/sims/sim_types";
 import {
@@ -17,6 +17,8 @@ import {
     Rotation
 } from "@xivgear/core/sims/cycle_sim";
 import { BuffSettingsManager } from "@xivgear/core/sims/common/party_comp_settings";
+
+export type RotationCacheKey = (number | boolean | string)[];
 
 /**
  * Base class for a CycleProcessor based simulation. You should extend this class,
@@ -50,7 +52,8 @@ implements Simulation<FullResultType, InternalSettingsType, ExternalCycleSetting
     readonly manualRun = false;
 
     private cachedCycleProcessors: [string, CycleProcessor][];
-    private cachedSpeed: number;
+    private cachedRotationKey: RotationCacheKey;
+
     protected constructor(public readonly job: JobName, settings?: ExternalCycleSettings<InternalSettingsType>) {
         this.settings = this.makeDefaultSettings();
         if (settings !== undefined) {
@@ -188,12 +191,20 @@ implements Simulation<FullResultType, InternalSettingsType, ExternalCycleSetting
         };
     }
 
+    protected computeCacheKey(set: CharacterGearSet): RotationCacheKey {
+        const stats = set.computedStats;
+        const sps = stats.spellspeed;
+        const sks = stats.skillspeed;
+        const wdly = stats.weaponDelay;
+        return [sps, sks, wdly];
+    }
+
     async simulate(set: CharacterGearSet): Promise<FullResultType> {
         console.debug("Sim start");
-        const setSpeed = set.isStatRelevant('spellspeed') ? set.computedStats.spellspeed : set.computedStats.skillspeed;
-        if (setSpeed !== this.cachedSpeed) {
+        const cacheKey = this.computeCacheKey(set);
+        if (!arrayEq(this.cachedRotationKey, cacheKey)) {
             this.cachedCycleProcessors = this.generateRotations(set);
-            this.cachedSpeed = setSpeed;
+            this.cachedRotationKey = cacheKey;
         }
         return this.calcDamage(set);
     };

--- a/packages/core/src/util/array_utils.ts
+++ b/packages/core/src/util/array_utils.ts
@@ -17,3 +17,28 @@ export function rangeInc(startInclusive: number, endInclusive: number, increment
     }
     return out;
 }
+
+/**
+ * Determine if two arrays have equal members. Not a deep equals - only inspects one level.
+ *
+ * @param left The first array
+ * @param right The second array
+ */
+export function arrayEq(left: unknown[] | undefined, right: unknown[] | undefined) {
+    if (left === undefined && right === undefined) {
+        return true;
+    }
+    if (left === undefined || right === undefined) {
+        return false;
+    }
+    if (left.length !== right.length) {
+        return false;
+    }
+    for (let i = 0; i < left.length; i++) {
+        if (left[i] !== right[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+

--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -1,4 +1,4 @@
-import {arrayEq, getHash, goHash, isEmbed, processHashLegacy, processNav, setHash} from "./nav_hash";
+import {getHash, goHash, isEmbed, processHashLegacy, processNav, setHash} from "./nav_hash";
 import {NamedSection} from "./components/section";
 import {NewSheetForm} from "./components/new_sheet_form";
 import {ImportSheetArea} from "./components/import_sheet";
@@ -14,6 +14,7 @@ import { workerPool } from "./workers/worker_pool";
 import {showSettingsModal} from "@xivgear/common-ui/settings/settings_modal";
 import {SETTINGS} from "@xivgear/common-ui/settings/persistent_settings";
 import {DISPLAY_SETTINGS} from "@xivgear/common-ui/settings/display_settings";
+import {arrayEq} from "@xivgear/core/util/array_utils";
 
 const pageTitle = 'XivGear - FFXIV Gear Planner';
 

--- a/packages/frontend/src/scripts/components/ads.ts
+++ b/packages/frontend/src/scripts/components/ads.ts
@@ -1,6 +1,6 @@
 import {recordEvent} from "@xivgear/core/analytics/analytics";
 import {BaseModal} from "@xivgear/common-ui/components/modal";
-import {arrayEq} from "../nav_hash";
+import {arrayEq} from "@xivgear/core/util/array_utils";
 
 type DisplayCondition = (width: number, height: number) => boolean;
 

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -21,35 +21,12 @@ import {
     showLoadingScreen, showNewSheetForm,
     showSheetPickerMenu
 } from "./base_ui";
+import {arrayEq} from "@xivgear/core/util/array_utils";
 
 let expectedHash: string[] | undefined = undefined;
 
 let embed = false;
 
-
-/**
- * Determine if two arrays have equal members. Not a deep equals - only inspects one level.
- *
- * @param left The first array
- * @param right The second array
- */
-export function arrayEq(left: unknown[] | undefined, right: unknown[] | undefined) {
-    if (left === undefined && right === undefined) {
-        return true;
-    }
-    if (left === undefined || right === undefined) {
-        return false;
-    }
-    if (left.length !== right.length) {
-        return false;
-    }
-    for (let i = 0; i < left.length; i++) {
-        if (left[i] !== right[i]) {
-            return false;
-        }
-    }
-    return true;
-}
 
 /**
  * Get the current page path

--- a/packages/math-frontend/src/scripts/base_ui.ts
+++ b/packages/math-frontend/src/scripts/base_ui.ts
@@ -1,9 +1,10 @@
-import {arrayEq, goHash, processNav, setHash} from "./nav_hash";
+import {goHash, processNav, setHash} from "./nav_hash";
 import {DISPLAY_SETTINGS} from "@xivgear/common-ui/settings/display_settings";
 import {showSettingsModal} from "@xivgear/common-ui/settings/settings_modal";
 import {splitPath} from "@xivgear/core/nav/common_nav";
 import {LoadingBlocker} from "@xivgear/common-ui/components/loader";
 import {applyCommonTopMenuFormatting} from "@xivgear/common-ui/components/top_menu";
+import {arrayEq} from "@xivgear/core/util/array_utils";
 
 const pageTitle = 'XivGear - FFXIV Gear Planner';
 

--- a/packages/math-frontend/src/scripts/nav_hash.ts
+++ b/packages/math-frontend/src/scripts/nav_hash.ts
@@ -2,33 +2,11 @@ import {CALC_HASH, HASH_QUERY_PARAM, PATH_SEPARATOR, splitPath} from "@xivgear/c
 
 import {formatTopMenu} from "./base_ui";
 import {openMath} from "./mathpage/math_ui";
+import {arrayEq} from "@xivgear/core/util/array_utils";
 
 let expectedHash: string[] | undefined = undefined;
 
 
-/**
- * Determine if two arrays have equal members. Not a deep equals - only inspects one level.
- *
- * @param left The first array
- * @param right The second array
- */
-export function arrayEq(left: unknown[] | undefined, right: unknown[] | undefined) {
-    if (left === undefined && right === undefined) {
-        return true;
-    }
-    if (left === undefined || right === undefined) {
-        return false;
-    }
-    if (left.length !== right.length) {
-        return false;
-    }
-    for (let i = 0; i < left.length; i++) {
-        if (left[i] !== right[i]) {
-            return false;
-        }
-    }
-    return true;
-}
 
 /**
  * Get the current page path


### PR DESCRIPTION
This allows for an array cache key instead of a single value. It also allows sub-classes to override the cache key, for if there are sim-specific tweaks where the cache should be invalidated.

Closes #422 