### PR TITLE
Toggle MNK sim to default

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -28,7 +28,7 @@ export const mnkSpec: SimSpec<MnkSim, MnkSettingsExternal> = {
     },
     supportedJobs: ['MNK'],
     supportedLevels: [100],
-    isDefaultSim: false,
+    isDefaultSim: true,
 };
 
 class MNKCycleProcessor extends CycleProcessor {


### PR DESCRIPTION
Forgot to enable this by default in the big PR.