### PR TITLE
[PCT Sim] Add initial Picto consts, types, actions, buffs, and a primitive gauge.

### DIFF
--- a/packages/core/src/sims/caster/pct/pct_actions.ts
+++ b/packages/core/src/sims/caster/pct/pct_actions.ts
@@ -1,0 +1,360 @@
+import {OriginCdAbility, SharedCdAbility} from "@xivgear/core/sims/sim_types";
+import {StarryMuse} from "@xivgear/core/sims/buffs";
+import PCTGauge from "./pct_gauge";
+import * as Buffs from "./pct_buffs";
+import * as Consts from "./pct_consts";
+import {PctGcdAbility, PctOgcdAbility, PctPaletteAbility, PctPaintAbility} from "./pct_types";
+
+export const Red : PctGcdAbility = {
+    type: 'gcd',
+    name: "Fire in Red",
+    id: Consts.RedID,
+    attackType: "Spell",
+    potency: 440,
+    gcd: 2.5,
+    cast: 1.5,
+    activatesBuffs: [Buffs.AetherhuesGYBuff],
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Green : PctGcdAbility = {
+    type: 'gcd',
+    name: "Aero in Green",
+    id: Consts.GreenID,
+    attackType: "Spell",
+    potency: 480,
+    gcd: 2.5,
+    cast: 1.5,
+    activatesBuffs: [Buffs.AetherhuesBMBuff],
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Blue : PctGcdAbility = {
+    type: 'gcd',
+    name: "Water in Blue",
+    id: Consts.BlueID,
+    attackType: "Spell",
+    potency: 520,
+    gcd: 2.5,
+    cast: 1.5,
+    updateGauge: (gauge: PCTGauge) => {
+        if (gauge.level > 60) {
+            gauge.paletteGauge += 25;
+        }
+        if (gauge.level > 80) {
+            gauge.whitePaintCharges += 1;
+        }
+    },
+};
+
+export const Cyan : PctGcdAbility = {
+    type: 'gcd',
+    name: "Blizzard in Cyan",
+    id: Consts.CyanID,
+    attackType: "Spell",
+    potency: 800,
+    gcd: 3.3,
+    cast: 2.3,
+    activatesBuffs: [Buffs.AetherhuesGYBuff],
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Yellow : PctGcdAbility = {
+    type: 'gcd',
+    name: "Stone in Yellow",
+    id: Consts.YellowID,
+    attackType: "Spell",
+    potency: 840,
+    gcd: 3.3,
+    cast: 2.3,
+    activatesBuffs: [Buffs.AetherhuesBMBuff],
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Magenta : PctGcdAbility = {
+    type: 'gcd',
+    name: "Thunder in Magenta",
+    id: Consts.MagentaID,
+    attackType: "Spell",
+    potency: 880,
+    gcd: 3.3,
+    cast: 2.3,
+    updateGauge: (gauge: PCTGauge) => {
+        if (gauge.level > 80) {
+            gauge.whitePaintCharges += 1;
+        }
+    },
+};
+
+export const Holy : PctPaintAbility = {
+    type: 'gcd',
+    name: "Holy in White",
+    id: Consts.HolyID,
+    attackType: "Spell",
+    potency: 520,
+    gcd: 2.5,
+    cast: 0,
+    appDelay: 1.34,
+    paintCost: 1,
+    updateGauge: gauge => gauge.whitePaintCharges -= 1,
+};
+export const Comet : PctPaintAbility = {
+    type: 'gcd',
+    name: "Comet in Black",
+    id: Consts.CometID,
+    attackType: "Spell",
+    potency: 880,
+    gcd: 3.3,
+    cast: 0,
+    appDelay: 1.87,
+    paintCost: 1,
+    updateGauge: gauge => gauge.whitePaintCharges -= 1,
+};
+
+export const RainbowDrip : PctGcdAbility = {
+    type: 'gcd',
+    name: "Rainbow Drip",
+    id: Consts.RainbowDripID,
+    attackType: "Spell",
+    potency: 1000,
+    gcd: 6,
+    cast: 4,
+    appDelay: 1.24,
+    updateGauge: gauge => gauge.whitePaintCharges += 1,
+};
+
+export const StarPrism : PctGcdAbility = {
+    type: 'gcd',
+    name: "Star Prism",
+    id: Consts.StarPrismID,
+    attackType: "Spell",
+    potency: 1400,
+    gcd: 2.5,
+    cast: 0,
+    appDelay: 1.25,
+    updateGauge: gauge => (gauge: PCTGauge) => {},
+};
+
+// TODO : Add logic to simplify the Creature motif into a single action.
+export const PomMotif : PctGcdAbility = {
+    type: 'gcd',
+    name: "Pom Motif",
+    id: Consts.PomMotifID,
+    attackType: "Spell",
+    potency: null,
+    gcd: 4.0,
+    cast: 3.0,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const WingMotif : PctGcdAbility = {
+    type: 'gcd',
+    name: "Wing Motif",
+    id: Consts.WingMotifID,
+    attackType: "Spell",
+    potency: null,
+    gcd: 4.0,
+    cast: 3.0,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const ClawMotif : PctGcdAbility = {
+    type: 'gcd',
+    name: "Claw Motif",
+    id: Consts.ClawMotifID,
+    attackType: "Spell",
+    potency: null,
+    gcd: 4.0,
+    cast: 3.0,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const MawMotif : PctGcdAbility = {
+    type: 'gcd',
+    name: "Maw Motif",
+    id: Consts.MawMotifID,
+    attackType: "Spell",
+    potency: null,
+    gcd: 4.0,
+    cast: 3.0,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const HammerMotif : PctGcdAbility = {
+    type: 'gcd',
+    name: "Hammer Motif",
+    id: Consts.HammerMotifID,
+    attackType: "Spell",
+    potency: null,
+    gcd: 4.0,
+    cast: 3.0,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const StarryMotif : PctGcdAbility = {
+    type: 'gcd',
+    name: "Starry Sky Motif",
+    id: Consts.StarryMotifID,
+    attackType: "Spell",
+    potency: null,
+    gcd: 4.0,
+    cast: 3.0,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+
+export const Mog : PctOgcdAbility & OriginCdAbility = {
+    type: 'ogcd',
+    name: "Mog of the Ages",
+    id: Consts.MogID,
+    attackType: "Ability",
+    potency: 1300,
+    appDelay: 1.15,
+    cooldown: {
+        time: 30,
+    },
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Madeen : PctOgcdAbility & SharedCdAbility = {
+    type: 'ogcd',
+    name: "Retribution of the Madeen",
+    id: Consts.MadeenID,
+    attackType: "Ability",
+    potency: 1400,
+    appDelay: 1.3,
+    cooldown: {
+        time: 30,
+        sharesCooldownWith: Mog,
+    },
+    updateGauge: (gauge: PCTGauge) => {},
+};
+// TODO: Since all creature Muses are the same potency and effect (other than the buff) can these be collapsed into a single action?
+export const Pom : PctOgcdAbility & OriginCdAbility = {
+    type: 'ogcd',
+    name: "Pom Muse",
+    id: Consts.PomMuseID,
+    attackType: "Ability",
+    potency: 1100,
+    cooldown: {
+        time: 40,
+        charges: 3,
+    },
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Wing : PctOgcdAbility & SharedCdAbility = {
+    type: 'ogcd',
+    name: "Winged Muse",
+    id: Consts.WingMuseID,
+    attackType: "Ability",
+    potency: 1100,
+    appDelay: 0.98,
+    cooldown: {
+        time: 40,
+        charges: 3,
+        sharesCooldownWith: Pom,
+    },
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Claw : PctOgcdAbility & SharedCdAbility = {
+    type: 'ogcd',
+    name: "Clawed Muse",
+    id: Consts.ClawMuseID,
+    attackType: "Ability",
+    potency: 1100,
+    appDelay: 0.98,
+    cooldown: {
+        time: 40,
+        charges: 3,
+        sharesCooldownWith: Pom,
+    },
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const Fang : PctOgcdAbility & SharedCdAbility = {
+    type: 'ogcd',
+    name: "Fanged Muse",
+    id: Consts.FangMuseID,
+    attackType: "Ability",
+    potency: 1100,
+    appDelay: 1.16,
+    cooldown: {
+        time: 40,
+        charges: 3,
+        sharesCooldownWith: Pom,
+    },
+    updateGauge: (gauge: PCTGauge) => {},
+};
+
+export const Striking : PctOgcdAbility = {
+    type: 'ogcd',
+    name: "Striking Muse",
+    id: Consts.StrikingMuseID,
+    attackType: "Ability",
+    potency: null,
+    activatesBuffs: [Buffs.HammerTimeBuff],
+    cooldown: {
+        time: 60,
+        charges: 2,
+    },
+    updateGauge: (gauge: PCTGauge) => {},
+};
+
+export const Starry : PctOgcdAbility = {
+    type: 'ogcd',
+    name: "Starry Muse",
+    id: Consts.StarryMuseID,
+    attackType: "Ability",
+    potency: null,
+    activatesBuffs: [
+        Buffs.HyperphantasiaBuff,
+        Buffs.RainbowBrightBuff,
+        Buffs.SubtractiveSpectrumBuff,
+        StarryMuse,
+    ],
+    updateGauge: (gauge: PCTGauge) => {},
+    cooldown: {
+        time: 120,
+    },
+};
+
+export const SubtractivePalette : PctPaletteAbility = {
+    type: 'ogcd',
+    name: "Subtractive Palette",
+    id: Consts.SubtractivePaletteID,
+    attackType: "Ability",
+    potency: null,
+    activatesBuffs: [Buffs.SubtractivePaletteBuff, Buffs.MonochromeBuff],
+    paletteCost: 50,
+    updateGauge: gauge => gauge.paletteGauge -= 50,
+};
+
+// TODO: Add the hidden buffs for tracking the Hammer Combo since it doens't
+//       drop when the hammer stamp buff drops.
+export const HStamp : PctGcdAbility = {
+    type: 'gcd',
+    name: "Hammer Stamp",
+    id: Consts.HStampID,
+    attackType: "Spell",
+    potency: 560,
+    gcd: 2.5,
+    cast: 0,
+    appDelay: 1.38,
+    autoDh: true,
+    autoCrit: true,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const HBrush : PctGcdAbility = {
+    type: 'gcd',
+    name: "Hammer Brush",
+    id: Consts.HBrushID,
+    attackType: "Spell",
+    potency: 620,
+    gcd: 2.5,
+    cast: 0,
+    appDelay: 1.25,
+    autoDh: true,
+    autoCrit: true,
+    updateGauge: (gauge: PCTGauge) => {},
+};
+export const HPolish : PctGcdAbility = {
+    type: 'gcd',
+    name: "Polishing Hammer",
+    id: Consts.HPolishID,
+    attackType: "Spell",
+    potency: 680,
+    gcd: 2.5,
+    cast: 0,
+    appDelay: 2.1,
+    autoDh: true,
+    autoCrit: true,
+    updateGauge: (gauge: PCTGauge) => {},
+};

--- a/packages/core/src/sims/caster/pct/pct_buffs.ts
+++ b/packages/core/src/sims/caster/pct/pct_buffs.ts
@@ -1,0 +1,162 @@
+import {Buff, BuffController} from "@xivgear/core/sims/sim_types";
+import {removeSelf} from "@xivgear/core/sims/common/utils";
+import * as Consts from "./pct_consts";
+
+/**
+ * Pictomancer-specific buffs.
+ */
+
+const HAMMER_ACTIONS: number[] = [
+    Consts.HStampID,
+    Consts.HBrushID,
+    Consts.HPolishID,
+];
+
+export const HammerTimeBuff: Buff = {
+    name: "Hammer Time",
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Able to execute Hammer combo GCDs",
+    appliesTo: ability => HAMMER_ACTIONS.includes(ability.id),
+    beforeSnapshot(controller: BuffController): void {
+        controller.subtractStacksSelf(1);
+    },
+    stacks: 3,
+    statusId: 3680,
+};
+
+export const RainbowBrightBuff: Buff = {
+    name: "Rainbow Bright",
+    duration: 30,
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Next Rainbow Drip has no cast time and a reduced recast time.",
+    appliesTo: ability => ability.id === Consts.RainbowDripID,
+    beforeAbility<PctGcdAbility>(controller: BuffController, ability: PctGcdAbility): PctGcdAbility | null {
+        controller.removeStatus(RainbowBrightBuff);
+        return {
+            ...ability,
+            gcd: 2.5,
+            cast: 0,
+        };
+    },
+    statusId: 3679,
+};
+
+export const StarstruckBuff: Buff = {
+    name: "Starstruck",
+    duration: 20,
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Able to execute Star Prism",
+    appliesTo: ability => ability.id === Consts.StarPrismID,
+    beforeSnapshot: removeSelf,
+    statusId: 3681,
+};
+
+const SUBTRACTIVE_ACTIONS: number[] = [
+    Consts.CyanID,
+    Consts.YellowID,
+    Consts.MagentaID,
+];
+
+export const SubtractivePaletteBuff: Buff = {
+    name: "Subtractive Palette",
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Able to execute Subtractive GCDs",
+    appliesTo: ability => SUBTRACTIVE_ACTIONS.includes(ability.id),
+    beforeSnapshot(controller: BuffController): void {
+        controller.subtractStacksSelf(1);
+    },
+    stacks: 3,
+    statusId: 3674,
+};
+
+export const MonochromeBuff: Buff = {
+    name: "Monochrome Tones",
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Able to execute Comet in Black",
+    appliesTo: ability => ability.id === Consts.CometID,
+    beforeSnapshot: removeSelf,
+    statusId: 3691,
+};
+
+export const SubtractiveSpectrumBuff: Buff = {
+    name: "Subtractive Spectrum",
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Able to execute Subtractive Palette without cost.",
+    appliesTo: ability => ability.id === Consts.SubtractivePaletteID,
+    beforeAbility<PctPaletteAbility>(controller: BuffController, ability: PctPaletteAbility): PctPaletteAbility {
+        controller.removeSelf();
+        return {
+            ...ability,
+            updateGauge: null,
+        };
+    },
+    statusId: 3690,
+};
+
+export const AetherhuesGYBuff: Buff = {
+    name: "Aetherhues",
+    duration: 30,
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Able to cast green and yellow magicks.",
+    appliesTo: ability => (ability.id === Consts.GreenID || ability.id === Consts.YellowID),
+    beforeSnapshot: removeSelf,
+    statusId: 3675,
+};
+
+export const AetherhuesBMBuff: Buff = {
+    name: "Aetherhues II",
+    duration: 30,
+    effects: {},
+    selfOnly: true,
+    descriptionOverride: "Able to cast blue and magenta magicks.",
+    appliesTo: ability => (ability.id === Consts.BlueID || ability.id === Consts.MagentaID),
+    beforeSnapshot: removeSelf,
+    statusId: 3676,
+};
+
+const HYPERPHANTASIA_ACTIONS: number[] = [
+    // You are going to be very sad when using these.
+    Consts.RedID, Consts.GreenID, Consts.BlueID,
+    Consts.HolyID,
+    // Standard Starry Muse window spells.
+    Consts.CyanID, Consts.YellowID, Consts.MagentaID,
+    Consts.CometID, Consts.StarPrismID,
+];
+
+/**
+ * Technically it is the Inspiration buff that grants haste, however, it's
+ * easier to just collapse both buffs into a single buff.
+ *
+ * If it turns out in a future patch that they make inspiration and/or
+ * hyperphantasia do more distinct things, then reconsider this.
+ */
+export const HyperphantasiaBuff: Buff = {
+    name: "Hyperphantasia",
+    duration: 30,
+    effects: {
+        haste: 25,
+    },
+    selfOnly: true,
+    descriptionOverride: "Aetherhue spells have reduced cast and recast times.",
+    appliesTo: ability => HYPERPHANTASIA_ACTIONS.includes(ability.id),
+    beforeAbility<PctGcdAbility>(controller: BuffController, ability: PctGcdAbility): PctGcdAbility {
+        controller.subtractStacksSelf(1);
+        const activatesBuffs = [];
+        if (this.stacks === 0) {
+            activatesBuffs.push(RainbowBrightBuff);
+        }
+        return {
+            ...ability,
+            activatesBuffs: [...activatesBuffs],
+        };
+    },
+    stacks: 5,
+    statusId: 3688,
+};

--- a/packages/core/src/sims/caster/pct/pct_consts.ts
+++ b/packages/core/src/sims/caster/pct/pct_consts.ts
@@ -1,0 +1,40 @@
+// TODO: move the ability names here too for consistency.
+// TODO: move status IDs here too for consistency.
+
+// Action IDs
+
+export const RedID : number = 34650;
+export const GreenID : number = 34651;
+export const BlueID : number = 34652;
+
+export const CyanID : number = 34653;
+export const YellowID : number = 34654;
+export const MagentaID : number = 34655;
+
+export const HolyID : number = 34662;
+export const CometID : number = 34663;
+export const RainbowDripID : number = 34688;
+export const StarPrismID : number = 34681;
+
+export const PomMotifID : number = 34664;
+export const WingMotifID : number = 34665;
+export const ClawMotifID : number = 34666;
+export const MawMotifID : number = 34667;
+export const HammerMotifID : number = 34668;
+export const StarryMotifID : number = 34669;
+
+export const PomMuseID : number = 34670;
+export const WingMuseID : number = 34671;
+export const ClawMuseID : number = 34672;
+export const FangMuseID : number = 34673;
+export const StrikingMuseID : number = 34674;
+export const StarryMuseID : number = 34675;
+
+export const SubtractivePaletteID : number = 34683;
+
+export const MogID : number = 34676;
+export const MadeenID : number = 34677;
+
+export const HStampID : number = 34678;
+export const HBrushID : number = 34679;
+export const HPolishID : number = 34680;

--- a/packages/core/src/sims/caster/pct/pct_gauge.ts
+++ b/packages/core/src/sims/caster/pct/pct_gauge.ts
@@ -1,0 +1,68 @@
+import {PctPaletteAbility, PCTGaugeState, PctPaintAbility} from './pct_types';
+
+class PCTGauge {
+    constructor(level: number) {
+        this._level = level;
+    }
+    private _level: number;
+    get level() {
+        return this._level;
+    }
+
+    private _paletteGauge : number = 0;
+    get paletteGauge() {
+        return this._paletteGauge;
+    }
+    set paletteGauge(newGauge : number) {
+        if (newGauge > 100) {
+            console.warn(`Overcapped Palette by ${newGauge - 100}.`);
+        }
+        else if (newGauge < 0) {
+            console.error(`Used ${this.paletteGauge - newGauge} Palette when you only have ${this.paletteGauge}.`);
+        }
+        this._paletteGauge = Math.max(Math.min(newGauge, 100), 0);
+    }
+
+    spendPalette(action: PctPaletteAbility) : void {
+        action.updateGauge(this);
+    }
+    paletteReady(): boolean {
+        return this.paletteGauge >= 50;
+    }
+
+    private _whitePaintCharges : number = 0;
+    get whitePaintCharges() {
+        return this._whitePaintCharges;
+    }
+    set whitePaintCharges(newGauge: number){
+        // Overcapping White Paint is not an issue so no need to check for it.
+        if (newGauge < 0) {
+            console.error(`No White Paint charges available for use.`);
+        }
+        this._paletteGauge = Math.max(Math.min(newGauge, 5), 0);
+    }
+    spendWhitePaint(action: PctPaintAbility) : void {
+        action.updateGauge(this);
+    }
+
+    private _hyperphantasiaStacks : number = 0;
+    get hyperphantasiaStacks() {
+        return this._hyperphantasiaStacks;
+    }
+    set hyperphantasiaStacks(newGauge: number){
+        if (newGauge < 0) {
+            console.error();
+        }
+    }
+
+    getGaugeState(): PCTGaugeState {
+        return {
+            level: this.level,
+            palette: this.paletteGauge,
+            whitePaint: this.whitePaintCharges,
+            hyperphantasia: this.hyperphantasiaStacks,
+        };
+    }
+}
+
+export default PCTGauge;

--- a/packages/core/src/sims/caster/pct/pct_types.ts
+++ b/packages/core/src/sims/caster/pct/pct_types.ts
@@ -1,0 +1,35 @@
+import {Ability, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
+import PCTGauge from "./pct_gauge";
+
+export type PctAbility = Ability & Readonly<{
+    /** Custom function to run to apply gauge updates relating to this ability */
+    updateGauge?(gauge: PCTGauge): void,
+    /** The Palette cost of this ability */
+    paletteCost?: number,
+    /** The White paint cost of this ability */
+    whitePaintCost?: number,
+}>;
+
+/** Represents a Pictomancer-specific GCD Ability */
+export type PctGcdAbility = GcdAbility & PctAbility;
+
+/** Represents a Pictomancer-specific oGCD Ability */
+export type PctOgcdAbility = OgcdAbility & PctAbility;
+
+/** Represens the Pictomancer gauge state */
+export type PCTGaugeState = {
+    level: number,
+    palette: number,
+    whitePaint: number,
+    hyperphantasia: number
+};
+
+export type PctPaletteAbility = PctOgcdAbility & Readonly<{
+    /** The Palette cost of the ability */
+    paletteCost: number,
+}>;
+
+export type PctPaintAbility = PctGcdAbility & Readonly <{
+    /** The white paint cost of the ability */
+    paintCost: number,
+}>;


### PR DESCRIPTION
Add the skeleton for a Pictomancer simulator for https://github.com/xiv-gear-planner/gear-planner/issues/238.

Adds in:

* Actions
  * All ST Spells
  * All relevant oGCDs
* Initial logic for applying and removing buffs
* Skeleton Gauge with no frills