### PR TITLE
Sheet index url param

### DIFF
--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -12,11 +12,11 @@ import {
     DEFAULT_DESC,
     DEFAULT_NAME,
     HASH_QUERY_PARAM,
-    NavPath,
+    NavPath, ONLY_SET_QUERY_PARAM,
     parsePath,
     PATH_SEPARATOR,
     PREVIEW_MAX_DESC_LENGTH,
-    PREVIEW_MAX_NAME_LENGTH
+    PREVIEW_MAX_NAME_LENGTH, tryParseOptionalIntParam
 } from "@xivgear/core/nav/common_nav";
 import {nonCachedFetch} from "./polyfills";
 import fastifyWebResponse from "fastify-web-response";
@@ -152,9 +152,11 @@ export function buildPreviewServer() {
         const responsePromise = nonCachedFetch(serverUrl + '/index.html', undefined);
         try {
             const path = request.query[HASH_QUERY_PARAM] ?? '';
+            const osIndex: number | undefined = tryParseOptionalIntParam(request.query[ONLY_SET_QUERY_PARAM]);
             const pathPaths = path.split(PATH_SEPARATOR);
-            const nav = parsePath(pathPaths);
+            const nav = parsePath(pathPaths, osIndex);
             request.log.info(pathPaths, 'Path');
+            // TODO: wire up osIndex to this
             const exported: object | null = await resolveNav(nav);
             if (exported !== null) {
                 let name: string = exported['name'] || "";

--- a/packages/backend-resolver/src/test/test_endpoints.ts
+++ b/packages/backend-resolver/src/test/test_endpoints.ts
@@ -4,7 +4,20 @@ import {buildPreviewServer, buildStatsServer} from "../server_builder";
 import {SheetStatsExport} from "@xivgear/xivmath/geartypes";
 import {BIS_HASH, SHORTLINK_HASH} from "@xivgear/core/nav/common_nav";
 
-describe("backend stat resolver server", () => {
+function readPreviewProps(document: Document): Record<string, string> {
+    const out = {};
+    document.querySelectorAll("head meta")
+        .forEach(meta => {
+            const key = meta.getAttribute("property");
+            if (key?.startsWith("og:")) {
+                const value = meta.getAttribute("content");
+                out[key] = value;
+            }
+        });
+    return out;
+}
+
+describe("backend servers", () => {
     describe("set fulldata endpoint", () => {
         const fastify = buildStatsServer();
         it("responds to health check", async () => {
@@ -78,6 +91,7 @@ describe("backend stat resolver server", () => {
     describe("preview endpoint", () => {
         const fastify = buildPreviewServer();
         const parser = new DOMParser();
+        const slTitle = 'WHM 6.4 copy - XivGear - FFXIV Gear Planner';
         it("resolves shortlink", async () => {
             const uuid = 'f9b260a9-650c-445a-b3eb-c56d8d968501';
             const response = await fastify.inject({
@@ -86,7 +100,7 @@ describe("backend stat resolver server", () => {
             });
             assert.equal(response.statusCode, 200);
             const parsed = parser.parseFromString(response.body, 'text/html');
-            assert.equal(parsed.querySelector('title').textContent, 'WHM 6.4 copy - XivGear - FFXIV Gear Planner');
+            assert.equal(parsed.querySelector('title').textContent, slTitle);
 
             // Check the preloads
             const preloads = Array.from(parsed.querySelectorAll('link'))
@@ -103,6 +117,11 @@ describe("backend stat resolver server", () => {
             assert.equal(shortlinkPreload.getAttribute('href'), `https://api.xivgear.app/shortlink/${uuid}`);
             assert.equal(shortlinkPreload.getAttribute('as'), "fetch");
             assert.equal(shortlinkPreload.hasAttribute('crossorigin'), true);
+
+            const props = readPreviewProps(parsed);
+            assert.equal(props['og:site_name'], 'XivGear');
+            assert.equal(props['og:type'], 'website');
+            assert.equal(props['og:title'], slTitle);
         }).timeout(30_000);
         it("resolves shortlink with trailing slash", async () => {
             const response = await fastify.inject({
@@ -111,8 +130,73 @@ describe("backend stat resolver server", () => {
             });
             assert.equal(response.statusCode, 200);
             const parsed = parser.parseFromString(response.body, 'text/html');
-            assert.equal(parsed.querySelector('title').textContent, 'WHM 6.4 copy - XivGear - FFXIV Gear Planner');
+            assert.equal(parsed.querySelector('title').textContent, slTitle);
         }).timeout(30_000);
+        it("resolves shortlink with set selection index", async () => {
+            const uuid = 'f9b260a9-650c-445a-b3eb-c56d8d968501';
+            const response = await fastify.inject({
+                method: 'GET',
+                url: `/?page=${SHORTLINK_HASH}|${uuid}&selectedIndex=3`,
+            });
+            assert.equal(response.statusCode, 200);
+            const parsed = parser.parseFromString(response.body, 'text/html');
+            assert.equal(parsed.querySelector('title').textContent, slTitle);
+
+
+            // Check the preloads
+            const preloads = Array.from(parsed.querySelectorAll('link'))
+                .filter(link => link.rel === 'preload');
+
+            const jobPreload = preloads[preloads.length - 2];
+            assert.equal(jobPreload.getAttribute('rel'), "preload");
+            assert.equal(jobPreload.getAttribute('href'), "https://data.xivgear.app/Items?job=WHM");
+            assert.equal(jobPreload.getAttribute('as'), "fetch");
+            assert.equal(jobPreload.hasAttribute('crossorigin'), true);
+
+            const shortlinkPreload = preloads[preloads.length - 1];
+            assert.equal(shortlinkPreload.getAttribute('rel'), "preload");
+            assert.equal(shortlinkPreload.getAttribute('href'), `https://api.xivgear.app/shortlink/${uuid}`);
+            assert.equal(shortlinkPreload.getAttribute('as'), "fetch");
+            assert.equal(shortlinkPreload.hasAttribute('crossorigin'), true);
+
+            const props = readPreviewProps(parsed);
+            assert.equal(props['og:site_name'], 'XivGear');
+            assert.equal(props['og:type'], 'website');
+            assert.equal(props['og:title'], slTitle);
+        }).timeout(30_000);
+        it("resolves shortlink exclusive set index", async () => {
+            const uuid = 'f9b260a9-650c-445a-b3eb-c56d8d968501';
+            const response = await fastify.inject({
+                method: 'GET',
+                url: `/?page=${SHORTLINK_HASH}|${uuid}&onlySetIndex=3`,
+            });
+            assert.equal(response.statusCode, 200);
+            const parsed = parser.parseFromString(response.body, 'text/html');
+            const setTitle = '6.4 Week 1 2.43 b - XivGear - FFXIV Gear Planner';
+            assert.equal(parsed.querySelector('title').textContent, setTitle);
+
+            // Check the preloads
+            const preloads = Array.from(parsed.querySelectorAll('link'))
+                .filter(link => link.rel === 'preload');
+
+            const jobPreload = preloads[preloads.length - 2];
+            assert.equal(jobPreload.getAttribute('rel'), "preload");
+            assert.equal(jobPreload.getAttribute('href'), "https://data.xivgear.app/Items?job=WHM");
+            assert.equal(jobPreload.getAttribute('as'), "fetch");
+            assert.equal(jobPreload.hasAttribute('crossorigin'), true);
+
+            const shortlinkPreload = preloads[preloads.length - 1];
+            assert.equal(shortlinkPreload.getAttribute('rel'), "preload");
+            assert.equal(shortlinkPreload.getAttribute('href'), `https://api.xivgear.app/shortlink/${uuid}`);
+            assert.equal(shortlinkPreload.getAttribute('as'), "fetch");
+            assert.equal(shortlinkPreload.hasAttribute('crossorigin'), true);
+
+            const props = readPreviewProps(parsed);
+            assert.equal(props['og:site_name'], 'XivGear');
+            assert.equal(props['og:type'], 'website');
+            assert.equal(props['og:title'], setTitle);
+        }).timeout(30_000);
+        const bisTitle = '6.55 Savage SGE BiS - XivGear - FFXIV Gear Planner';
         it("resolves bis link", async () => {
             const response = await fastify.inject({
                 method: 'GET',
@@ -120,7 +204,7 @@ describe("backend stat resolver server", () => {
             });
             assert.equal(response.statusCode, 200);
             const parsed = parser.parseFromString(response.body, 'text/html');
-            assert.equal(parsed.querySelector('title').textContent, '6.55 Savage SGE BiS - XivGear - FFXIV Gear Planner');
+            assert.equal(parsed.querySelector('title').textContent, bisTitle);
 
             // Check the preloads
             const preloads = Array.from(parsed.querySelectorAll('link'))
@@ -137,6 +221,11 @@ describe("backend stat resolver server", () => {
             assert.equal(shortlinkPreload.getAttribute('href'), `https://staticbis.xivgear.app/sge/endwalker/anabaseios.json`);
             assert.equal(shortlinkPreload.getAttribute('as'), "fetch");
             assert.equal(shortlinkPreload.hasAttribute('crossorigin'), true);
+
+            const props = readPreviewProps(parsed);
+            assert.equal(props['og:site_name'], 'XivGear');
+            assert.equal(props['og:type'], 'website');
+            assert.equal(props['og:title'], bisTitle);
         }).timeout(30_000);
         it("resolves bis link with trailing slash", async () => {
             const response = await fastify.inject({
@@ -146,6 +235,41 @@ describe("backend stat resolver server", () => {
             assert.equal(response.statusCode, 200);
             const parsed = parser.parseFromString(response.body, 'text/html');
             assert.equal(parsed.querySelector('title').textContent, '6.55 Savage SGE BiS - XivGear - FFXIV Gear Planner');
+        }).timeout(30_000);
+        it("resolves bis link with onlySetIndex", async () => {
+            const response = await fastify.inject({
+                method: 'GET',
+                url: `/?page=${BIS_HASH}|sge|endwalker|anabaseios&onlySetIndex=2`,
+            });
+            assert.equal(response.statusCode, 200);
+            const parsed = parser.parseFromString(response.body, 'text/html');
+
+            const setTitle = '2.45 Non-Relic - XivGear - FFXIV Gear Planner';
+            const setDesc = '(6.4) - Same as WHM 2.45. Lowest piety but highest DPS.\n\nXivGear is an advanced and easy-to-use FFXIV gear planner/set builder with built-in simulation support.';
+
+            assert.equal(parsed.querySelector('title').textContent, setTitle);
+
+            // Check the preloads
+            const preloads = Array.from(parsed.querySelectorAll('link'))
+                .filter(link => link.rel === 'preload');
+
+            const jobPreload = preloads[preloads.length - 2];
+            assert.equal(jobPreload.getAttribute('rel'), "preload");
+            assert.equal(jobPreload.getAttribute('href'), "https://data.xivgear.app/Items?job=SGE");
+            assert.equal(jobPreload.getAttribute('as'), "fetch");
+            assert.equal(jobPreload.hasAttribute('crossorigin'), true);
+
+            const shortlinkPreload = preloads[preloads.length - 1];
+            assert.equal(shortlinkPreload.getAttribute('rel'), "preload");
+            assert.equal(shortlinkPreload.getAttribute('href'), `https://staticbis.xivgear.app/sge/endwalker/anabaseios.json`);
+            assert.equal(shortlinkPreload.getAttribute('as'), "fetch");
+            assert.equal(shortlinkPreload.hasAttribute('crossorigin'), true);
+
+            const props = readPreviewProps(parsed);
+            assert.equal(props['og:site_name'], 'XivGear');
+            assert.equal(props['og:type'], 'website');
+            assert.equal(props['og:title'], setTitle);
+            assert.equal(props['og:description'], setDesc);
         }).timeout(30_000);
     });
 });

--- a/packages/core/src/external/shortlink_server.ts
+++ b/packages/core/src/external/shortlink_server.ts
@@ -1,4 +1,4 @@
-import {EMBED_HASH, makeUrl, SHORTLINK_HASH} from "../nav/common_nav";
+import {EMBED_HASH, makeUrl, NavState, SHORTLINK_HASH} from "../nav/common_nav";
 
 const SHORTLINK_SERVER: URL = new URL("https://api.xivgear.app/shortlink/");
 
@@ -39,10 +39,10 @@ export async function putShortLink(content: string, embed: boolean = false): Pro
     }).then(response => response.text()).then(uuid => {
         // If on prod, use the fancy share link.
         if (embed) {
-            return makeUrl(EMBED_HASH, SHORTLINK_HASH, uuid);
+            return makeUrl(new NavState([EMBED_HASH, SHORTLINK_HASH, uuid]));
         }
         else {
-            return makeUrl(SHORTLINK_HASH, uuid);
+            return makeUrl(new NavState([SHORTLINK_HASH, uuid]));
         }
     });
 }

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -19,6 +19,11 @@ export const CALC_HASH = 'math';
 export const PATH_SEPARATOR = '|';
 /** The query param used to represent the path */
 export const HASH_QUERY_PARAM = 'page';
+
+/**
+ * The query param used to select a single gear set out of a sheet.
+ */
+export const ONLY_SET_QUERY_PARAM = 'onlySetIndex';
 /**
  * Special hash value used to indicate that the page should stay with the old-style hash, rather than redirecting
  * to the new style query parameter.
@@ -60,7 +65,8 @@ export type NavPath = {
     saveKey: string
 } | {
     type: 'shortlink',
-    uuid: string
+    uuid: string,
+    onlySetIndex?: number
 } | {
     type: 'setjson'
     jsonBlob: object
@@ -73,11 +79,12 @@ export type NavPath = {
     job: JobName,
     expac: string,
     sheet: string,
+    onlySetIndex?: number
 }));
 
 export type SheetType = NavPath['type'];
 
-export function parsePath(originalPath: string[]): NavPath | null {
+export function parsePath(originalPath: string[], onlySetIndex: number | undefined): NavPath | null {
     let path = [...originalPath];
     let embed = false;
     if (path.length === 0) {
@@ -164,6 +171,7 @@ export function parsePath(originalPath: string[]): NavPath | null {
                 uuid: path[1],
                 embed: embed,
                 viewOnly: true,
+                onlySetIndex: onlySetIndex,
             };
         }
     }
@@ -178,6 +186,7 @@ export function parsePath(originalPath: string[]): NavPath | null {
                 sheet: path[3],
                 viewOnly: true,
                 embed: false,
+                onlySetIndex: onlySetIndex,
             };
         }
     }
@@ -227,4 +236,16 @@ export function splitPath(input: string) {
         .filter(item => item)
         .map(item => decodeURIComponent(item))
         .map(pp => pp.replaceAll(VERTICAL_BAR_REPLACEMENT, PATH_SEPARATOR));
+}
+
+export function tryParseOptionalIntParam(input: string | undefined): number | undefined {
+    if (input) {
+        try {
+            return parseInt(input);
+        }
+        catch (e) {
+            console.error(`Error parsing '${input}'`, e);
+        }
+    }
+    return undefined;
 }

--- a/packages/core/src/test/common_nav_test.ts
+++ b/packages/core/src/test/common_nav_test.ts
@@ -18,20 +18,20 @@ describe('parsePath', () => {
 
     describe('mysheets', () => {
         it('resolves empty path to mysheets', () => {
-            const result = parsePath([]);
+            const result = parsePath([], undefined);
             expect(result).to.deep.equals({
                 type: 'mysheets',
             });
         });
         it('resolves raw embed to null', () => {
-            const result = parsePath(['embed']);
+            const result = parsePath(['embed'], undefined);
             expect(result).to.be.null;
         });
     });
 
     describe('saved sheets', () => {
         it('resolves saved sheet path', () => {
-            const result = parsePath(['sheet', 'foo']);
+            const result = parsePath(['sheet', 'foo'], undefined);
             expect(result).to.deep.equals({
                 type: 'saved',
                 viewOnly: false,
@@ -40,7 +40,7 @@ describe('parsePath', () => {
             });
         });
         it('does not try to embed saved sheet', () => {
-            const result = parsePath(['embed', 'sheet', 'foo']);
+            const result = parsePath(['embed', 'sheet', 'foo'], undefined);
             expect(result).to.deep.equals({
                 type: 'saved',
                 viewOnly: false,
@@ -52,19 +52,19 @@ describe('parsePath', () => {
 
     describe('newsheet', () => {
         it('resolves newsheet path', () => {
-            const result = parsePath(['newsheet']);
+            const result = parsePath(['newsheet'], undefined);
             expect(result).to.deep.equals({
                 type: 'newsheet',
             });
         });
         it('does not try to embed newsheet', () => {
-            const result = parsePath(['embed', 'newsheet']);
+            const result = parsePath(['embed', 'newsheet'], undefined);
             expect(result).to.deep.equals({
                 type: 'newsheet',
             });
         });
         it('resolves import form', () => {
-            const result = parsePath(['importsheet']);
+            const result = parsePath(['importsheet'], undefined);
             expect(result).to.deep.equals({
                 type: 'importform',
             });
@@ -73,7 +73,7 @@ describe('parsePath', () => {
 
     describe('importsheet', () => {
         it('does not try to embed import form', () => {
-            const result = parsePath(['embed', 'importsheet']);
+            const result = parsePath(['embed', 'importsheet'], undefined);
             expect(result).to.deep.equals({
                 type: 'importform',
             });
@@ -82,7 +82,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['importsheet', JSON.stringify(setValue)]);
+            const result = parsePath(['importsheet', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -94,7 +94,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'importsheet', JSON.stringify(setValue)]);
+            const result = parsePath(['embed', 'importsheet', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -109,7 +109,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['viewsheet', JSON.stringify(setValue)]);
+            const result = parsePath(['viewsheet', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -121,7 +121,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'viewsheet', JSON.stringify(setValue)]);
+            const result = parsePath(['embed', 'viewsheet', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -136,7 +136,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['importset', JSON.stringify(setValue)]);
+            const result = parsePath(['importset', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -149,7 +149,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'importset', JSON.stringify(setValue)]);
+            const result = parsePath(['embed', 'importset', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -164,7 +164,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['viewset', JSON.stringify(setValue)]);
+            const result = parsePath(['viewset', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -176,7 +176,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'viewset', JSON.stringify(setValue)]);
+            const result = parsePath(['embed', 'viewset', JSON.stringify(setValue)], undefined);
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -190,7 +190,7 @@ describe('parsePath', () => {
     describe('shortlink', () => {
 
         it('can resolve shortlink', () => {
-            const result = parsePath(['sl', 'asdf']);
+            const result = parsePath(['sl', 'asdf'], undefined);
             expect(result).to.deep.equals({
                 type: 'shortlink',
                 uuid: 'asdf',
@@ -199,7 +199,7 @@ describe('parsePath', () => {
             });
         });
         it('can embed shortlink', () => {
-            const result = parsePath(['embed', 'sl', 'asdf']);
+            const result = parsePath(['embed', 'sl', 'asdf'], undefined);
             expect(result).to.deep.equals({
                 type: 'shortlink',
                 uuid: 'asdf',
@@ -208,14 +208,14 @@ describe('parsePath', () => {
             });
         });
         it('returns null if no link', () => {
-            const result = parsePath(['sl']);
+            const result = parsePath(['sl'], undefined);
             expect(result).to.be.null;
         });
     });
 
     describe('bis', () => {
         it('can resolve bis', () => {
-            const result = parsePath(['bis', 'sge', 'endwalker', 'anabaseios']);
+            const result = parsePath(['bis', 'sge', 'endwalker', 'anabaseios'], undefined);
             expect(result).to.deep.equals({
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
@@ -227,7 +227,7 @@ describe('parsePath', () => {
             });
         });
         it('does not try to embed bis', () => {
-            const result = parsePath(['embed', 'bis', 'sge', 'endwalker', 'anabaseios']);
+            const result = parsePath(['embed', 'bis', 'sge', 'endwalker', 'anabaseios'], undefined);
             expect(result).to.deep.equals({
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
@@ -239,7 +239,7 @@ describe('parsePath', () => {
             });
         });
         it('returns null if incomplete url', () => {
-            const result = parsePath(['bis', 'sge', 'endwalker']);
+            const result = parsePath(['bis', 'sge', 'endwalker'], undefined);
             expect(result).to.be.null;
         });
 

--- a/packages/core/src/test/common_nav_test.ts
+++ b/packages/core/src/test/common_nav_test.ts
@@ -1,4 +1,4 @@
-import {parsePath, splitHashLegacy, splitPath} from "../nav/common_nav";
+import {NavState, parsePath, splitHashLegacy, splitPath} from "../nav/common_nav";
 import {expect} from "chai";
 
 describe('path splitting and joining', () => {
@@ -18,20 +18,20 @@ describe('parsePath', () => {
 
     describe('mysheets', () => {
         it('resolves empty path to mysheets', () => {
-            const result = parsePath([], undefined);
+            const result = parsePath(new NavState([]));
             expect(result).to.deep.equals({
                 type: 'mysheets',
             });
         });
         it('resolves raw embed to null', () => {
-            const result = parsePath(['embed'], undefined);
+            const result = parsePath(new NavState(['embed']));
             expect(result).to.be.null;
         });
     });
 
     describe('saved sheets', () => {
         it('resolves saved sheet path', () => {
-            const result = parsePath(['sheet', 'foo'], undefined);
+            const result = parsePath(new NavState(['sheet', 'foo']));
             expect(result).to.deep.equals({
                 type: 'saved',
                 viewOnly: false,
@@ -40,7 +40,7 @@ describe('parsePath', () => {
             });
         });
         it('does not try to embed saved sheet', () => {
-            const result = parsePath(['embed', 'sheet', 'foo'], undefined);
+            const result = parsePath(new NavState(['embed', 'sheet', 'foo']));
             expect(result).to.deep.equals({
                 type: 'saved',
                 viewOnly: false,
@@ -52,19 +52,19 @@ describe('parsePath', () => {
 
     describe('newsheet', () => {
         it('resolves newsheet path', () => {
-            const result = parsePath(['newsheet'], undefined);
+            const result = parsePath(new NavState(['newsheet']));
             expect(result).to.deep.equals({
                 type: 'newsheet',
             });
         });
         it('does not try to embed newsheet', () => {
-            const result = parsePath(['embed', 'newsheet'], undefined);
+            const result = parsePath(new NavState(['embed', 'newsheet']));
             expect(result).to.deep.equals({
                 type: 'newsheet',
             });
         });
         it('resolves import form', () => {
-            const result = parsePath(['importsheet'], undefined);
+            const result = parsePath(new NavState(['importsheet']));
             expect(result).to.deep.equals({
                 type: 'importform',
             });
@@ -73,7 +73,7 @@ describe('parsePath', () => {
 
     describe('importsheet', () => {
         it('does not try to embed import form', () => {
-            const result = parsePath(['embed', 'importsheet'], undefined);
+            const result = parsePath(new NavState(['embed', 'importsheet']));
             expect(result).to.deep.equals({
                 type: 'importform',
             });
@@ -82,7 +82,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['importsheet', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['importsheet', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -94,7 +94,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'importsheet', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['embed', 'importsheet', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -109,7 +109,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['viewsheet', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['viewsheet', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -121,7 +121,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'viewsheet', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['embed', 'viewsheet', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'sheetjson',
                 jsonBlob: setValue,
@@ -136,7 +136,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['importset', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['importset', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -149,7 +149,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'importset', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['embed', 'importset', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -164,7 +164,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['viewset', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['viewset', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -176,7 +176,7 @@ describe('parsePath', () => {
             const setValue = {
                 foo: 'bar|baz',
             };
-            const result = parsePath(['embed', 'viewset', JSON.stringify(setValue)], undefined);
+            const result = parsePath(new NavState(['embed', 'viewset', JSON.stringify(setValue)]));
             expect(result).to.deep.equals({
                 type: 'setjson',
                 jsonBlob: setValue,
@@ -190,7 +190,7 @@ describe('parsePath', () => {
     describe('shortlink', () => {
 
         it('can resolve shortlink', () => {
-            const result = parsePath(['sl', 'asdf'], undefined);
+            const result = parsePath(new NavState(['sl', 'asdf']));
             expect(result).to.deep.equals({
                 type: 'shortlink',
                 uuid: 'asdf',
@@ -199,7 +199,7 @@ describe('parsePath', () => {
             });
         });
         it('can embed shortlink', () => {
-            const result = parsePath(['embed', 'sl', 'asdf'], undefined);
+            const result = parsePath(new NavState(['embed', 'sl', 'asdf']));
             expect(result).to.deep.equals({
                 type: 'shortlink',
                 uuid: 'asdf',
@@ -208,14 +208,14 @@ describe('parsePath', () => {
             });
         });
         it('returns null if no link', () => {
-            const result = parsePath(['sl'], undefined);
+            const result = parsePath(new NavState(['sl']));
             expect(result).to.be.null;
         });
     });
 
     describe('bis', () => {
         it('can resolve bis', () => {
-            const result = parsePath(['bis', 'sge', 'endwalker', 'anabaseios'], undefined);
+            const result = parsePath(new NavState(['bis', 'sge', 'endwalker', 'anabaseios']));
             expect(result).to.deep.equals({
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
@@ -227,7 +227,7 @@ describe('parsePath', () => {
             });
         });
         it('does not try to embed bis', () => {
-            const result = parsePath(['embed', 'bis', 'sge', 'endwalker', 'anabaseios'], undefined);
+            const result = parsePath(new NavState(['embed', 'bis', 'sge', 'endwalker', 'anabaseios']));
             expect(result).to.deep.equals({
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
@@ -239,7 +239,7 @@ describe('parsePath', () => {
             });
         });
         it('returns null if incomplete url', () => {
-            const result = parsePath(['bis', 'sge', 'endwalker'], undefined);
+            const result = parsePath(new NavState(['bis', 'sge', 'endwalker']));
             expect(result).to.be.null;
         });
 

--- a/packages/core/src/test/common_nav_test.ts
+++ b/packages/core/src/test/common_nav_test.ts
@@ -1,4 +1,4 @@
-import {NavState, parsePath, splitHashLegacy, splitPath} from "../nav/common_nav";
+import {NavPath, NavState, parsePath, splitHashLegacy, splitPath} from "../nav/common_nav";
 import {expect} from "chai";
 
 describe('path splitting and joining', () => {
@@ -196,7 +196,9 @@ describe('parsePath', () => {
                 uuid: 'asdf',
                 embed: false,
                 viewOnly: true,
-            });
+                onlySetIndex: undefined,
+                defaultSelectionIndex: undefined,
+            } satisfies NavPath);
         });
         it('can embed shortlink', () => {
             const result = parsePath(new NavState(['embed', 'sl', 'asdf']));
@@ -205,6 +207,30 @@ describe('parsePath', () => {
                 uuid: 'asdf',
                 embed: true,
                 viewOnly: true,
+                onlySetIndex: undefined,
+                defaultSelectionIndex: undefined,
+            });
+        });
+        it('can handle selection index', () => {
+            const result = parsePath(new NavState(['embed', 'sl', 'asdf'], undefined, 3));
+            expect(result).to.deep.equals({
+                type: 'shortlink',
+                uuid: 'asdf',
+                embed: true,
+                viewOnly: true,
+                onlySetIndex: undefined,
+                defaultSelectionIndex: 3,
+            });
+        });
+        it('can handle exclusive index', () => {
+            const result = parsePath(new NavState(['embed', 'sl', 'asdf'], 2, undefined));
+            expect(result).to.deep.equals({
+                type: 'shortlink',
+                uuid: 'asdf',
+                embed: true,
+                viewOnly: true,
+                onlySetIndex: 2,
+                defaultSelectionIndex: undefined,
             });
         });
         it('returns null if no link', () => {
@@ -224,6 +250,8 @@ describe('parsePath', () => {
                 sheet: 'anabaseios',
                 embed: false,
                 viewOnly: true,
+                onlySetIndex: undefined,
+                defaultSelectionIndex: undefined,
             });
         });
         it('does not try to embed bis', () => {
@@ -236,6 +264,36 @@ describe('parsePath', () => {
                 sheet: 'anabaseios',
                 embed: false,
                 viewOnly: true,
+                onlySetIndex: undefined,
+                defaultSelectionIndex: undefined,
+            });
+        });
+        it('can resolve bis with selection index', () => {
+            const result = parsePath(new NavState(['bis', 'sge', 'endwalker', 'anabaseios'], undefined, 5));
+            expect(result).to.deep.equals({
+                type: 'bis',
+                path: ['sge', 'endwalker', 'anabaseios'],
+                job: 'sge',
+                expac: 'endwalker',
+                sheet: 'anabaseios',
+                embed: false,
+                viewOnly: true,
+                onlySetIndex: undefined,
+                defaultSelectionIndex: 5,
+            });
+        });
+        it('can resolve bis with exclusive index', () => {
+            const result = parsePath(new NavState(['bis', 'sge', 'endwalker', 'anabaseios'], 4, undefined));
+            expect(result).to.deep.equals({
+                type: 'bis',
+                path: ['sge', 'endwalker', 'anabaseios'],
+                job: 'sge',
+                expac: 'endwalker',
+                sheet: 'anabaseios',
+                embed: false,
+                viewOnly: true,
+                onlySetIndex: 4,
+                defaultSelectionIndex: undefined,
             });
         });
         it('returns null if incomplete url', () => {

--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -2,7 +2,7 @@ import {getHash, goHash, isEmbed, processHashLegacy, processNav, setHash} from "
 import {NamedSection} from "./components/section";
 import {NewSheetForm} from "./components/new_sheet_form";
 import {ImportSheetArea} from "./components/import_sheet";
-import {SetExport, SheetExport} from "@xivgear/xivmath/geartypes";
+import {SetExport, SetExportExternalSingle, SheetExport} from "@xivgear/xivmath/geartypes";
 import {displayEmbedError, openEmbed} from "./embed";
 import {LoadingBlocker} from "@xivgear/common-ui/components/loader";
 import {SheetPickerTable} from "./components/saved_sheet_picker";
@@ -135,7 +135,30 @@ export async function openSheetByKey(sheet: string) {
     }
 }
 
-export async function openExport(exported: (SheetExport | SetExport), changeHash: boolean, viewOnly: boolean) {
+export async function openExport(exportedPre: (SheetExport | SetExport), changeHash: boolean, viewOnly: boolean, onlySetIndex: number | undefined) {
+    const exportedInitial = exportedPre;
+    const initiallyFullSheet = 'sets' in exportedInitial;
+    if (onlySetIndex !== undefined) {
+        if (!initiallyFullSheet) {
+            console.warn("onlySetIndex does not make sense when isFullSheet is false");
+        }
+        else {
+            const theSet = exportedInitial.sets[onlySetIndex];
+            // noinspection AssignmentToFunctionParameterJS
+            exportedPre = {
+                ...theSet,
+                job: exportedInitial.job,
+                level: exportedInitial.level,
+                ilvlSync: exportedInitial.ilvlSync,
+                sims: exportedInitial.sims,
+                customItems: exportedInitial.customItems,
+                customFoods: exportedInitial.customFoods,
+                partyBonus: exportedInitial.partyBonus,
+                race: exportedInitial.race,
+            } satisfies SetExportExternalSingle;
+        }
+    }
+    const exported = exportedPre;
     const isFullSheet = 'sets' in exported;
     const sheet = isFullSheet ? GRAPHICAL_SHEET_PROVIDER.fromExport(exported) : GRAPHICAL_SHEET_PROVIDER.fromSetExport(exported);
     const embed = isEmbed();

--- a/packages/frontend/src/scripts/components/export_controller.ts
+++ b/packages/frontend/src/scripts/components/export_controller.ts
@@ -8,7 +8,7 @@ import {closeModal} from "@xivgear/common-ui/modalcontrol";
 import {putShortLink} from "@xivgear/core/external/shortlink_server";
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {BaseModal} from "@xivgear/common-ui/components/modal";
-import {makeUrl, ONLY_SET_QUERY_PARAM, VIEW_SET_HASH} from "@xivgear/core/nav/common_nav";
+import {makeUrlSimple, ONLY_SET_QUERY_PARAM, VIEW_SET_HASH} from "@xivgear/core/nav/common_nav";
 import {GearPlanSheet} from "@xivgear/core/sheet";
 import {writeProxy} from "@xivgear/core/util/proxies";
 import {EquipSlots, Materia, XivItem} from "@xivgear/xivmath/geartypes";
@@ -368,7 +368,7 @@ class SheetExportModal extends ExportModal<GearPlanSheet> {
 
     get previewUrl(): string {
         const exported = this.sheet.exportSheet(true);
-        const url = makeUrl(VIEW_SET_HASH, JSON.stringify(exported));
+        const url = makeUrlSimple(VIEW_SET_HASH, JSON.stringify(exported));
         console.log("Preview url", url);
         return url.toString();
     }
@@ -382,7 +382,7 @@ class SetExportModal extends ExportModal<CharacterGearSet> {
 
     get previewUrl(): string {
         const exported = this.sheet.exportGearSet(this.item, true);
-        const url = makeUrl(VIEW_SET_HASH, JSON.stringify(exported));
+        const url = makeUrlSimple(VIEW_SET_HASH, JSON.stringify(exported));
         console.log("Preview url", url);
         return url.toString();
     }

--- a/packages/frontend/src/scripts/components/export_controller.ts
+++ b/packages/frontend/src/scripts/components/export_controller.ts
@@ -8,7 +8,7 @@ import {closeModal} from "@xivgear/common-ui/modalcontrol";
 import {putShortLink} from "@xivgear/core/external/shortlink_server";
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {BaseModal} from "@xivgear/common-ui/components/modal";
-import {makeUrl, VIEW_SET_HASH} from "@xivgear/core/nav/common_nav";
+import {makeUrl, ONLY_SET_QUERY_PARAM, VIEW_SET_HASH} from "@xivgear/core/nav/common_nav";
 import {GearPlanSheet} from "@xivgear/core/sheet";
 import {writeProxy} from "@xivgear/core/util/proxies";
 import {EquipSlots, Materia, XivItem} from "@xivgear/xivmath/geartypes";
@@ -72,13 +72,19 @@ const linkPerSet = {
     exportInstantly: false,
     async doExport(sheet: GearPlanSheet): Promise<string> {
         const sets = sheet.sets;
-        if (sets.length === 0) {
+        if (sets.filter(set => !set.isSeparator).length === 0) {
             return "This sheet does not have any sets!";
         }
         let out = '';
-        for (const set of sets) {
-            const exportedSet = JSON.stringify(sheet.exportGearSet(set, true));
-            const linkToSet = await putShortLink(exportedSet).then(link => link.toString());
+        const exportedSheet = JSON.stringify(sheet.exportSheet(true));
+        const linkToSheet = await putShortLink(exportedSheet);
+        for (const i in sets) {
+            const set = sets[i];
+            if (set.isSeparator) {
+                continue;
+            }
+            const linkToSet = new URL(linkToSheet);
+            linkToSet.searchParams.set(ONLY_SET_QUERY_PARAM, i);
             out += linkToSet;
             out += '\n';
         }
@@ -94,13 +100,19 @@ const embedLinkPerSet = {
     exportInstantly: false,
     async doExport(sheet: GearPlanSheet): Promise<string> {
         const sets = sheet.sets;
-        if (sets.length === 0) {
+        if (sets.filter(set => !set.isSeparator).length === 0) {
             return "This sheet does not have any sets!";
         }
         let out = '';
-        for (const set of sets) {
-            const exportedSet = JSON.stringify(sheet.exportGearSet(set, true));
-            const linkToSet = await putShortLink(exportedSet, true).then(link => link.toString());
+        const exportedSheet = JSON.stringify(sheet.exportSheet(true));
+        const linkToSheet = await putShortLink(exportedSheet, true);
+        for (const i in sets) {
+            const set = sets[i];
+            if (set.isSeparator) {
+                continue;
+            }
+            const linkToSet = new URL(linkToSheet);
+            linkToSet.searchParams.set(ONLY_SET_QUERY_PARAM, i);
             out += linkToSet;
             out += '\n';
         }

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -71,7 +71,7 @@ import {simpleAutoResultTable} from "../sims/components/simple_tables";
 import {rangeInc} from "@xivgear/core/util/array_utils";
 import {SimCurrentResult, SimResult, SimSettings, SimSpec, Simulation} from "@xivgear/core/sims/sim_types";
 import {getRegisteredSimSpecs} from "@xivgear/core/sims/sim_registry";
-import {makeUrl, makeUrlSimple, NavState, ONLY_SET_QUERY_PARAM} from "@xivgear/core/nav/common_nav";
+import {makeUrl, NavState, ONLY_SET_QUERY_PARAM} from "@xivgear/core/nav/common_nav";
 import {simMaintainersInfoElement} from "./sims";
 import {SaveAsModal} from "./new_sheet_form";
 import {DropdownActionMenu} from "./dropdown_actions_menu";

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -71,7 +71,7 @@ import {simpleAutoResultTable} from "../sims/components/simple_tables";
 import {rangeInc} from "@xivgear/core/util/array_utils";
 import {SimCurrentResult, SimResult, SimSettings, SimSpec, Simulation} from "@xivgear/core/sims/sim_types";
 import {getRegisteredSimSpecs} from "@xivgear/core/sims/sim_registry";
-import {makeUrl} from "@xivgear/core/nav/common_nav";
+import {makeUrl, ONLY_SET_QUERY_PARAM} from "@xivgear/core/nav/common_nav";
 import {simMaintainersInfoElement} from "./sims";
 import {SaveAsModal} from "./new_sheet_form";
 import {DropdownActionMenu} from "./dropdown_actions_menu";
@@ -1031,6 +1031,7 @@ export class GearSetViewer extends HTMLElement {
             const headingLink = document.createElement('a');
             const hash = getCurrentHash();
             const linkUrl = makeUrl(...hash.slice(1));
+            linkUrl.searchParams.delete(ONLY_SET_QUERY_PARAM);
             headingLink.href = linkUrl.toString();
             headingLink.target = '_blank';
             headingLink.replaceChildren(this.gearSet.name, faIcon('fa-arrow-up-right-from-square', 'fa'));
@@ -1442,7 +1443,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
                     const set = new CharacterGearSet(this);
                     set.name = 'Separator';
                     set.isSeparator = true;
-                    this.addGearSet(set);
+                    this.addGearSet(set, undefined, true);
                 },
             });
             // const renameButton = makeActionButton("Sheet Name/Description", () => {

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -49,7 +49,7 @@ import {
     RaceName,
     STAT_ABBREVIATIONS
 } from "@xivgear/xivmath/xivconstants";
-import {getCurrentHash} from "../nav_hash";
+import {getCurrentHash, getCurrentState} from "../nav_hash";
 import {MateriaTotalsDisplay} from "./materia";
 import {FoodItemsTable, FoodItemViewTable, GearItemsTable, GearItemsViewTable} from "./items";
 import {SetViewToolbar} from "./totals_display";
@@ -71,7 +71,7 @@ import {simpleAutoResultTable} from "../sims/components/simple_tables";
 import {rangeInc} from "@xivgear/core/util/array_utils";
 import {SimCurrentResult, SimResult, SimSettings, SimSpec, Simulation} from "@xivgear/core/sims/sim_types";
 import {getRegisteredSimSpecs} from "@xivgear/core/sims/sim_registry";
-import {makeUrl, ONLY_SET_QUERY_PARAM} from "@xivgear/core/nav/common_nav";
+import {makeUrl, makeUrlSimple, NavState, ONLY_SET_QUERY_PARAM} from "@xivgear/core/nav/common_nav";
 import {simMaintainersInfoElement} from "./sims";
 import {SaveAsModal} from "./new_sheet_form";
 import {DropdownActionMenu} from "./dropdown_actions_menu";
@@ -1030,7 +1030,7 @@ export class GearSetViewer extends HTMLElement {
         if (this.sheet.isEmbed) {
             const headingLink = document.createElement('a');
             const hash = getCurrentHash();
-            const linkUrl = makeUrl(...hash.slice(1));
+            const linkUrl = makeUrl(new NavState(hash.slice(1), undefined, getCurrentState().onlySetIndex));
             linkUrl.searchParams.delete(ONLY_SET_QUERY_PARAM);
             headingLink.href = linkUrl.toString();
             headingLink.target = '_blank';
@@ -1254,6 +1254,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
     private readonly _loadingScreen: LoadingBlocker;
     private _gearEditToolBar: GearEditToolbar;
     private _selectFirstRowByDefault: boolean = false;
+    private _defaultSelectionIndex: number | undefined = undefined;
     readonly headerArea: HTMLDivElement;
     readonly tableArea: HTMLDivElement;
     readonly tableHolderOuter: HTMLDivElement;
@@ -1335,6 +1336,14 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
     setSelectFirstRowByDefault() {
         this._selectFirstRowByDefault = true;
+    }
+
+    get defaultSelectionIndex(): number | undefined {
+        return this._defaultSelectionIndex;
+    }
+
+    set defaultSelectionIndex(value: number | undefined) {
+        this._defaultSelectionIndex = value;
     }
 
     private get editorItem() {
@@ -1739,7 +1748,16 @@ export class GearPlanSheetGui extends GearPlanSheet {
             document.addEventListener('pointerup', after);
         });
 
-        if (this._selectFirstRowByDefault && this.sets.length >= 1) {
+        if (this._defaultSelectionIndex !== undefined) {
+            const characterGearSet = this.sets[this._defaultSelectionIndex];
+            if (characterGearSet) {
+                this._gearPlanTable.selectGearSet(characterGearSet);
+            }
+            else {
+                console.error("Invalid selection index", this._defaultSelectionIndex);
+            }
+        }
+        else if (this._selectFirstRowByDefault && this.sets.length >= 1) {
             // First, try to select a real gear set
             const firstNonSeparator = this.sets.find(set => !set.isSeparator);
             // Failing that, just select whatever

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -25,7 +25,6 @@ import {
     showNewSheetForm,
     showSheetPickerMenu
 } from "./base_ui";
-import {arrayEq} from "@xivgear/core/util/array_utils";
 
 // let expectedHash: string[] | undefined = undefined;
 
@@ -59,9 +58,12 @@ export async function processHashLegacy() {
         // This path allows certain things such as /viewset/<json> to continue to use the old-style hash, since the
         // URL query param method causes the whole thing to be too long of a URL for the server to handle.
         if (split[0] === NO_REDIR_HASH) {
-            await doNav(state);
+            // The actual list is prefixed with the NO_REDIR_HASH, indicating that it should be stripped and not redirected.
+            const trueState = new NavState(split.splice(1), undefined, undefined);
+            await doNav(trueState);
         }
         else {
+            // Otherwise, redirect to a new-style hash
             goPath(...split);
             location.hash = "";
         }

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -1,10 +1,13 @@
 import {
     HASH_QUERY_PARAM,
-    NO_REDIR_HASH, ONLY_SET_QUERY_PARAM,
+    NavState,
+    NO_REDIR_HASH,
+    ONLY_SET_QUERY_PARAM,
     parsePath,
-    PATH_SEPARATOR,
+    PATH_SEPARATOR, SELECTION_INDEX_QUERY_PARAM,
     splitHashLegacy,
-    splitPath, tryParseOptionalIntParam
+    splitPath,
+    tryParseOptionalIntParam
 } from "@xivgear/core/nav/common_nav";
 import {displayEmbedError, earlyEmbedInit} from "./embed";
 import {SetExport, SheetExport} from "@xivgear/xivmath/geartypes";
@@ -18,22 +21,29 @@ import {
     openSheetByKey,
     setMainContent,
     showImportSheetForm,
-    showLoadingScreen, showNewSheetForm,
+    showLoadingScreen,
+    showNewSheetForm,
     showSheetPickerMenu
 } from "./base_ui";
 import {arrayEq} from "@xivgear/core/util/array_utils";
-import * as os from "node:os";
 
-let expectedHash: string[] | undefined = undefined;
+// let expectedHash: string[] | undefined = undefined;
+
+
+let expectedState: NavState = new NavState(["$$$UNINITIALIZED$$$"], undefined, undefined);
 
 let embed = false;
 
 
-/**
- * Get the current page path
- */
 export function getCurrentHash() {
-    return [...expectedHash];
+    return expectedState.path;
+}
+
+/**
+ * Get the current navigation state, or undefined if it has not been processed yet.
+ */
+export function getCurrentState(): NavState {
+    return expectedState;
 }
 
 /**
@@ -42,27 +52,28 @@ export function getCurrentHash() {
 export async function processHashLegacy() {
     const newHash = location.hash;
     const split = splitHashLegacy(newHash);
-    formatTopMenu(split);
+    const state = new NavState(split, undefined, undefined);
+    formatTopMenu(state);
     if (split.length > 0) {
         console.log('processHashLegacy', newHash);
         // This path allows certain things such as /viewset/<json> to continue to use the old-style hash, since the
         // URL query param method causes the whole thing to be too long of a URL for the server to handle.
         if (split[0] === NO_REDIR_HASH) {
-            await doNav(split.slice(1), undefined);
+            await doNav(state);
         }
         else {
-            goHash(...split);
+            goPath(...split);
             location.hash = "";
         }
     }
 }
 
 /**
- * Process a potential change in hash.
+ * Process a potential change in navigation state.
  *
  * Note that unlike the old hash-based method, there is no catch-all listener for hash changes. Rather, anything
- * wishing to change the hash should use {@link goHash} to have the navigation automatically performed (if the
- * entire desired state can be determined from the path alone), or {@link setHash} if you wish to set the location
+ * wishing to change the hash should use {@link goPath} to have the navigation automatically performed (if the
+ * entire desired state can be determined from the path alone), or {@link setPath} if you wish to set the location
  * but manually replace the page contents.
  */
 export async function processNav() {
@@ -71,24 +82,26 @@ export async function processNav() {
     const qp = getQueryParams();
     const path = qp.get(HASH_QUERY_PARAM) ?? '';
     const osIndex = tryParseOptionalIntParam(qp.get(ONLY_SET_QUERY_PARAM));
+    const selIndex = tryParseOptionalIntParam(qp.get(SELECTION_INDEX_QUERY_PARAM));
     const pathParts = splitPath(path);
-    formatTopMenu(pathParts);
-    console.info("processQuery", pathParts, osIndex);
+    const newNav = new NavState(pathParts, osIndex, selIndex);
+    formatTopMenu(newNav);
+    console.info("processQuery", newNav);
     if (pathParts.length > 0) {
         hideWelcomeArea();
     }
-    if (arrayEq(pathParts, expectedHash)) {
-        console.info("Ignoring internal query change");
+    if (expectedState.isEqual(newNav)) {
+        console.info("Ignoring internal nav change");
         return;
     }
-    expectedHash = pathParts;
-    await doNav(pathParts, osIndex);
+    expectedState = newNav;
+    await doNav(newNav);
 }
 
-async function doNav(pathParts: string[], onlySetIndex: number | undefined) {
-    const nav = parsePath(pathParts, onlySetIndex);
+async function doNav(navState: NavState) {
+    const nav = parsePath(navState);
     if (nav === null) {
-        console.error('unknown nav', pathParts);
+        console.error('unknown nav', navState);
         showSheetPickerMenu();
         return;
     }
@@ -122,7 +135,7 @@ async function doNav(pathParts: string[], onlySetIndex: number | undefined) {
             const resolved: string | null = await getShortLink(uuid);
             if (resolved) {
                 const json = JSON.parse(resolved);
-                openExport(json, false, true, onlySetIndex);
+                openExport(json, false, true, nav.onlySetIndex, nav.defaultSelectionIndex);
                 return;
             }
             else {
@@ -135,10 +148,10 @@ async function doNav(pathParts: string[], onlySetIndex: number | undefined) {
             break;
         }
         case "setjson":
-            openExport(nav.jsonBlob as SetExport, false, nav.viewOnly, onlySetIndex);
+            openExport(nav.jsonBlob as SetExport, false, nav.viewOnly, undefined, undefined);
             return;
         case "sheetjson":
-            openExport(nav.jsonBlob as SheetExport, false, nav.viewOnly, onlySetIndex);
+            openExport(nav.jsonBlob as SheetExport, false, nav.viewOnly, undefined, undefined);
             return;
         case "bis": {
             showLoadingScreen();
@@ -146,7 +159,7 @@ async function doNav(pathParts: string[], onlySetIndex: number | undefined) {
                 const resolved: string | null = await getBisSheet(nav.job, nav.expac, nav.sheet);
                 if (resolved) {
                     const json = JSON.parse(resolved);
-                    openExport(json, false, true, onlySetIndex);
+                    openExport(json, false, true, nav.onlySetIndex, nav.defaultSelectionIndex);
                     return;
                 }
                 else {
@@ -162,7 +175,7 @@ async function doNav(pathParts: string[], onlySetIndex: number | undefined) {
             return;
         }
     }
-    console.error("I don't know what to do with this path", pathParts);
+    console.error("I don't know what to do with this path", navState);
     // TODO: handle remaining invalid cases
 }
 
@@ -180,6 +193,10 @@ function manipulateUrlParams(action: (params: URLSearchParams) => void) {
     }
 }
 
+export function setPath(...pathParts: string[]) {
+    setNav(new NavState(pathParts, undefined, undefined));
+}
+
 /**
  * Change the path of the current URL. Does not perform the actual navigation (i.e. the page contents will not be
  * changed). This will, however, update the state of the top menu - that is, if you navigate to the 'new sheet' page,
@@ -189,30 +206,31 @@ function manipulateUrlParams(action: (params: URLSearchParams) => void) {
  * for some paths. For example, when importing a sheet, the 'imported' path does not contain the actual sheet data
  * nor anything that would lead to it, so it must use this method.
  *
- * @param hashParts The path parts, e.g. for 'foo|bar', use ['foo', 'bar'] as the argument.
+ * @param newState The new navigation state to assume.
  */
-export function setHash(...hashParts: string[]) {
+export function setNav(newState: NavState) {
+    const hashParts = newState.path;
     for (const hashPart of hashParts) {
         if (hashPart === undefined) {
             console.error(new Error("Undefined url hash part!"), hashParts);
             return;
         }
     }
-    expectedHash = [...hashParts];
+    expectedState = newState;
     console.log("New hash parts", hashParts);
     const hash = hashParts.map(part => encodeURIComponent(part)).join(PATH_SEPARATOR);
     // location.hash = '#' + hashParts.map(part => '/' + encodeURIComponent(part)).join('');
     // console.log(location.hash);
     manipulateUrlParams(params => params.set(HASH_QUERY_PARAM, hash));
     // TODO: there are redundant calls to this
-    formatTopMenu(expectedHash);
+    formatTopMenu(newState);
     if (hashParts.length > 0) {
         hideWelcomeArea();
     }
 }
 
 export function getHash(): string[] | undefined {
-    return expectedHash;
+    return getCurrentState().path;
 }
 
 /**
@@ -225,15 +243,19 @@ export function getHash(): string[] | undefined {
  *
  * @param hashParts The path parts, e.g. for 'foo|bar', use ['foo', 'bar'] as the argument.
  */
-export function goHash(...hashParts: string[]) {
+export function goPath(...hashParts: string[]) {
     for (const hashPart of hashParts) {
         if (hashPart === undefined) {
             console.error(new Error("Undefined url hash part!"), hashParts);
             return;
         }
     }
-    const hash = hashParts.map(part => encodeURIComponent(part)).join(PATH_SEPARATOR);
-    manipulateUrlParams(params => params.set(HASH_QUERY_PARAM, hash));
+    goNav(new NavState(hashParts, undefined, undefined));
+}
+
+export function goNav(nav: NavState) {
+    const encodedPath = nav.encodedPath;
+    manipulateUrlParams(params => params.set(HASH_QUERY_PARAM, encodedPath));
     processNav();
 }
 

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -4,7 +4,8 @@ import {
     NO_REDIR_HASH,
     ONLY_SET_QUERY_PARAM,
     parsePath,
-    PATH_SEPARATOR, SELECTION_INDEX_QUERY_PARAM,
+    PATH_SEPARATOR,
+    SELECTION_INDEX_QUERY_PARAM,
     splitHashLegacy,
     splitPath,
     tryParseOptionalIntParam
@@ -257,7 +258,11 @@ export function goPath(...hashParts: string[]) {
 
 export function goNav(nav: NavState) {
     const encodedPath = nav.encodedPath;
-    manipulateUrlParams(params => params.set(HASH_QUERY_PARAM, encodedPath));
+    manipulateUrlParams(params => {
+        params.set(HASH_QUERY_PARAM, encodedPath);
+        params.set(ONLY_SET_QUERY_PARAM, nav.onlySetIndex.toString());
+        params.set(SELECTION_INDEX_QUERY_PARAM, nav.selectIndex.toString());
+    });
     processNav();
 }
 

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -260,8 +260,8 @@ export function goNav(nav: NavState) {
     const encodedPath = nav.encodedPath;
     manipulateUrlParams(params => {
         params.set(HASH_QUERY_PARAM, encodedPath);
-        params.set(ONLY_SET_QUERY_PARAM, nav.onlySetIndex.toString());
-        params.set(SELECTION_INDEX_QUERY_PARAM, nav.selectIndex.toString());
+        params.set(ONLY_SET_QUERY_PARAM, nav.onlySetIndex?.toString());
+        params.set(SELECTION_INDEX_QUERY_PARAM, nav.selectIndex?.toString());
     });
     processNav();
 }


### PR DESCRIPTION
Allows for full sheets to be filtered to a single set and opened as if they were a single set export. This will have some other benefits, like allowing the pop-out link on embedded sets to link back to a full sheet.

- [X] Implement onlySetIndex URL parameter on client side to allow it to pre-filter a full sheet down to a single set.
- [x] Implement onlySetIndex URL parameter on server side so that social media previews will reflect the set, rather than the sheet
- [x] Implement another URL parameter to allow for pre-selecting a specific sheet index.
- [x] Test that this also works as expected with BiS links
- [x] Update tests accordingly

Closes #442 