### PR TITLE
Implement more compact table view for narrow screens

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -875,11 +875,20 @@ table.gear-plan-table {
     --chance-stat-col-width: 40px;
     --multi-stat-col-width: 40px;
     --multi-mit-stat-col-width: 40px;
+    @media screen and (max-width: 800px) {
+      .stat-col-less-important {
+        display: none;
+      }
+    }
 
     &.show-advanced-stats {
       --chance-stat-col-width: 110px;
       --multi-stat-col-width: 70px;
       --multi-mit-stat-col-width: 130px;
+
+      .stat-col-less-important {
+        display: revert;
+      }
 
       .extra-stat-info {
         display: unset !important;
@@ -1107,7 +1116,6 @@ gear-plan {
     // I hate css
     margin-right: -60px;
     width: min(100%, 100vw);
-    pointer-events: none;
     background-color: color-mix(in srgb, var(--bg-color) 80%, transparent);
 
     border-top: var(--standard-border);

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -103,7 +103,7 @@ function mainStatCol(sheet: GearPlanSheet, stat: RawStatKey): CustomColumnSpec<C
         }),
         condition: () => sheet.isStatRelevant(stat),
         renderer: multiplierStatTooltip,
-        extraClasses: ['stat-col', 'main-stat-col'],
+        extraClasses: ['stat-col', 'main-stat-col', 'stat-col-less-important'],
         rowCondition: noSeparators,
     };
 }
@@ -118,7 +118,7 @@ function tooltipMultiStatCol(sheet: GearPlanSheet, stat: RawStatKey, multiKey: {
         }),
         condition: () => sheet.isStatRelevant(stat),
         renderer: multiplierStatTooltip,
-        extraClasses: ['stat-col', 'compact-multiplier-stat-col'],
+        extraClasses: ['stat-col', 'compact-multiplier-stat-col', 'stat-col-less-important'],
         rowCondition: noSeparators,
     };
 }
@@ -489,14 +489,14 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
                 }),
                 initialWidth: statColWidth,
                 renderer: multiplierStatTooltip,
-                extraClasses: ['stat-col'],
+                extraClasses: ['stat-col', 'stat-col-less-important'],
                 rowCondition: noSeparators,
             } as CustomColumnSpec<CharacterGearSet, MultiplierStat>,
             {
                 shortName: "hp",
                 displayName: "HP",
                 getter: gearSet => gearSet.computedStats.hp,
-                extraClasses: ['stat-col', 'stat-col-hp'],
+                extraClasses: ['stat-col', 'stat-col-hp', 'stat-col-less-important'],
                 rowCondition: noSeparators,
             },
             {
@@ -523,7 +523,7 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
                 }) as ChanceStat,
                 renderer: chanceStatDisplay,
                 condition: () => this.sheet.isStatRelevant('crit'),
-                extraClasses: ['stat-col', 'chance-stat-col'],
+                extraClasses: ['stat-col', 'chance-stat-col', 'stat-col-less-important'],
                 rowCondition: noSeparators,
             },
             {
@@ -536,7 +536,7 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
                 }) as ChanceStat,
                 renderer: chanceStatDisplay,
                 condition: () => this.sheet.isStatRelevant('dhit'),
-                extraClasses: ['stat-col', 'chance-stat-col'],
+                extraClasses: ['stat-col', 'chance-stat-col', 'stat-col-less-important'],
                 rowCondition: noSeparators,
             },
             {
@@ -548,7 +548,7 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
                 }) as MultiplierStat,
                 renderer: multiplierStatDisplay,
                 condition: () => this.sheet.isStatRelevant('determination'),
-                extraClasses: ['stat-col', 'multiplier-stat-col'],
+                extraClasses: ['stat-col', 'multiplier-stat-col', 'stat-col-less-important'],
                 rowCondition: noSeparators,
             },
             {
@@ -568,6 +568,7 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
                 initialWidth: statColWidth,
                 condition: () => this.sheet.isStatRelevant('piety'),
                 rowCondition: noSeparators,
+                extraClasses: ['stat-col-less-important'],
             },
             {
                 shortName: "tenacity",
@@ -579,7 +580,7 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, GearSetSel> {
                 }) as MultiplierMitStat,
                 renderer: multiplierMitStatDisplay,
                 condition: () => this.sheet.isStatRelevant('tenacity'),
-                extraClasses: ['stat-col', 'multiplier-mit-stat-col'],
+                extraClasses: ['stat-col', 'multiplier-mit-stat-col', 'stat-col-less-important'],
                 rowCondition: noSeparators,
             },
             ...(viewOnly ? [] : simColumns),


### PR DESCRIPTION
If width <= 800px, only the name/description, sims, and GCD(s) will be shown by default:

![image](https://github.com/user-attachments/assets/96e37ea7-673c-47df-b113-b19eff4e2f44)

"Toggle Details" will still show all the columns:

![image](https://github.com/user-attachments/assets/12d517ca-9ac9-4f24-bf32-0619f6a7a818)

Also fixes a bug due to a leftover from an older version of the UI where you could hover/click through the semi-transparent backgrop of the buttons.