### PR TITLE
Add generic gauge bar and change PLD+NIN to use it

### DIFF
--- a/packages/common-ui/src/components/gauges.ts
+++ b/packages/common-ui/src/components/gauges.ts
@@ -1,0 +1,39 @@
+export class GaugeWithText<X> extends HTMLElement {
+
+    private readonly bar: GaugeBar<X>;
+    private readonly label: HTMLSpanElement;
+
+    constructor(barColorFunc: (val: X) => Color, private readonly labelFormat: (val: X) => string, private readonly toPercent: (val: X) => number) {
+        super();
+        this.bar = new GaugeBar(barColorFunc, toPercent);
+        this.label = document.createElement('span');
+        this.replaceChildren(this.bar, this.label);
+    }
+
+    setDataValue(value: X) {
+        this.label.textContent = this.labelFormat(value);
+        this.bar.setDataValue(value);
+    }
+}
+
+type Color = CSSStyleDeclaration['backgroundColor']
+
+export class GaugeBar<X> extends HTMLElement {
+
+    private readonly inner: HTMLDivElement;
+
+    constructor(private readonly barColorFunc: (val: X) => Color, private readonly toPercent: (val: X) => number) {
+        super();
+        this.inner = document.createElement('div');
+        this.inner.classList.add('gauge-bar-inner');
+        this.appendChild(this.inner);
+    }
+
+    setDataValue(value: X) {
+        this.inner.style.width = `${this.toPercent(value)}%`;
+        this.inner.style.backgroundColor = this.barColorFunc(value);
+    }
+}
+
+customElements.define('gauge-outer', GaugeWithText);
+customElements.define('gauge-bar', GaugeBar);

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -3531,3 +3531,5 @@ settings-modal {
   }
 
 }
+
+@import 'gauge.less';

--- a/packages/common-ui/styles/gauge.less
+++ b/packages/common-ui/styles/gauge.less
@@ -1,0 +1,25 @@
+gauge-outer {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+  box-sizing: border-box;
+
+  &.sim-gauge {
+    padding: 2px 0 2px 0;
+  }
+}
+
+gauge-bar {
+  display: inline-block;
+  overflow: hidden;
+  width: 120px;
+  border-radius: 20px;
+  background-color: #00000033;
+  height: calc(100% - 3px);
+  border: 1px solid black;
+
+  .gauge-bar-inner {
+    height: 100%;
+  }
+}

--- a/packages/frontend/src/scripts/sims/melee/nin/nin_lvl100_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/melee/nin/nin_lvl100_sim_ui.ts
@@ -3,8 +3,9 @@ import {AbilitiesUsedTable} from "../../components/ability_used_table";
 import {BaseMultiCycleSimGui} from "../../multicyclesim_ui";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {CustomColumnSpec} from "../../../tables";
-import {NinSimResult, NinSettings} from "@xivgear/core/sims/melee/nin/nin_lv100_sim";
+import {NinSettings, NinSimResult} from "@xivgear/core/sims/melee/nin/nin_lv100_sim";
 import {NINExtraData} from "@xivgear/core/sims/melee/nin/nin_types";
