### PR TITLE
Set size of the worker pool based on number of logical processors available

### DIFF
--- a/packages/frontend/src/scripts/workers/worker_pool.ts
+++ b/packages/frontend/src/scripts/workers/worker_pool.ts
@@ -231,6 +231,8 @@ export class WorkerPool {
     }
 }
 
-// TODO: pool size
-// Going too high seemed to slow it down even on a system with more than enough cores
-export const workerPool: WorkerPool = new WorkerPool(4);
+// set maxWorkers to the number of logical processors - 1 (minimum of 1)
+// defaults to 3 on browsers that don't support hardwareConcurrency (widely supported)
+// some browsers (e.g. Safari, Brave) clamp or randomize hardwareConcurrency to prevent device fingerprinting
+const maxWorkers = Math.max((navigator.hardwareConcurrency || 4) - 1, 1);
+export const workerPool: WorkerPool = new WorkerPool(maxWorkers);

--- a/packages/frontend/src/scripts/workers/worker_pool.ts
+++ b/packages/frontend/src/scripts/workers/worker_pool.ts
@@ -231,8 +231,8 @@ export class WorkerPool {
     }
 }
 
-// set maxWorkers to the number of logical processors - 1 (minimum of 1)
-// defaults to 3 on browsers that don't support hardwareConcurrency (widely supported)
+// set maxWorkers to the number of logical processors (minimum 4)
+// defaults to 4 on browsers that don't support hardwareConcurrency (widely supported)
 // some browsers (e.g. Safari, Brave) clamp or randomize hardwareConcurrency to prevent device fingerprinting
-const maxWorkers = Math.max((navigator.hardwareConcurrency || 4) - 1, 1);
+const maxWorkers = Math.max((navigator.hardwareConcurrency || 4), 4);
 export const workerPool: WorkerPool = new WorkerPool(maxWorkers);


### PR DESCRIPTION
Improves meld solving speed on systems with > 4 cores (previous fixed worker pool size).

As an aside: Mocha is already pulling in [workerpool](https://www.npmjs.com/package/workerpool) as a dependency; it might have made more sense to use that instead of rolling our own implementation.