### PR TITLE
Scaffold for haste types so that monk has correct auto delay calculations

### DIFF
--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -1202,8 +1202,17 @@ export class CycleProcessor {
             snapshotTimeFromStart: 0,
             lockTime: 0,
         });
-        const aaDelay = this.stats.aaDelay * (100 - this.stats.haste('Auto-attack') - combinedEffects.haste) / 100;
-        this.nextAutoAttackTime = this.currentTime + aaDelay;
+        if (combinedEffects.haste) {
+            // the buffs do not know their haste, assume they are the same type and stack additively for back-compat
+            const aaDelay = this.stats.aaDelay * (100 - this.stats.haste('Auto-attack') - combinedEffects.haste) / 100;
+            this.nextAutoAttackTime = this.currentTime + aaDelay;
+        } else {
+            // see https://www.akhmorning.com/allagan-studies/how-to-be-a-math-wizard/shadowbringers/speed/#gcds--cast-times
+            const gcd_2 = (100 - this.stats.haste('Auto-attack', 'Y') - combinedEffects.hasteY) / 100;
+            const gcd_3 = (100 - this.stats.haste('Auto-attack', 'Z') - combinedEffects.hasteZ) / 100;
+            const aaDelay = this.stats.aaDelay * gcd_2 * gcd_3;
+            this.nextAutoAttackTime = this.currentTime + aaDelay;
+        }
     }
 
     /**

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -1206,11 +1206,12 @@ export class CycleProcessor {
             // the buffs do not know their haste, assume they are the same type and stack additively for back-compat
             const aaDelay = this.stats.aaDelay * (100 - this.stats.haste('Auto-attack') - combinedEffects.haste) / 100;
             this.nextAutoAttackTime = this.currentTime + aaDelay;
-        } else {
+        }
+        else {
             // see https://www.akhmorning.com/allagan-studies/how-to-be-a-math-wizard/shadowbringers/speed/#gcds--cast-times
-            const gcd_2 = (100 - this.stats.haste('Auto-attack', 'Y') - combinedEffects.hasteY) / 100;
-            const gcd_3 = (100 - this.stats.haste('Auto-attack', 'Z') - combinedEffects.hasteZ) / 100;
-            const aaDelay = this.stats.aaDelay * gcd_2 * gcd_3;
+            const gcd2 = (100 - this.stats.haste('Auto-attack', 'Y') - combinedEffects.hasteY) / 100;
+            const gcd3 = (100 - this.stats.haste('Auto-attack', 'Z') - combinedEffects.hasteZ) / 100;
+            const aaDelay = this.stats.aaDelay * gcd2 * gcd3;
             this.nextAutoAttackTime = this.currentTime + aaDelay;
         }
     }

--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -204,7 +204,7 @@ export const RiddleOfWindBuff: PersonalBuff = {
     statusId: 2687,
     appliesTo: (ability) => ability.attackType === 'Auto-attack',
     effects: {
-        haste: 50,
+        hasteY: 50,
     },
 };
 export const FiresRumination: PersonalBuff = {

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -543,8 +543,17 @@ export type BuffEffects = {
     forceDhit?: boolean,
     /**
      * Haste. Expressed as the percentage value, e.g. 20 = 20% faster GCD
+     * Remains for backwards compatibility with calculations and Buffs that do not know their typing
      */
     haste?: number,
+    /**
+     * Haste. Expressed as the percentage value, e.g. 20 = 20% faster GCD
+     */
+    hasteY?: number,
+    /**
+     * Haste. Expressed as the percentage value, e.g. 20 = 20% faster GCD
+     */
+    hasteZ?: number,
     /**
      * Modify stats directly
      */
