### PR TITLE
Improve GNB at 100, add support for 90, 80, 70

### DIFF
--- a/packages/core/src/sims/tank/drk/drk_gauge.ts
+++ b/packages/core/src/sims/tank/drk/drk_gauge.ts
@@ -45,7 +45,6 @@ export class DrkGauge {
 
     getGaugeState(): DrkGaugeState {
         return {
-            level: 100,
             blood: this.bloodGauge,
             mp: this.magicPoints,
             darkArts: this.darkArts,

--- a/packages/core/src/sims/tank/drk/drk_types.ts
+++ b/packages/core/src/sims/tank/drk/drk_types.ts
@@ -33,7 +33,6 @@ export type BloodAbility = DrkAbility & Readonly<{
 
 /** Represents the DRK gauge state */
 export type DrkGaugeState = {
-    level: number,
     blood: number,
     mp: number,
     darkArts: boolean,

--- a/packages/core/src/sims/tank/gnb/gnb_actions.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_actions.ts
@@ -22,7 +22,7 @@ export const KeenEdge: GnbGcdAbility = {
     cast: 0,
     levelModifiers: [
         {
-            minLevel: 94,
+            minLevel: 84,
             potency: 200,
         },
         {
@@ -42,7 +42,7 @@ export const BrutalShell: GnbGcdAbility = {
     cast: 0,
     levelModifiers: [
         {
-            minLevel: 94,
+            minLevel: 84,
             potency: 300,
         },
         {
@@ -63,7 +63,7 @@ export const SolidBarrel: GnbGcdAbility = {
     updateCartridges: (gauge: GnbGauge) => gauge.cartridges += 1,
     levelModifiers: [
         {
-            minLevel: 94,
+            minLevel: 84,
             potency: 360,
         },
         {

--- a/packages/core/src/sims/tank/gnb/gnb_actions.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_actions.ts
@@ -248,7 +248,7 @@ export const DangerZone: GnbOgcdAbility = {
     type: 'ogcd',
     name: "Danger Zone",
     id: 16144,
-    potency: 800,
+    potency: 250,
     attackType: "Ability",
     cooldown: {
         time: 30,

--- a/packages/core/src/sims/tank/gnb/gnb_actions.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_actions.ts
@@ -16,38 +16,68 @@ export const KeenEdge: GnbGcdAbility = {
     type: 'gcd',
     name: "Keen Edge",
     id: 16137,
-    potency: 300,
+    potency: 150,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 200,
+        },
+        {
+            minLevel: 94,
+            potency: 300,
+        },
+    ],
 };
 
 export const BrutalShell: GnbGcdAbility = {
     type: 'gcd',
     name: "Brutal Shell",
     id: 16139,
-    potency: 380,
+    potency: 200,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 300,
+        },
+        {
+            minLevel: 94,
+            potency: 380,
+        },
+    ],
 };
 
 export const SolidBarrel: GnbGcdAbility = {
     type: 'gcd',
     name: "Solid Barrel",
     id: 16145,
-    potency: 460,
+    potency: 320,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
     updateCartridges: (gauge: GnbGauge) => gauge.cartridges += 1,
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 360,
+        },
+        {
+            minLevel: 94,
+            potency: 460,
+        },
+    ],
 };
 
 export const GnashingFang: GnbGcdAbility = {
     type: 'gcd',
     name: "Gnashing Fang",
     id: 16146,
-    potency: 500,
+    potency: 380,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
@@ -59,40 +89,69 @@ export const GnashingFang: GnbGcdAbility = {
         charges: 1,
     },
     updateCartridges: (gauge: GnbGauge) => gauge.cartridges -= 1,
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 500,
+        },
+    ],
 };
 
 export const SavageClaw: GnbGcdAbility = {
     type: 'gcd',
     name: "Savage Claw",
     id: 16147,
-    potency: 560,
+    potency: 460,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
     activatesBuffs: [ReadyToTearBuff],
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 560,
+        },
+    ],
 };
 
 export const WickedTalon: GnbGcdAbility = {
     type: 'gcd',
     name: "Wicked Talon",
     id: 16150,
-    potency: 620,
+    potency: 540,
     attackType: "Weaponskill",
     gcd: 2.5,
     cast: 0,
     activatesBuffs: [ReadyToGougeBuff],
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 620,
+        },
+    ],
 };
 
 export const BurstStrike: GnbGcdAbility = {
     type: 'gcd',
     name: "Burst Strike",
     id: 16162,
-    potency: 460,
+    potency: 380,
     attackType: "Weaponskill",
     gcd: 2.5,
     cartridgeCost: 1,
-    activatesBuffs: [ReadyToBlastBuff],
+    activatesBuffs: [],
     updateCartridges: (gauge: GnbGauge) => gauge.cartridges -= 1,
+    levelModifiers: [
+        {
+            minLevel: 86,
+            activatesBuffs: [ReadyToBlastBuff],
+        },
+        {
+            minLevel: 94,
+            potency: 460,
+            activatesBuffs: [ReadyToBlastBuff],
+        },
+    ],
 };
 
 export const DoubleDown: GnbGcdAbility = {
@@ -175,20 +234,44 @@ export const Bloodfest: GnbOgcdAbility = {
         time: 120,
         charges: 1,
     },
-    activatesBuffs: [ReadyToReignBuff],
-    updateCartridges: (gauge: GnbGauge) => gauge.cartridges += 3,
+    activatesBuffs: [],
+    updateCartridges: (gauge: GnbGauge) => gauge.cartridges += gauge.maxCartridges,
+    levelModifiers: [
+        {
+            minLevel: 100,
+            activatesBuffs: [ReadyToReignBuff],
+        },
+    ],
 };
 
-export const BlastingZone: GnbOgcdAbility = {
+export const DangerZone: GnbOgcdAbility = {
     type: 'ogcd',
-    name: "Blasting Zone",
-    id: 16165,
+    name: "Danger Zone",
+    id: 16144,
     potency: 800,
     attackType: "Ability",
     cooldown: {
         time: 30,
         charges: 1,
     },
+};
+
+export const BlastingZone: GnbOgcdAbility = {
+    type: 'ogcd',
+    name: "Blasting Zone",
+    id: 16165,
+    potency: 720,
+    attackType: "Ability",
+    cooldown: {
+        time: 30,
+        charges: 1,
+    },
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 800,
+        },
+    ],
 };
 
 export const BowShock: GnbOgcdAbility = {
@@ -213,47 +296,71 @@ export const Hypervelocity: GnbOgcdAbility = {
     type: 'ogcd',
     name: "Hypervelocity",
     id: 25759,
-    potency: 200,
+    potency: 160,
     attackType: "Ability",
     cooldown: {
         time: 1,
         charges: 1,
     },
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 200,
+        },
+    ],
 };
 
 export const JugularRip: GnbOgcdAbility = {
     type: 'ogcd',
     name: "Jugular Rip",
     id: 16156,
-    potency: 240,
+    potency: 200,
     attackType: "Ability",
     cooldown: {
         time: 1,
         charges: 1,
     },
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 240,
+        },
+    ],
 };
 
 export const AbdomenTear: GnbOgcdAbility = {
     type: 'ogcd',
     name: "Abdomen Tear",
     id: 16157,
-    potency: 280,
+    potency: 240,
     attackType: "Ability",
     cooldown: {
         time: 1,
         charges: 1,
     },
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 280,
+        },
+    ],
 };
 
 export const EyeGouge: GnbOgcdAbility = {
     type: 'ogcd',
     name: "Eye Gouge",
     id: 16158,
-    potency: 320,
+    potency: 280,
     attackType: "Ability",
     cooldown: {
         time: 1,
         charges: 1,
     },
+    levelModifiers: [
+        {
+            minLevel: 94,
+            potency: 320,
+        },
+    ],
 };
 

