### PR TITLE
Default meld solver to current GCD, small UX tweaks

### DIFF
--- a/packages/common-ui/src/components/util.ts
+++ b/packages/common-ui/src/components/util.ts
@@ -172,6 +172,14 @@ export interface FbctArgs<ObjType, FieldType> {
     inputMode?: string;
 }
 
+export interface FieldBoundFloatFieldFbctArgs<ObjType, FieldType> extends FbctArgs<ObjType, FieldType> {
+    /**
+     * Optionally, how many decimal places to fix the float to. You can use 2 to make GCD speeds (i.e. 2.50)
+     * show up as 2.50 instead of 2.5.
+     */
+    fixDecimals?: number;
+}
+
 export class FieldBoundConvertingTextField<ObjType, FieldType> extends HTMLInputElement {
 
     reloadValue: () => void;
@@ -364,7 +372,7 @@ export class FieldBoundIntField<ObjType> extends FieldBoundConvertingTextField<O
 }
 
 export class FieldBoundFloatField<ObjType> extends FieldBoundConvertingTextField<ObjType, number> {
-    constructor(obj: ObjType, field: { [K in keyof ObjType]: ObjType[K] extends number ? K : never }[keyof ObjType], extraArgs: FbctArgs<ObjType, number> = {}, displayTwoDecimalPlaces = false) {
+    constructor(obj: ObjType, field: { [K in keyof ObjType]: ObjType[K] extends number ? K : never }[keyof ObjType], extraArgs: FieldBoundFloatFieldFbctArgs<ObjType, number> = {}) {
         const numberValidator = (ctx) => {
             // filter out NaNs and other garbage values
             // noinspection PointlessArithmeticExpressionJS
@@ -377,8 +385,7 @@ export class FieldBoundFloatField<ObjType> extends FieldBoundConvertingTextField
         // Spinner arrows aren't styleable. Love CSS!
         // extraArgs.type = extraArgs.type ?? 'number';
         // extraArgs.inputMode = extraArgs.inputMode ?? 'numeric';
-        // Primarily useful when displaying GCD speeds, i.e. 2.50 instead of 2.5.
-        const toStringFunc = displayTwoDecimalPlaces ? (x: number) => x.toFixed(2) : (x: number) => x.toString();
+        const toStringFunc = extraArgs.fixDecimals ? (x: number) => x.toFixed(extraArgs.fixDecimals) : (x: number) => x.toString();
         super(obj, field, (s) => toStringFunc(s), (s) => Number(s), extraArgs);
     }
 }

--- a/packages/common-ui/src/components/util.ts
+++ b/packages/common-ui/src/components/util.ts
@@ -364,7 +364,7 @@ export class FieldBoundIntField<ObjType> extends FieldBoundConvertingTextField<O
 }
 
 export class FieldBoundFloatField<ObjType> extends FieldBoundConvertingTextField<ObjType, number> {
-    constructor(obj: ObjType, field: { [K in keyof ObjType]: ObjType[K] extends number ? K : never }[keyof ObjType], extraArgs: FbctArgs<ObjType, number> = {}) {
+    constructor(obj: ObjType, field: { [K in keyof ObjType]: ObjType[K] extends number ? K : never }[keyof ObjType], extraArgs: FbctArgs<ObjType, number> = {}, displayTwoDecimalPlaces = false) {
         const numberValidator = (ctx) => {
             // filter out NaNs and other garbage values
             // noinspection PointlessArithmeticExpressionJS
@@ -377,7 +377,9 @@ export class FieldBoundFloatField<ObjType> extends FieldBoundConvertingTextField
         // Spinner arrows aren't styleable. Love CSS!
         // extraArgs.type = extraArgs.type ?? 'number';
         // extraArgs.inputMode = extraArgs.inputMode ?? 'numeric';
-        super(obj, field, (s) => s.toString(), (s) => Number(s), extraArgs);
+        // Primarily useful when displaying GCD speeds, i.e. 2.50 instead of 2.5.
+        const toStringFunc = displayTwoDecimalPlaces ? (x: number) => x.toFixed(2) : (x: number) => x.toString();
+        super(obj, field, (s) => toStringFunc(s), (s) => Number(s), extraArgs);
     }
 }
 

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -415,7 +415,7 @@ export class MateriaPriorityPicker extends HTMLElement {
                     ctx.failValidation("Cannot be greater than " + MAX_GCD);
                 }
             }],
-        });
+        }, true);
         minGcdInput.addListener(val => {
             recordCurrentSheetEvent('currentSheet', {
                 gcd: val,

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -415,7 +415,8 @@ export class MateriaPriorityPicker extends HTMLElement {
                     ctx.failValidation("Cannot be greater than " + MAX_GCD);
                 }
             }],
-        }, true);
+            fixDecimals: 2,
+        });
         minGcdInput.addListener(val => {
             recordCurrentSheetEvent('currentSheet', {
                 gcd: val,

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -43,7 +43,7 @@ export class MeldSolverDialog extends BaseModal {
         this.classList.add('meld-solver-area');
         this.descriptionText = document.createElement('div');
         this.descriptionText.textContent = "Solve for the highest-dps set of melds for this gearset.\r\n"
-            + "Speed up computations by targeting a specific GCD and/or pre-filling some materia slots";
+            + "Computation will be much slower without a target GCD.";
 
         this.setNameText = document.createElement('div');
         this.setNameText.textContent = `"${set.name}"`;
@@ -200,7 +200,7 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
                     break;
             }
         }
-        this.gearsetGenSettings = new GearsetGenerationSettings(set, false, false, gcd);
+        this.gearsetGenSettings = new GearsetGenerationSettings(set, false, true, gcd);
         this.simSettings = {
             sim: sheet.sims.at(0),
             sets: undefined, // Not referenced in UI
@@ -221,14 +221,13 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
                     ctx.failValidation("Cannot be greater than " + MAX_GCD);
                 }
             }],
-        });
+        }, true);
 
         this.useTargetGcdCheckBox = new FieldBoundCheckBox(this.gearsetGenSettings, 'useTargetGcd');
         this.useTargetGcdCheckBox.classList.add('meld-solver-settings');
         this.targetGcdInput.pattern = '\\d\\.\\d\\d?';
         this.targetGcdInput.title = 'Solve for the best set with this GCD';
         this.targetGcdInput.classList.add('meld-solver-target-gcd-input');
-        this.targetGcdInput.disabled = true;
 
         const targetGcdText = labelFor("Target GCD: ", this.useTargetGcdCheckBox);
         targetGcdText.textContent = "Target GCD: ";

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -221,7 +221,8 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
                     ctx.failValidation("Cannot be greater than " + MAX_GCD);
                 }
             }],
-        }, true);
+            fixDecimals: 2,
+        });
 
         this.useTargetGcdCheckBox = new FieldBoundCheckBox(this.gearsetGenSettings, 'useTargetGcd');
         this.useTargetGcdCheckBox.classList.add('meld-solver-settings');


### PR DESCRIPTION
Meld solver now defaults to target GCD being toggled as true, and displays the number to two decimal places (i.e. `2.50` instead of `2.5`.

After:
![image](https://github.com/user-attachments/assets/72588fae-1dfb-4bcf-a254-8f1e2a22b9e6)