@@ -710,6 +719,16 @@ export type CombinedBuffEffect = {
      * Haste as an integer, e.g. 20 haste = 20% lower cast/gcd time.
      */
     haste: number,
+    /**
+     * Type-Y haste as an integer, e.g. 20 haste = 20% lower cast/gcd time.
+     * see https://www.akhmorning.com/allagan-studies/how-to-be-a-math-wizard/shadowbringers/speed/#gcds--cast-times
+     */
+    hasteY: number,
+    /**
+     * Type-Z haste as an integer, e.g. 20 haste = 20% lower cast/gcd time.
+     * see https://www.akhmorning.com/allagan-studies/how-to-be-a-math-wizard/shadowbringers/speed/#gcds--cast-times
+     */
+    hasteZ: number,
     /**
      * Function for modifying a ComputedSetStats for any changes which cannot be expressed using the other fields.
      */

--- a/packages/core/src/sims/sim_utils.ts
+++ b/packages/core/src/sims/sim_utils.ts
@@ -83,6 +83,8 @@ export function noBuffEffects(): CombinedBuffEffect {
         forceCrit: false,
         forceDhit: false,
         haste: 0,
+        hasteY: 0,
+        hasteZ: 0,
         modifyStats: stats => stats,
     };
 }
@@ -127,6 +129,12 @@ export function combineBuffEffects(buffs: Buff[]): CombinedBuffEffect {
         }
         if (effects.haste) {
             combinedEffects.haste += effects.haste;
+        }
+        if (effects.hasteY) {
+            combinedEffects.hasteY += effects.hasteY;
+        }
+        if (effects.hasteZ) {
+            combinedEffects.hasteZ += effects.hasteZ;
         }
         if (effects.forceCrit) {
             combinedEffects.forceCrit = true;

--- a/packages/frontend/src/scripts/sims/components/ability_used_table.ts
+++ b/packages/frontend/src/scripts/sims/components/ability_used_table.ts
@@ -177,6 +177,12 @@ export class AbilitiesUsedTable extends CustomTable<DisplayRecordFinalized> {
                     if (effects.haste) {
                         out.push(`${effects.haste}% Haste`);
                     }
+                    if (effects.hasteY) {
+                        out.push(`${effects.hasteY}% Haste`);
+                    }
+                    if (effects.hasteZ) {
+                        out.push(`${effects.hasteZ}% Haste`);
+                    }
                     return document.createTextNode(out.join(', '));
                 },
             },

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -271,7 +271,7 @@ export interface ComputedSetStats extends RawStats {
     /**
      * Base haste value for a given attack type
      */
-    haste(attackType: AttackType): number;
+    haste(attackType: AttackType, hasteType?: 'Y'| 'Z'): number;
 
     /**
      * Crit chance. Ranges from 0 to 1.

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -212,44 +212,64 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
                 minLevel: 1,
                 maxLevel: 19,
                 apply: (stats) => {
-                    stats.bonusHaste.push(attackType =>
-                        attackType === 'Weaponskill'
-                        || attackType === 'Spell'
-                        || attackType === 'Auto-attack'
-                            ? 5 : 0);
-                },
+                    stats.bonusHaste.push({
+                        type: 'Z',
+                        apply: (attackType) => {
+                            return attackType === 'Weaponskill'
+                                || attackType === 'Spell'
+                                || attackType === 'Auto-attack'
+                                ? 5 : 0;
+                        },
+                    },
+                    )
+                }
             },
             {
                 minLevel: 20,
                 maxLevel: 39,
                 apply: (stats) => {
-                    stats.bonusHaste.push(attackType =>
-                        attackType === 'Weaponskill'
-                        || attackType === 'Spell'
-                        || attackType === 'Auto-attack'
-                            ? 10 : 0);
-                },
+                    stats.bonusHaste.push({
+                        type: 'Z',
+                        apply: (attackType) => {
+                            return attackType === 'Weaponskill'
+                                || attackType === 'Spell'
+                                || attackType === 'Auto-attack'
+                                ? 10 : 0;
+                        },
+                    },
+                    )
+                }
             },
             {
                 minLevel: 40,
                 maxLevel: 75,
                 apply: (stats) => {
-                    stats.bonusHaste.push(attackType =>
-                        attackType === 'Weaponskill'
-                        || attackType === 'Spell'
-                        || attackType === 'Auto-attack'
-                            ? 15 : 0);
-                },
+                    stats.bonusHaste.push({
+                        type: 'Z',
+                        apply: (attackType) => {
+                            return attackType === 'Weaponskill'
+                                || attackType === 'Spell'
+                                || attackType === 'Auto-attack'
+                                ? 15 : 0;
+                        },
+                    },
+                    )
+                }
             },
             {
                 minLevel: 76,
                 apply: (stats) => {
-                    stats.bonusHaste.push(attackType =>
-                        attackType === 'Weaponskill'
-                    || attackType === 'Spell'
-                    || attackType === 'Auto-attack'
-                            ? 20 : 0);
-                },
+                    stats.bonusHaste.push({
+                        type: 'Z',
+                        apply: (attackType) => {
+                            return attackType === 'Weaponskill'
+                                || attackType === 'Spell'
+                                || attackType === 'Auto-attack'
+                                ? 20 : 0;
+                        },
+                    },
+                    )
+                }
             }],
     },
     NIN: {

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -220,9 +220,9 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
                                 || attackType === 'Auto-attack'
                                 ? 5 : 0;
                         },
-                    },
-                    )
-                }
+                    }
+                    );
+                },
             },
             {
                 minLevel: 20,
@@ -236,9 +236,9 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
                                 || attackType === 'Auto-attack'
                                 ? 10 : 0;
                         },
-                    },
-                    )
-                }
+                    }
+                    );
+                },
             },
             {
                 minLevel: 40,
@@ -252,9 +252,9 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
                                 || attackType === 'Auto-attack'
                                 ? 15 : 0;
                         },
-                    },
-                    )
-                }
+                    }
+                    );
+                },
             },
             {
                 minLevel: 76,
@@ -267,9 +267,9 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
                                 || attackType === 'Auto-attack'
                                 ? 20 : 0;
                         },
-                    },
-                    )
-                }
+                    }
+                    );
+                },
             }],
     },
     NIN: {

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -49,7 +49,10 @@ export function addStats(baseStats: RawStats, addedStats: RawStats): void {
 /**
  * Function from an attack type to a haste amount. Haste amount is percentage, e.g. 20 haste = 20% faster.
  */
-export type HasteBonus = (attackType: AttackType) => number;
+export type HasteBonus = {
+    type?: 'Y' | 'Z',
+    apply: (attackType: AttackType) => number;
+}
 
 /**
  * Represents a post-computation stat modification (e.g. a crit chance buff).
@@ -243,8 +246,14 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
         return spsToGcd(baseGcd, this.levelStats, this.spellspeed, haste);
     }
 
-    haste(attackType: AttackType): number {
-        return sum(this.finalBonusStats.bonusHaste.map(hb => hb(attackType)));
+    haste(attackType: AttackType, hasteType?: 'Y' | 'Z'): number {
+        return sum(this.finalBonusStats.bonusHaste.map(hb => {
+            if (hasteType === undefined || hb.type === undefined) {
+                // assume the haste applies for backwards compatibility
+                return hb.apply(attackType)
+            }
+            return hb.type === hasteType ? hb.apply(attackType) : 0
+        }));
     }
 
     traitMulti(attackType: AttackType): number {

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -250,9 +250,9 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
         return sum(this.finalBonusStats.bonusHaste.map(hb => {
             if (hasteType === undefined || hb.type === undefined) {
                 // assume the haste applies for backwards compatibility
-                return hb.apply(attackType)
+                return hb.apply(attackType);
             }
-            return hb.type === hasteType ? hb.apply(attackType) : 0
+            return hb.type === hasteType ? hb.apply(attackType) : 0;
         }));
     }
 


### PR DESCRIPTION
#431

I've been investigating the type of Riddle of Wind's haste buff, and Aya Liz confirms that RoW should have an auto delay of 1.024. The only way for that to be true is for RoW and GL4 to have different haste types as defined by Allagan Studies. This bug currently only affects monk, as no other job has two sources of haste.

I've left backwards compatibility in for any `HasteBonus`es or traits that aren't typed, but with approval I can go through and modify these.