### PR TITLE
Improve /fulldata/ endpoint

### DIFF
--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -149,15 +149,38 @@ export function buildStatsServer() {
     });
 
     fastifyInstance.get('/fulldata/:uuid', async (request: FastifyRequest, reply) => {
+        const osIndex: number | undefined = tryParseOptionalIntParam(request.query[ONLY_SET_QUERY_PARAM]);
+        const selIndex: number | undefined = tryParseOptionalIntParam(request.query[SELECTION_INDEX_QUERY_PARAM]);
+        const nav: NavPath = {
+            type: 'shortlink',
+            uuid: request.params['uuid'],
+            onlySetIndex: osIndex,
+            defaultSelectionIndex: selIndex,
+            embed: false,
+            viewOnly: true,
+        };
         const rawData = await getShortLink(request.params['uuid'] as string);
-        const out = await importExportSheet(request, JSON.parse(rawData));
+        const out = await importExportSheet(request, JSON.parse(rawData), nav);
         reply.header("cache-control", "max-age=7200, public");
         reply.send(out);
     });
 
     fastifyInstance.get('/fulldata/bis/:job/:expac/:sheet', async (request: FastifyRequest, reply) => {
+        const osIndex: number | undefined = tryParseOptionalIntParam(request.query[ONLY_SET_QUERY_PARAM]);
+        const selIndex: number | undefined = tryParseOptionalIntParam(request.query[SELECTION_INDEX_QUERY_PARAM]);
+        const nav: NavPath = {
+            type: 'bis',
+            job: request.params['job'],
+            expac: request.params['expac'],
+            sheet: request.params['sheet'],
+            path: [request.params['job'], request.params['expac'], request.params['sheet']],
+            onlySetIndex: osIndex,
+            defaultSelectionIndex: selIndex,
+            embed: false,
+            viewOnly: true,
+        };
         const rawData = await getBisSheet(request.params['job'] as JobName, request.params['expac'] as string, request.params['sheet'] as string);
-        const out = await importExportSheet(request, JSON.parse(rawData));
+        const out = await importExportSheet(request, JSON.parse(rawData), nav);
         reply.header("cache-control", "max-age=7200, public");
         reply.send(out);
     });

--- a/packages/backend-resolver/src/test/test_endpoints.ts
+++ b/packages/backend-resolver/src/test/test_endpoints.ts
@@ -17,6 +17,7 @@ function readPreviewProps(document: Document): Record<string, string> {
     return out;
 }
 
+// TODO: add tests for nonexistent UUIDs and other error cases
 describe("backend servers", () => {
     describe("set fulldata endpoint", () => {
         const fastify = buildStatsServer();

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -79,6 +79,7 @@ export type NavPath = {
     jsonBlob: object
 } | {
     type: 'bis',
+    // TODO: is this being used anywhere?
     path: string[],
     job: JobName,
     expac: string,


### PR DESCRIPTION
Adds onlySetIndex support, and also allows you to call `/fulldata/?page=xyz` with the exact same paths as you would on the client side to make the endpoint easier to use.