### PR TITLE
Correct Riddle auto timing in a hacky way

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -204,7 +204,13 @@ export const RiddleOfWindBuff: PersonalBuff = {
     statusId: 2687,
     appliesTo: (ability) => ability.attackType === 'Auto-attack',
     effects: {
-        haste: 50,
+        /**
+         * Riddle of Wind is actually a 50% increase type-Y speed buff. But until gear-planner supports type-Y and
+         * type-Z speed buffs separately (this only affects Monk auto attacks currently) the actual recast time
+         * of autos can be simulated by pretending it's a 40% type-Z speed buff.
+         * The correct in game auto timing is 1.024 between autos.
+         */
+        haste: 40,
     },
 };
 export const FiresRumination: PersonalBuff = {


### PR DESCRIPTION
While talking with Hint, she expressed that it would be desirable to fix RoW auto timing no matter how, as inaccurate auto timing would favor higher SkS gearsets due to auto scaling.

This fix is mathematically valid, but obviously needs to be documented in case changes to haste calculations are done in the future.

`2.56 * (100 - 40 - 20) / 100 == 1.024`