+import {GaugeWithText} from "@xivgear/common-ui/components/gauges";
 
 export class NINGaugeGui {
     static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
@@ -15,37 +16,14 @@ export class NINGaugeGui {
             renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const ninki = (usedAbility.extraData as NINExtraData).gauge.ninki;
-
-                    const div = document.createElement('div');
-                    div.style.height = '100%';
-                    div.style.display = 'flex';
-                    div.style.alignItems = 'center';
-                    div.style.gap = '6px';
-                    div.style.padding = '2px 0 2px 0';
-                    div.style.boxSizing = 'border-box';
-
-                    const span = document.createElement('span');
-                    span.textContent = `${ninki}`;
-
-                    const barOuter = document.createElement('div');
-                    barOuter.style.borderRadius = '20px';
-                    barOuter.style.background = '#00000033';
-                    barOuter.style.width = '120px';
-                    barOuter.style.height = 'calc(100% - 3px)';
-                    barOuter.style.display = 'inline-block';
-                    barOuter.style.overflow = 'hidden';
-                    barOuter.style.border = '1px solid black';
-
-                    const barInner = document.createElement('div');
-                    barInner.style.backgroundColor = ninki >= 50 ? '#DB5858' : '#995691';
-                    barInner.style.width = `${ninki}%`;
-                    barInner.style.height = '100%';
-                    barOuter.appendChild(barInner);
-
-                    div.appendChild(barOuter);
-                    div.appendChild(span);
-
-                    return div;
+                    const out = new GaugeWithText<number>(
+                        ninki => ninki >= 50 ? '#DB5858' : '#995691',
+                        ninki => ninki.toString(),
+                        ninki => ninki
+                    );
+                    out.setDataValue(ninki);
+                    out.classList.add('sim-gauge');
+                    return out;
                 }
                 return document.createTextNode("");
             },
@@ -65,6 +43,7 @@ export class NINGaugeGui {
     }
 
 }
+
 export class NinSheetSimGui extends BaseMultiCycleSimGui<NinSimResult, NinSettings> {
 
     override makeAbilityUsedTable(result: NinSimResult): AbilitiesUsedTable {

--- a/packages/frontend/src/scripts/sims/tank/pld_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld_sheet_sim_ui.ts
@@ -6,6 +6,7 @@ import {CustomColumnSpec} from "../../tables";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {PldExtraData} from "@xivgear/core/sims/tank/pld/pld_types";
 import {PldSettings, PldSimResult} from "@xivgear/core/sims/tank/pld/pld_sheet_sim";
+import {GaugeWithText} from "@xivgear/common-ui/components/gauges";
 
 export class PldSimGui extends BaseMultiCycleSimGui<PldSimResult, PldSettings> {
     static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
@@ -17,36 +18,10 @@ export class PldSimGui extends BaseMultiCycleSimGui<PldSimResult, PldSettings> {
                 renderer: (usedAbility?: PreDmgUsedAbility) => {
                     if (usedAbility?.extraData !== undefined) {
                         const fightOrFlightDuration = (usedAbility.extraData as PldExtraData).fightOrFlightDuration;
-                        const div = document.createElement('div');
-                        div.style.height = '100%';
-                        div.style.display = 'flex';
-                        div.style.alignItems = 'center';
-                        div.style.gap = '6px';
-                        div.style.padding = '2px 0 2px 0';
-                        div.style.boxSizing = 'border-box';
-
-                        const span = document.createElement('span');
-                        span.textContent = `${fightOrFlightDuration}s`;
-
-                        const barOuter = document.createElement('div');
-                        barOuter.style.borderRadius = '20px';
-                        barOuter.style.background = '#00000033';
-                        barOuter.style.width = '120px';
-                        barOuter.style.height = 'calc(100% - 3px)';
-                        barOuter.style.display = 'inline-block';
-                        barOuter.style.overflow = 'hidden';
-                        barOuter.style.border = '1px solid black';
-
-                        const barInner = document.createElement('div');
-                        barInner.style.backgroundColor = '#B14FAE';
-                        barInner.style.height = '100%';
-                        barInner.style.width = `${Math.round((fightOrFlightDuration / 20) * 100)}%`;
-                        barOuter.appendChild(barInner);
-
-                        div.appendChild(barOuter);
-                        div.appendChild(span);
-
-                        return div;
+                        const out = new GaugeWithText<number>(() => '#B14FAE', v => `${fightOrFlightDuration}s`, v => v / 20 * 100);
+                        out.setDataValue(fightOrFlightDuration);
+                        out.classList.add('sim-gauge');
+                        return out;
                     }
                     return document.createTextNode("");
                 },


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/32cfc035-d721-4a6f-9130-33849d24fd73)
Should look exactly the same as before, but now has a standalone class that can be used to implement this, rather than copy-pasting the same code into every sim gui.

This PR only updates PLD and NIN, the rest can be updated later.