--- a/packages/core/src/sims/tank/gnb/gnb_gauge.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_gauge.ts
@@ -1,26 +1,39 @@
 import {GnbGaugeState} from "./gnb_types";
 
 export class GnbGauge {
-
+    private _maxCartridges: number;
     private _cartridges: number = 0;
+
+    constructor(level: number) {
+        if (level >= 88) {
+            this._maxCartridges = 3;
+        }
+        else {
+            this._maxCartridges = 2;
+        }
+    }
 
     get cartridges(): number {
         return this._cartridges;
     }
 
+    get maxCartridges(): number {
+        return this._maxCartridges;
+    }
+
     set cartridges(newGauge: number) {
-        if (newGauge > 3) {
-            console.warn(`[GNB Sim] Overcapped Cartriges by ${newGauge - 3}.`);
+        if (newGauge > this._maxCartridges) {
+            console.warn(`[GNB Sim] Overcapped Cartridges by ${newGauge - this._maxCartridges}.`);
         }
         if (newGauge < 0) {
-            console.warn(`[GNB Sim] Used ${this._cartridges - newGauge} cartriges when you only have ${this._cartridges}.`);
+            console.warn(`[GNB Sim] Used ${this._cartridges - newGauge} cartridges when you only have ${this._cartridges}.`);
         }
-        this._cartridges = Math.max(Math.min(newGauge, 3), 0);
+        this._cartridges = Math.max(Math.min(newGauge, this._maxCartridges), 0);
     }
 
     getGaugeState(): GnbGaugeState {
         return {
-            level: 100,
+            maxCartridges: this.maxCartridges,
             cartridges: this.cartridges,
         };
     }

--- a/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
@@ -469,8 +469,8 @@ export class GnbSim extends BaseMultiCycleSim<GnbSimResult, GnbSettings, GnbCycl
             this.use(cp, Actions.BowShock);
         }
 
-        if (cp.canUseWithoutClipping(Actions.BlastingZone)) {
-            this.use(cp, Actions.BlastingZone);
+        if (cp.canUseWithoutClipping(cp.blastingZoneAbility)) {
+            this.use(cp, cp.blastingZoneAbility);
         }
 
         // We need the cartridge check even though we unload carts before Bloodfest just in case

--- a/packages/core/src/sims/tank/gnb/gnb_types.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_types.ts
@@ -22,7 +22,7 @@ export type CartridgeAbility = GnbAbility & Readonly<{
 
 /** Represents the GNB gauge state */
 export type GnbGaugeState = {
-    level: number,
+    maxCartridges: number,
     cartridges: number,
 }
 

--- a/packages/core/src/sims/tank/pld/pld_sheet_sim.ts
+++ b/packages/core/src/sims/tank/pld/pld_sheet_sim.ts
@@ -124,7 +124,7 @@ class PldCycleProcessor extends CycleProcessor {
         const fof = usedAbility.buffs.find(buff => buff.name === FightOrFlightBuff.name);
         const fofBuffData = fof && this.getActiveBuffData(fof, usedAbility.usedAt);
         if (fofBuffData) {
-            extraData.fightOrFlightDuration = Math.round(fofBuffData.end - usedAbility.usedAt);
+            extraData.fightOrFlightDuration = fofBuffData.end - usedAbility.usedAt;
         }
 
         const requiescat = usedAbility.buffs.find(buff => buff.name === RequiescatBuff.name);

--- a/packages/core/src/sims/tank/war/war_gauge.ts
+++ b/packages/core/src/sims/tank/war/war_gauge.ts
@@ -20,7 +20,6 @@ export class WarGauge {
 
     getGaugeState(): WarGaugeState {
         return {
-            level: 100,
             beastGauge: this.beastGauge,
         };
     }

--- a/packages/core/src/sims/tank/war/war_types.ts
+++ b/packages/core/src/sims/tank/war/war_types.ts
@@ -23,7 +23,6 @@ export type BeastGaugeAbility = WarAbility & Readonly<{
 
 /** Represents the WAR gauge state */
 export type WarGaugeState = {
-    level: number,
     beastGauge: number,
 }
 

--- a/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
@@ -16,6 +16,7 @@ export class GnbSimGui extends BaseMultiCycleSimGui<GnbSimResult, GnbSettings> {
             renderer: (usedAbility?: PreDmgUsedAbility) => {
                 if (usedAbility?.extraData !== undefined) {
                     const cartridges = (usedAbility.extraData as GnbExtraData).gauge.cartridges;
+                    const maxCarts = (usedAbility.extraData as GnbExtraData).gauge.maxCartridges;
 
                     const div = document.createElement('div');
                     div.style.height = '100%';
@@ -28,7 +29,7 @@ export class GnbSimGui extends BaseMultiCycleSimGui<GnbSimResult, GnbSettings> {
                     const span = document.createElement('span');
                     span.textContent = `${cartridges}`;
 
-                    for (let i = 1; i <= 3; i++) {
+                    for (let i = 1; i <= maxCarts; i++) {
                         const stack = document.createElement('span');
                         stack.style.clipPath = `circle()`;
                         stack.style.background = '#00000033';
@@ -68,7 +69,7 @@ export class GnbSimGui extends BaseMultiCycleSimGui<GnbSimResult, GnbSettings> {
                     div.style.boxSizing = 'border-box';
 
                     const span = document.createElement('span');
-                    span.textContent = `${noMercyDuration}s`;
+                    span.textContent = `${noMercyDuration.toFixed(1)}s`;
 
                     const barOuter = document.createElement('div');
                     barOuter.style.borderRadius = '20px';

--- a/packages/frontend/src/scripts/sims/tank/pld_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld_sheet_sim_ui.ts
@@ -18,7 +18,7 @@ export class PldSimGui extends BaseMultiCycleSimGui<PldSimResult, PldSettings> {
                 renderer: (usedAbility?: PreDmgUsedAbility) => {
                     if (usedAbility?.extraData !== undefined) {
                         const fightOrFlightDuration = (usedAbility.extraData as PldExtraData).fightOrFlightDuration;
-                        const out = new GaugeWithText<number>(() => '#B14FAE', v => `${fightOrFlightDuration}s`, v => v / 20 * 100);
+                        const out = new GaugeWithText<number>(() => '#B14FAE', v => `${fightOrFlightDuration.toFixed(1)}s`, v => v / 20 * 100);
                         out.setDataValue(fightOrFlightDuration);
                         out.classList.add('sim-gauge');
                         return out;


### PR DESCRIPTION
This adds some missing optimizations for Gunbreaker, improving the sim at every speed.
including:
- Using Sonic Break earlier if the fight is ending sooner
- Making sure we get Hypervelocities in No Mercy if possible by using Lionheart as our last No Mercy GCD instead of Burst Strike, in places where that's applicable

Before:
![image](https://github.com/user-attachments/assets/032962ba-49ac-4a73-9477-89170da36d81)

After:
![image-1](https://github.com/user-attachments/assets/86bb5d49-7f04-4e88-9583-ac56790fc390)

I also added a decimal point of precision to No Mercy and Fight or Flight.

This also adds support for level 90, 80, and 70 for Gunbreaker.

Level 90, 80, and 70 results (I used slightly lazy fully synced gear and Manderville relic for my own sanity instead of recreating all of the BiS). These use DSR/TEA/UWU scaling respectively.
![image](https://github.com/user-attachments/assets/dd672933-467f-44cb-acc3-23d9fef47a9d)
![image](https://github.com/user-attachments/assets/534dfa63-9365-4e2c-8039-e9a817f3649b)
![image](https://github.com/user-attachments/assets/90d022dc-43c3-4fa4-bd2f-e74bc71d6626)


It also only shows two cartridges in the UI when you only have two carts, e.g. this is level 80:
![image](https://github.com/user-attachments/assets/d7c4993c-f325-401f-af17-1cf5ce391ea0)
