### PR TITLE
Bust monk rotation cache using crit chance

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -2,7 +2,7 @@ import {Ability, Buff, GcdAbility, OgcdAbility, SimSettings, SimSpec} from "@xiv
 import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, AbilityUseResult, Rotation, PreDmgAbilityUseRecordUnf} from "@xivgear/core/sims/cycle_sim";
 import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
 import {CharacterGearSet} from "@xivgear/core/gear";
-import {BaseMultiCycleSim} from "@xivgear/core/sims/processors/sim_processors";
+import {BaseMultiCycleSim, RotationCacheKey} from "@xivgear/core/sims/processors/sim_processors";
 import {FuryAbility, MnkAbility, MNKExtraData, MnkGcdAbility, Opener} from "./mnk_types";
 import {MNKGauge as MnkGauge} from "./mnk_gauge";
 import {Brotherhood, BrotherhoodBuff, CelestialRevolution, CoeurlForm, Demolish, DragonKick, ElixirBurst, FiresReply, FiresRumination, ForbiddenMeditation, FormShift, FormlessFist, LeapingOpo, MeditativeBrotherhood, OGCD_PRIORITY, OPO_ABILITIES, OpoForm, PerfectBalance, PerfectBalanceBuff, PhantomRush, PouncingCoeurl, RaptorForm, RiddleOfFire, RiddleOfFireBuff, RiddleOfWind, RisingPhoenix, RisingRaptor, SOLAR_WEAKEST_STRONGEST, SixSidedStar, TheForbiddenChakra, TwinSnakes, WindsReply, WindsRumination} from "./mnk_actions";
@@ -436,6 +436,15 @@ export class MnkSim extends BaseMultiCycleSim<CycleSimResult, MnkSettings, MNKCy
         return new MNKCycleProcessor({
             ...settings,
         });
+    }
+
+    /**
+     * Because monk has a probabilistic chakra generation, the rotation changes due to crit chance.
+     * Preserving crit chance at the same GCD tier leads to inaccurate DPS estimates.
+     * This means monk sim doesn't get to use the cache behavior much at all.
+     */
+    protected computeCacheKey(set: CharacterGearSet): RotationCacheKey {
+        return [set.computedStats.weaponDelay, set.computedStats.skillspeed, set.computedStats.critChance];
     }
 
     getRotationsToSimulate(set: CharacterGearSet): Rotation<MNKCycleProcessor>[] {


### PR DESCRIPTION
Because monk has a probabilistic chakra generation, the rotation changes due to crit chance. Preserving crit chance at the same GCD tier leads to inaccurate DPS estimates. This means monk sim doesn't get to use the cache behavior much at all.

Closes #437