### PR TITLE
Make role bonus for new sheets 5 default (or 1 for BLU)

### DIFF
--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -98,7 +98,7 @@ export class SheetProvider<SheetType extends GearPlanSheet> {
             job: classJob,
             level: level,
             name: sheetName,
-            partyBonus: 0,
+            partyBonus: classJob === 'BLU' ? 1 : 5,
             race: undefined,
             saveKey: sheetKey,
             sets: [{

--- a/packages/core/src/test/export_import_tests.ts
+++ b/packages/core/src/test/export_import_tests.ts
@@ -94,7 +94,7 @@ describe('importing and exporting', () => {
 
             // Does not keep these
             expect(newSheet.race).to.equal(undefined);
-            expect(newSheet.partyBonus).to.equal(0);
+            expect(newSheet.partyBonus).to.equal(5);
             // Should come from set name
             expect(newSheet.sheetName).to.equal('Foo2');
 


### PR DESCRIPTION
Makes the default role bonus 5 for non-BLU jobs and 1 for BLU, to better be a (in my opinion) better and more expected default.