### PR TITLE
Give toolbar drag indicators a tiny bit of breathing room

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1689,7 +1689,7 @@ div.gear-sheet-toolbar-holder {
     top: 0;
     bottom: 0;
     height: fit-content;
-    margin: auto 1px auto 1px;
+    margin: auto 0.25rem;
   }
 
   &::before {


### PR DESCRIPTION
Before:

<img width="373" alt="image" src="https://github.com/user-attachments/assets/e288aee5-6051-4674-8183-7a118c0f45a4" />

After:

<img width="376" alt="image" src="https://github.com/user-attachments/assets/d6fefd84-97df-427c-8567-e099dd3aa546" />
