### PR TITLE
Refactor meld solver workers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -28,6 +28,7 @@ export default [
             "@typescript-eslint/no-unused-vars": [
                 "warn",
                 {
+                    "varsIgnorePattern": "^_$",
                     "args": "none",
                     "caughtErrors": "none"
                 }

--- a/packages/common-ui/src/components/util.ts
+++ b/packages/common-ui/src/components/util.ts
@@ -371,6 +371,27 @@ export class FieldBoundIntField<ObjType> extends FieldBoundConvertingTextField<O
     }
 }
 
+export class FieldBoundOrUndefIntField<ObjType> extends FieldBoundConvertingTextField<ObjType, number | undefined> {
+    constructor(obj: ObjType, field: { [K in keyof ObjType]: ObjType[K] extends (number | undefined) ? K : never }[keyof ObjType], extraArgs: FbctArgs<ObjType, number | undefined> = {}) {
+        const intValidator = (ctx) => {
+            if (ctx.newValue !== undefined && ctx.newValue % 1 !== 0) {
+                ctx.failValidation('Value must be an integer');
+            }
+        };
+        extraArgs.preValidators = [skipMinus, ...(extraArgs.preValidators ?? [])];
+        extraArgs.postValidators = [intValidator, ...(extraArgs.postValidators ?? [])];
+        // Spinner arrows aren't styleable. Love CSS!
+        // extraArgs.type = extraArgs.type ?? 'number';
+        // extraArgs.inputMode = extraArgs.inputMode ?? 'numeric';
+        super(obj, field, (s) => s === undefined ? "" : s.toString(), (s) => s.trim() === "" ? undefined : Number(s), extraArgs);
+        if (this.type === 'numeric') {
+            if (!this.step) {
+                this.step = '1';
+            }
+        }
+    }
+}
+
 export class FieldBoundFloatField<ObjType> extends FieldBoundConvertingTextField<ObjType, number> {
     constructor(obj: ObjType, field: { [K in keyof ObjType]: ObjType[K] extends number ? K : never }[keyof ObjType], extraArgs: FieldBoundFloatFieldFbctArgs<ObjType, number> = {}) {
         const numberValidator = (ctx) => {
@@ -642,6 +663,7 @@ customElements.define("data-select", DataSelect, {extends: "select"});
 customElements.define("field-bound-converting-text-field", FieldBoundConvertingTextField, {extends: "input"});
 customElements.define("field-bound-text-field", FieldBoundTextField, {extends: "input"});
 customElements.define("field-bound-float-field", FieldBoundFloatField, {extends: "input"});
+customElements.define("field-bound-int-or-undef-field", FieldBoundOrUndefIntField, {extends: "input"});
 customElements.define("field-bound-int-field", FieldBoundIntField, {extends: "input"});
 customElements.define("field-bound-checkbox", FieldBoundCheckBox, {extends: "input"});
 customElements.define("field-bound-data-select", FieldBoundDataSelect, {extends: "select"});

--- a/packages/common-ui/src/settings/persistent_settings.ts
+++ b/packages/common-ui/src/settings/persistent_settings.ts
@@ -10,6 +10,7 @@ export type PersistentSettings = {
     set viewDetailedStats(detailedStats: boolean);
     get languageOverride(): Language | undefined;
     set languageOverride(value: Language);
+    workersOverride: number | undefined;
     hideWelcomeMessage: boolean;
 }
 
@@ -18,6 +19,7 @@ const MODERN_THEME_KEY = 'modern-theme';
 const DETAILED_STATS_KEY = 'detailed-stats';
 const HIDE_WELCOME_KEY = 'hide-welcome-area';
 const LANGUAGE_OVERRIDE_KEY = 'language-override';
+const WORKERS_OVERRIDE_KEY = 'workers-override';
 export const SETTINGS: PersistentSettings = {
     get lightMode(): boolean | undefined {
         return getBool(LIGHT_MODE_KEY);
@@ -60,7 +62,18 @@ export const SETTINGS: PersistentSettings = {
             localStorage.removeItem(LANGUAGE_OVERRIDE_KEY);
         }
     },
+    get workersOverride(): number | undefined {
+        return getInt(WORKERS_OVERRIDE_KEY);
+    },
+    set workersOverride(value: number | undefined) {
+        if (value < 2) {
+            throw new Error("Value must be an integer >= 2");
+        }
+        setInt(WORKERS_OVERRIDE_KEY, value);
+    },
 };
+
+window['xivgearSettings'] = SETTINGS;
 
 function getBool(key: string): boolean | undefined {
     const raw = localStorage.getItem(key);
@@ -74,4 +87,24 @@ function getBool(key: string): boolean | undefined {
 
 function setBool(key: string, value: boolean) {
     localStorage.setItem(key, String(value));
+}
+
+function getInt(key: string): number | undefined {
+    const raw = localStorage.getItem(key);
+    if (raw === undefined || raw === null) {
+        return undefined;
+    }
+    return parseInt(raw, 10);
+}
+
+function setInt(key: string, value: number | undefined) {
+    if (value === undefined) {
+        localStorage.removeItem(key);
+    }
+    else {
+        if (Math.floor(value) !== value) {
+            throw new Error(`Not an integer: ${value} (${key})`);
+        }
+        localStorage.setItem(key, value.toString());
+    }
 }

--- a/packages/common-ui/src/settings/settings_modal.ts
+++ b/packages/common-ui/src/settings/settings_modal.ts
@@ -3,7 +3,7 @@ import {
     clampValues,
     FieldBoundCheckBox,
     FieldBoundDataSelect,
-    FieldBoundIntField, FieldBoundOrUndefIntField,
+    FieldBoundOrUndefIntField,
     labelFor,
     quickElement
 } from "@xivgear/common-ui/components/util";

--- a/packages/common-ui/src/settings/settings_modal.ts
+++ b/packages/common-ui/src/settings/settings_modal.ts
@@ -1,28 +1,42 @@
 import {BaseModal} from "@xivgear/common-ui/components/modal";
-import {FieldBoundCheckBox, FieldBoundDataSelect, labelFor} from "@xivgear/common-ui/components/util";
+import {
+    clampValues,
+    FieldBoundCheckBox,
+    FieldBoundDataSelect,
+    FieldBoundIntField, FieldBoundOrUndefIntField,
+    labelFor,
+    quickElement
+} from "@xivgear/common-ui/components/util";
 import {DISPLAY_SETTINGS} from "./display_settings";
 import {BoolToggle} from "@xivgear/common-ui/components/bool_toggle";
 import {recordEvent} from "@xivgear/core/analytics/analytics";
 import {ALL_LANGS, LangaugeDisplayName, Language} from "@xivgear/core/i18n/translation";
+import {SETTINGS} from "./persistent_settings";
 
 
 class SettingsModal extends BaseModal {
+
+    private readonly refreshLabel = quickElement('span', [], ['Refresh to apply settings']);
+
     constructor() {
         super();
         this.headerText = 'Settings';
+        this.setDisplayRefreshLabel(false);
 
-        const settings = DISPLAY_SETTINGS;
-        const lightModeCb = new FieldBoundCheckBox(settings, 'lightMode');
+        // const displaySettingsHeader = quickElement('h3', [], ['Theme']);
+        // this.contentArea.append(displaySettingsHeader);
+        const displaySettings = DISPLAY_SETTINGS;
+        const lightModeCb = new FieldBoundCheckBox(displaySettings, 'lightMode');
         const lightModeToggle = new BoolToggle(lightModeCb, 'Light', 'Dark');
         lightModeCb.addListener(val => recordEvent('lightModeToggle', {lightMode: val}));
         this.contentArea.append(lightModeToggle);
 
-        const modernThemeCb = new FieldBoundCheckBox(settings, 'modernTheme');
+        const modernThemeCb = new FieldBoundCheckBox(displaySettings, 'modernTheme');
         const modernThemeToggle = new BoolToggle(modernThemeCb, 'Modern', 'Classic');
         modernThemeCb.addListener(val => recordEvent('modernTheme', {modernTheme: val}));
         this.contentArea.append(modernThemeToggle);
 
-        const langDropdown = new FieldBoundDataSelect<typeof settings, Language | undefined>(settings, 'languageOverride', val => {
+        const langDropdown = new FieldBoundDataSelect<typeof displaySettings, Language | undefined>(displaySettings, 'languageOverride', val => {
             if (val) {
                 return LangaugeDisplayName[val];
             }
@@ -31,15 +45,37 @@ class SettingsModal extends BaseModal {
             }
         }, [undefined, ...ALL_LANGS]);
         langDropdown.addListener(val => recordEvent('langChange', {lang: val}));
+        langDropdown.addListener(() => this.setDisplayRefreshLabel(true));
         langDropdown.id = 'language-picker';
         const langLabel = labelFor("Game Items Language:", langDropdown);
         this.contentArea.append(langLabel);
         this.contentArea.append(document.createElement('br'));
         this.contentArea.append(langDropdown);
         this.contentArea.append(document.createElement('br'));
-        this.contentArea.append('Refresh after changing language.');
+
+        const workersCount = new FieldBoundOrUndefIntField(SETTINGS, 'workersOverride', {
+            postValidators: [clampValues(2, 1024)],
+        });
+        workersCount.style.width = '100%';
+        workersCount.style.boxSizing = 'border-box';
+        const workersLabel = labelFor("Meld Solver Workers: ", workersCount);
+        workersCount.addListener(() => this.setDisplayRefreshLabel(true));
+        this.contentArea.append(document.createElement('br'));
+        this.contentArea.append(workersLabel);
+        this.contentArea.append(workersCount);
+        this.contentArea.append(document.createElement('br'));
+        this.contentArea.append(this.refreshLabel);
 
         this.addCloseButton();
+    }
+
+    setDisplayRefreshLabel(show: boolean): void {
+        if (show) {
+            this.refreshLabel.style.visibility = '';
+        }
+        else {
+            this.refreshLabel.style.visibility = 'hidden';
+        }
     }
 }
 

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1756,8 +1756,7 @@ div.gear-sheet-toolbar-holder {
 
     .meld-solver-target-gcd-input:disabled {
       border: var(--faint-border);
-      background-color: #333339;
-      color: #909090;
+      opacity: 50%;
     }
 
     select.meld-solver-sim-dropdown {

--- a/packages/core/src/sims/common/potency_ratio.ts
+++ b/packages/core/src/sims/common/potency_ratio.ts
@@ -43,6 +43,11 @@ export class PotencyRatioSim implements Simulation<PotencyRatioSimResults, SimSe
         };
     };
 
+    async simulateSimple(set: CharacterGearSet): Promise<number> {
+        return (await this.simulate(set)).mainDpsResult;
+    }
+
+
     spec = potRatioSimSpec;
 
     settingsChanged(): void {

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -560,7 +560,7 @@ export class CycleProcessor {
      * Modifies the stack value for a given buff. The stack value provided should be the modified amount and not the final amount
      *
      * @param buff The Buff
-     * @param stacks The stack modification to add
+     * @param stacksDelta +/- change in stacks
      */
     modifyBuffStacks(buff: Buff, stacksDelta: number) {
         const activeUsages = this.getActiveBuffsData().filter(buffHist => buffHist.buff.name === buff.name);

--- a/packages/core/src/sims/healer/healer_mp.ts
+++ b/packages/core/src/sims/healer/healer_mp.ts
@@ -119,4 +119,9 @@ export class MPPerMinute implements Simulation<MPResult, MPSettings, EmptyObject
             minutesToZero: minutesToZero,
         };
     }
+
+    async simulateSimple(set: CharacterGearSet): Promise<number> {
+        return (await this.simulate(set)).mainDpsResult;
+    }
+
 }

--- a/packages/core/src/sims/healer/sge_sheet_sim.ts
+++ b/packages/core/src/sims/healer/sge_sheet_sim.ts
@@ -108,6 +108,11 @@ export class SgeSheetSim implements Simulation<SgeSheetSimResult, SgeSheetSettin
         };
     }
 
+    async simulateSimple(set: CharacterGearSet): Promise<number> {
+        return (await this.simulate(set)).mainDpsResult;
+    }
+
+
     PhlegmaB(cycle: number) {
         return (phlegmaPot - dosis3pot) * (cycle / 40);
     }

--- a/packages/core/src/sims/healer/whm_sheet_sim.ts
+++ b/packages/core/src/sims/healer/whm_sheet_sim.ts
@@ -123,6 +123,10 @@ export class WhmSheetSim implements Simulation<WhmSheetSimResult, WhmSheetSettin
         };
     }
 
+    async simulateSimple(set: CharacterGearSet): Promise<number> {
+        return (await this.simulate(set)).mainDpsResult;
+    }
+
     afflatusTime(stats: ComputedSetStats, cycle: number) {
         return 6 * stats.gcdMag(2.5) * (cycle / 360 - 1);
     }

--- a/packages/core/src/sims/processors/count_sim.ts
+++ b/packages/core/src/sims/processors/count_sim.ts
@@ -40,7 +40,7 @@ export type BuffWindowUsages = {
 export type SkillCount = [ability: Ability, count: number];
 
 export abstract class BaseUsageCountSim<ResultType extends CountSimResult, InternalSettingsType extends SimSettings>
-implements Simulation<ResultType, InternalSettingsType, ExternalCountSettings<InternalSettingsType>> {
+    implements Simulation<ResultType, InternalSettingsType, ExternalCountSettings<InternalSettingsType>> {
 
     abstract displayName: string;
     abstract shortName: string;
@@ -178,6 +178,10 @@ implements Simulation<ResultType, InternalSettingsType, ExternalCountSettings<In
             unbuffedPps: pps,
             buffBuckets: resultBuckets,
         } satisfies CountSimResult as unknown as ResultType;
+    }
+
+    async simulateSimple(set: CharacterGearSet): Promise<number> {
+        return (await this.simulate(set)).mainDpsResult;
     }
 
     /**

--- a/packages/core/src/sims/processors/sim_processors.ts
+++ b/packages/core/src/sims/processors/sim_processors.ts
@@ -134,7 +134,7 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
     };
 
 
-    generateRotations(set: CharacterGearSet): [string, CycleProcessor][] {
+    generateRotations(set: CharacterGearSet, simple: boolean = false): [string, CycleProcessor][] {
 
         const allBuffs = this.buffManager.enabledBuffs;
         const rotations = this.getRotationsToSimulate(set);
@@ -148,6 +148,7 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
                 manuallyActivatedBuffs: this.manuallyActivatedBuffs ?? [],
                 useAutos: (this.cycleSettings.useAutos ?? true) && set.getItemInSlot('Weapon') !== null,
                 cutoffMode: this.cycleSettings.cutoffMode,
+                simpleMode: simple,
             });
             rot.apply(cp);
             return [rot.name ?? `Unnamed #${index + 1}`, cp];
@@ -231,9 +232,13 @@ export abstract class BaseMultiCycleSim<ResultType extends CycleSimResult, Inter
         console.debug("Sim start");
         const cacheKey = this.computeCacheKey(set);
         if (!arrayEq(this.cachedRotationKey, cacheKey)) {
-            this.cachedCycleProcessors = this.generateRotations(set);
+            // console.error(`cache MISS: ${this.cachedRotationKey} => ${cacheKey}`);
+            this.cachedCycleProcessors = this.generateRotations(set, true);
             this.cachedRotationKey = cacheKey;
         }
+        // else {
+        //     console.error("cache HIT");
+        // }
         return this.calcDamageSimple(set);
     };
 

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -115,6 +115,16 @@ export interface Simulation<ResultType extends SimResult, SettingsType extends S
     simulate(set: CharacterGearSet): Promise<ResultType>;
 
     /**
+     * Like {@link simulate}, but only needs to return a single number. This is used for meld solving and such, as the
+     * brute force sim does not need to display any additional data to the user. If the extra processing time and
+     * memory use from the normal simulation path is trivial for a particular sim implementation, then this can be
+     * implemented as simply "return (await this.simulate(set)).mainDpsResult".
+     *
+     * @param set
+     */
+    simulateSimple(set: CharacterGearSet): Promise<number>;
+
+    /**
      * The internalized settings of the object.
      */
     settings: SettingsType;
@@ -256,9 +266,9 @@ export type DamagingAbility = Readonly<{
  * the potency of skills, or granting new buffs.
  */
 export type LevelModifier = ({
-    minLevel: number,
-})
-& Omit<Partial<BaseAbility>, 'levelModifiers'>;
+        minLevel: number,
+    })
+    & Omit<Partial<BaseAbility>, 'levelModifiers'>;
 
 /**
  * Combo mode:
@@ -338,9 +348,9 @@ export type BaseAbility = Readonly<{
      */
     levelModifiers?: LevelModifier[],
     /**
-    * If the ability uses alternate scalings, such as Living Shadow Strength
-    * scaling or using the pet action Weapon Damage multiplier.
-    */
+     * If the ability uses alternate scalings, such as Living Shadow Strength
+     * scaling or using the pet action Weapon Damage multiplier.
+     */
     alternativeScalings?: AlternativeScaling[],
 } & (NonDamagingAbility | DamagingAbility)>;
 

--- a/packages/core/src/sims/sim_utils.ts
+++ b/packages/core/src/sims/sim_utils.ts
@@ -1,6 +1,21 @@
 import {ComputedSetStats} from "@xivgear/xivmath/geartypes";
-import {Ability, AlternativeScaling, Buff, CombinedBuffEffect, ComputedDamage, DamageResult, DamagingAbility, ScalingOverrides} from "./sim_types";
-import {applyDhCritFull, baseDamageFull, getDefaultScalings, getLivingShadowStrength, mainStatMultiLivingShadow} from "@xivgear/xivmath/xivmath";
+import {
+    Ability,
+    AlternativeScaling,
+    Buff,
+    CombinedBuffEffect,
+    ComputedDamage,
+    DamageResult,
+    DamagingAbility,
+    ScalingOverrides
+} from "./sim_types";
+import {
+    applyDhCritFull,
+    baseDamageFull,
+    getDefaultScalings,
+    getLivingShadowStrength,
+    mainStatMultiLivingShadow
+} from "@xivgear/xivmath/xivmath";
 import {multiplyFixed} from "@xivgear/xivmath/deviation";
 import {StatModification} from "@xivgear/xivmath/xivstats";
 
@@ -73,7 +88,7 @@ export function abilityToDamageNew(stats: ComputedSetStats, ability: Ability, co
 }
 
 /**
- * Returns the "zero" CombinedBuffEffect object, which represents not having any offensive buffs.
+ * Returns the "zero" CombinedBuffEffect object, which represents not having any offensive buffs. This is safe to modify in place.
  */
 export function noBuffEffects(): CombinedBuffEffect {
     return {

--- a/packages/core/src/solving/sim_runner.ts
+++ b/packages/core/src/solving/sim_runner.ts
@@ -57,9 +57,10 @@ export class SimRunner<SimType extends Simulation<SimResult, unknown, unknown>> 
 
         let bestDps = 0;
         let bestSet = null;
-        let set = gearsets.shift();
-        while (set) {
+        for (let i = 0; i < gearsets.length; i++) {
+            const set = gearsets[i];
             const result = await this._sim.simulateSimple(set);
+            gearsets[i] = undefined;
 
             if (result > bestDps) {
                 bestDps = result;
@@ -71,10 +72,6 @@ export class SimRunner<SimType extends Simulation<SimResult, unknown, unknown>> 
                 update(numSetsProcessed);
                 numSetsProcessed = 0;
             }
-
-            set = undefined;
-            // TODO: this has to mutate the underlying array, might be slower?
-            set = gearsets.shift();
         }
 
         return [bestDps, bestSet];

--- a/packages/core/src/solving/sim_runner.ts
+++ b/packages/core/src/solving/sim_runner.ts
@@ -73,6 +73,7 @@ export class SimRunner<SimType extends Simulation<SimResult, unknown, unknown>> 
             }
 
             set = undefined;
+            // TODO: this has to mutate the underlying array, might be slower?
             set = gearsets.shift();
         }
 

--- a/packages/core/src/solving/sim_runner.ts
+++ b/packages/core/src/solving/sim_runner.ts
@@ -53,19 +53,18 @@ export class SimRunner<SimType extends Simulation<SimResult, unknown, unknown>> 
 
         update(0);
         let numSetsProcessed = 0;
-        const threshold = gearsets.length * .05;
+        const threshold = gearsets.length * 0.05;
 
         let bestDps = 0;
         let bestSet = null;
         let set = gearsets.shift();
         while (set) {
-            let result = await this._sim.simulate(set);
+            const result = await this._sim.simulateSimple(set);
 
-            if (result.mainDpsResult > bestDps) {
-                bestDps = result.mainDpsResult;
+            if (result > bestDps) {
+                bestDps = result;
                 bestSet = set;
             }
-            result = undefined;
 
             numSetsProcessed++;
             if (numSetsProcessed > threshold) {

--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -222,7 +222,7 @@ export async function openSheet(planner: GearPlanSheetGui, changeHash: boolean =
         contentArea.replaceChildren(document.createTextNode("Error loading sheet!"));
     });
     await loadSheetPromise;
-    await workerPool.initializeWorkers(planner);
+    await workerPool.setSheet(planner);
 }
 
 export function showSheetPickerMenu() {

--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -10,7 +10,7 @@ import {GearPlanSheetGui, GRAPHICAL_SHEET_PROVIDER} from "./components/sheet";
 import {makeUrl, NavState, splitPath} from "@xivgear/core/nav/common_nav";
 import {applyCommonTopMenuFormatting} from "@xivgear/common-ui/components/top_menu";
 import {recordSheetEvent} from "@xivgear/core/analytics/analytics";
-import {workerPool} from "./workers/worker_pool";
+import {WORKER_POOL} from "./workers/worker_pool";
 import {showSettingsModal} from "@xivgear/common-ui/settings/settings_modal";
 import {SETTINGS} from "@xivgear/common-ui/settings/persistent_settings";
 import {DISPLAY_SETTINGS} from "@xivgear/common-ui/settings/display_settings";
@@ -222,7 +222,7 @@ export async function openSheet(planner: GearPlanSheetGui, changeHash: boolean =
         contentArea.replaceChildren(document.createTextNode("Error loading sheet!"));
     });
     await loadSheetPromise;
-    await workerPool.setSheet(planner);
+    await WORKER_POOL.setSheet(planner);
 }
 
 export function showSheetPickerMenu() {

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -60,13 +60,17 @@ export class MeldSolverDialog extends BaseModal {
             this.buttonArea.removeChild(this.solveMeldsButton);
             this.showProgress();
 
+            let displayedSimText: boolean = false;
             const solverPromise = this.solver.solveMelds(
                 this.settingsDiv.gearsetGenSettings,
                 this.settingsDiv.simSettings,
-                (num: number) => {
+                (num: number, total: number) => {
                     this.progressDisplay.loadbar.updateProgress(num);
-                    this.progressDisplay.text.textContent = "Simulating...";
-
+                    // Don't re-render this unnecessarily
+                    if (!displayedSimText) {
+                        this.progressDisplay.text.textContent = `Simulating ${total} sets...`;
+                        displayedSimText = true;
+                    }
                 });
             solverPromise.then(([set, dps]) => this.solveResultReceived(set, dps));
             recordEvent("SolveMelds", {
@@ -265,6 +269,7 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
         pentameldWarning.style.overflow = 'hidden';
         pentameldWarning.style.display = 'block';
         pentameldWarning.style.maxWidth = "90%";
+        pentameldWarning.style.width = "90%";
         const warningSpan = document.createElement('span');
         warningSpan.textContent = "⚠️ Solving pentameld sets can take a long time. To speed it up, try filling some materia and solving without Overwrite existing materia.";
         warningSpan.style.fontSize = '90%';

--- a/packages/frontend/src/scripts/components/meldsolver.ts
+++ b/packages/frontend/src/scripts/components/meldsolver.ts
@@ -2,7 +2,7 @@ import {CharacterGearSet} from "@xivgear/core/gear";
 import {SetExport, SimExport} from "@xivgear/xivmath/geartypes";
 import {SimResult, SimSettings, Simulation} from "@xivgear/core/sims/sim_types";
 import {GearPlanSheet} from "@xivgear/core/sheet";
-import {GearsetGenerationRequest, SolverSimulationRequest, workerPool} from "../workers/worker_pool";
+import {GearsetGenerationRequest, SolverSimulationRequest, WORKER_POOL} from "../workers/worker_pool";
 import {GearsetGenerationSettings} from "@xivgear/core/solving/gearset_generation";
 import {SolverSimulationSettings} from "@xivgear/core/solving/sim_runner";
 import {range} from "@xivgear/core/util/array_utils";
@@ -45,7 +45,7 @@ export class MeldSolver {
     public async cancel() {
         const promises = [];
         for (const job of this.jobs) {
-            promises.push(workerPool.cancelJob(job.jobId));
+            promises.push(WORKER_POOL.cancelJob(job.jobId));
         }
         await Promise.all(promises);
     }
@@ -65,7 +65,7 @@ export class MeldSolver {
             data: GearsetGenerationSettings.export(gearsetGenSettings, this._sheet),
         };
 
-        const gearGenJob = workerPool.submitTask(gearsetGenRequest);
+        const gearGenJob = WORKER_POOL.submitTask(gearsetGenRequest);
         this.jobs.push(gearGenJob);
 
         // This will return gear sets "loosely ordered", where they are broken into buckets based on
@@ -77,7 +77,7 @@ export class MeldSolver {
         }
         this.jobs = [];
 
-        const nSimJobs = workerPool.maxWorkers;
+        const nSimJobs = WORKER_POOL.maxWorkers;
         const nSetsPerJob = Math.ceil(sets.length / nSimJobs);
         const numSets = sets.length;
         let totalSimmed = 0;
@@ -104,7 +104,7 @@ export class MeldSolver {
                 },
             };
 
-            this.jobs.push(workerPool.submitTask(simRequest, (numSimmed: number) => {
+            this.jobs.push(WORKER_POOL.submitTask(simRequest, (numSimmed: number) => {
                 totalSimmed += numSimmed;
                 update(100 * totalSimmed / numSets, numSets);
             }));

--- a/packages/frontend/src/scripts/workers/meld_generation_worker.ts
+++ b/packages/frontend/src/scripts/workers/meld_generation_worker.ts
@@ -1,7 +1,7 @@
 import {SetExport} from "@xivgear/xivmath/geartypes";
 import {GearPlanSheet} from "@xivgear/core/sheet";
 import {GearsetGenerator} from "@xivgear/core/solving/gearset_generation";
-import {JobInfo, WorkerBehavior} from "./worker_common";
+import {DEBUG_FINAL_REGISTRY, JobInfo, WorkerBehavior} from "./worker_common";
 import {GearsetGenerationRequest, JobContext} from "./worker_pool";
 
 
@@ -13,6 +13,7 @@ export class GearsetGenerationWorker extends WorkerBehavior<GearsetGenerationJob
     constructor(sheet: GearPlanSheet, info: JobInfo) {
         super(info);
         this.sheet = sheet;
+        DEBUG_FINAL_REGISTRY.register(this, "GearsetGenerationWorker");
     }
 
     override async execute(request: GearsetGenerationRequest) {
@@ -30,5 +31,7 @@ export class GearsetGenerationWorker extends WorkerBehavior<GearsetGenerationJob
         const setsToExport: SetExport[] = allGearsets.map(set => this.sheet.exportGearSet(set));
 
         this.postResult(setsToExport);
+
+        setsToExport.splice(0, setsToExport.length);
     }
 }

--- a/packages/frontend/src/scripts/workers/meld_generation_worker.ts
+++ b/packages/frontend/src/scripts/workers/meld_generation_worker.ts
@@ -1,7 +1,7 @@
 import {SetExport} from "@xivgear/xivmath/geartypes";
 import {GearPlanSheet} from "@xivgear/core/sheet";
 import {GearsetGenerator} from "@xivgear/core/solving/gearset_generation";
-import {WorkerBehavior} from "./worker_common";
+import {JobInfo, WorkerBehavior} from "./worker_common";
 import {GearsetGenerationRequest, JobContext} from "./worker_pool";
 
 
@@ -10,8 +10,8 @@ export type GearsetGenerationJobContext = JobContext<GearsetGenerationRequest, n
 export class GearsetGenerationWorker extends WorkerBehavior<GearsetGenerationJobContext> {
 
     sheet: GearPlanSheet;
-    constructor(sheet: GearPlanSheet) {
-        super();
+    constructor(sheet: GearPlanSheet, info: JobInfo) {
+        super(info);
         this.sheet = sheet;
     }
 

--- a/packages/frontend/src/scripts/workers/ping_worker.ts
+++ b/packages/frontend/src/scripts/workers/ping_worker.ts
@@ -1,0 +1,16 @@
+import {JobInfo, WorkerBehavior} from "./worker_common";
+import {JobContext, PingData, PingRequest} from "./worker_pool";
+
+export type PingContext = JobContext<PingRequest, never, PingData>;
+
+export class PingWorker extends WorkerBehavior<PingContext> {
+
+    constructor(jobInfo: JobInfo) {
+        super(jobInfo);
+    }
+
+    override async execute(request: PingRequest) {
+        await new Promise(r => setTimeout(r, request.data.waitMs));
+        this.postResult(request.data);
+    }
+}

--- a/packages/frontend/src/scripts/workers/simulation_worker.ts
+++ b/packages/frontend/src/scripts/workers/simulation_worker.ts
@@ -1,7 +1,7 @@
 import {GearPlanSheet} from "@xivgear/core/sheet";
 import {SimRunner} from "@xivgear/core/solving/sim_runner";
 import {SetExport} from "@xivgear/xivmath/geartypes";
-import {WorkerBehavior} from "./worker_common";
+import {JobInfo, WorkerBehavior} from "./worker_common";
 import {JobContext, SolverSimulationRequest} from "./worker_pool";
 
 export type SolverSimulationResult = {
@@ -15,8 +15,8 @@ export class SolverSimulationRunner extends WorkerBehavior<SolverSimulationJobCo
 
     readonly sheet: GearPlanSheet;
 
-    public constructor(sheet: GearPlanSheet) {
-        super();
+    public constructor(sheet: GearPlanSheet, info: JobInfo) {
+        super(info);
         this.sheet = sheet;
     }
 
@@ -35,7 +35,7 @@ export class SolverSimulationRunner extends WorkerBehavior<SolverSimulationJobCo
         });
 
         settings.sets = undefined;
-        const [bestDps, bestSet] = await simRunner.simulateSetsAndReturnBest(sorted, this.postUpdate);
+        const [bestDps, bestSet] = await simRunner.simulateSetsAndReturnBest(sorted, (n) => this.postUpdate(n));
         const result = {
             dps: bestDps,
             set: this.sheet.exportGearSet(bestSet),

--- a/packages/frontend/src/scripts/workers/simulation_worker.ts
+++ b/packages/frontend/src/scripts/workers/simulation_worker.ts
@@ -29,13 +29,10 @@ export class SolverSimulationRunner extends WorkerBehavior<SolverSimulationJobCo
             this.postResult(null);
             return;
         }
-
-        const sorted = settings.sets?.map(s => this.sheet.importGearSet(s))?.sort((a, b) => {
-            return a.computedStats.gcdPhys(2.5) - b.computedStats.gcdPhys(2.5);
-        });
+        const imported = settings.sets.map(s => this.sheet.importGearSet(s));
 
         settings.sets = undefined;
-        const [bestDps, bestSet] = await simRunner.simulateSetsAndReturnBest(sorted, (n) => this.postUpdate(n));
+        const [bestDps, bestSet] = await simRunner.simulateSetsAndReturnBest(imported, (n) => this.postUpdate(n));
         const result = {
             dps: bestDps,
             set: this.sheet.exportGearSet(bestSet),

--- a/packages/frontend/src/scripts/workers/worker_common.ts
+++ b/packages/frontend/src/scripts/workers/worker_common.ts
@@ -1,26 +1,52 @@
-import {AnyWorkRequest, JobContext, RequestTypeOf, ResponseTypeOf, UpdateTypeOf} from "./worker_pool";
+import {
+    AnyWorkRequest,
+    AnyWorkResponse,
+    JobContext,
+    RequestTypeOf,
+    ResponseTypeOf,
+    UpdateTypeOf,
+    WorkerToMainMessage
+} from "./worker_pool";
+
+export type JobInfo = {
+    jobId: number,
+}
 
 export abstract class WorkerBehavior<X extends JobContext<AnyWorkRequest, unknown, unknown>> {
 
-    postUpdate(update: UpdateTypeOf<X>) {
+    protected readonly jobId: number;
+
+    protected constructor(jobInfo: JobInfo) {
+        this.jobId = jobInfo.jobId;
+    }
+
+    post(response: AnyWorkResponse) {
         postMessage({
+            res: response,
+            jobId: this.jobId,
+        } satisfies WorkerToMainMessage);
+    }
+
+    postUpdate(update: UpdateTypeOf<X>) {
+        this.post({
             responseType: 'update',
             data: update,
         });
     }
 
     postResult(result: ResponseTypeOf<X>) {
-        postMessage({
+        this.post({
             responseType: 'done',
             data: result,
         });
     }
 
     postError(error: unknown) {
-        postMessage({
+        this.post({
             responseType: 'error',
             data: error,
         });
     }
+
     abstract execute(request: RequestTypeOf<X>): void;
 }

--- a/packages/frontend/src/scripts/workers/worker_common.ts
+++ b/packages/frontend/src/scripts/workers/worker_common.ts
@@ -12,6 +12,10 @@ export type JobInfo = {
     jobId: number,
 }
 
+export function postMsg(msg: WorkerToMainMessage) {
+    postMessage(msg);
+}
+
 export abstract class WorkerBehavior<X extends JobContext<AnyWorkRequest, unknown, unknown>> {
 
     protected readonly jobId: number;
@@ -21,10 +25,10 @@ export abstract class WorkerBehavior<X extends JobContext<AnyWorkRequest, unknow
     }
 
     post(response: AnyWorkResponse) {
-        postMessage({
+        postMsg({
             res: response,
             jobId: this.jobId,
-        } satisfies WorkerToMainMessage);
+        });
     }
 
     postUpdate(update: UpdateTypeOf<X>) {
@@ -50,3 +54,7 @@ export abstract class WorkerBehavior<X extends JobContext<AnyWorkRequest, unknow
 
     abstract execute(request: RequestTypeOf<X>): void;
 }
+
+export const DEBUG_FINAL_REGISTRY = new FinalizationRegistry((item) => {
+    console.info("Finalized " + item);
+});

--- a/packages/frontend/src/scripts/workers/worker_main.ts
+++ b/packages/frontend/src/scripts/workers/worker_main.ts
@@ -4,7 +4,7 @@ import {GearsetGenerationWorker} from "./meld_generation_worker";
 import {AnyWorkRequest, AnyWorkResponse, MainToWorkerMessage, WorkerToMainMessage} from "./worker_pool";
 import {SolverSimulationRunner} from "./simulation_worker";
 import {makeDataManager} from "@xivgear/core/datamanager";
-import {JobInfo} from "./worker_common";
+import {JobInfo, postMsg} from "./worker_common";
 import {PingWorker} from "./ping_worker";
 
 registerDefaultSims();
@@ -12,45 +12,58 @@ let dataManager = null;
 onmessage = async function (event) {
 
     const msg = event.data as MainToWorkerMessage;
-    const request: AnyWorkRequest = msg.req;
-    if (request.jobType === "workerInitialization") {
-        // This "sheet" is only used to get everything into the cache - it is never actually used.
-        // We re-use the DataManager only.
-        const sheet = HEADLESS_SHEET_PROVIDER.fromExport(request.sheet);
-        dataManager = makeDataManager(sheet.classJobName, sheet.level, sheet.ilvlSync);
-        await dataManager.loadData();
+    const jobId = msg.jobId;
+    try {
 
-        const response: AnyWorkResponse = {
-            responseType: "done",
-            data: null,
+        const request: AnyWorkRequest = msg.req;
+        if (request.jobType === "workerInitialization") {
+            // This "sheet" is only used to get everything into the cache - it is never actually used.
+            // We re-use the DataManager only.
+            const sheet = HEADLESS_SHEET_PROVIDER.fromExport(request.sheet);
+            dataManager = makeDataManager(sheet.classJobName, sheet.level, sheet.ilvlSync);
+            await dataManager.loadData();
+
+            const response: AnyWorkResponse = {
+                responseType: "done",
+                data: null,
+            };
+            this.postMessage({
+                res: response,
+                jobId: jobId,
+            } satisfies WorkerToMainMessage);
+            return;
+        }
+
+        const jobInfo: JobInfo = {
+            jobId: jobId,
         };
-        this.postMessage({
-            res: response,
-            jobId: msg.jobId,
-        } satisfies WorkerToMainMessage);
-        return;
+        if (request.jobType === 'ping') {
+            const pinger = new PingWorker(jobInfo);
+            await pinger.execute(request);
+            return;
+        }
+        // This sheet is fresh for each work request, but it re-uses an already-loaded DataManager.
+        const sheet = HEADLESS_SHEET_PROVIDER.fromExport(request.sheet);
+        await sheet.loadFromDataManager(dataManager);
+        if (request.jobType === "generateGearset") {
+            let gearsetGen = new GearsetGenerationWorker(sheet, jobInfo);
+            await gearsetGen.execute(request);
+            // TODO
+            gearsetGen = undefined;
+            return;
+        }
+        if (request.jobType === "solverSimulation") {
+            await new SolverSimulationRunner(sheet, jobInfo).execute(request);
+            return;
+        }
     }
-
-    const jobInfo: JobInfo = {
-        jobId: msg.jobId,
-    };
-    if (request.jobType === 'ping') {
-        const pinger = new PingWorker(jobInfo);
-        await pinger.execute(request);
-        return;
-    }
-    // This sheet is fresh for each work request, but it re-uses an already-loaded DataManager.
-    const sheet = HEADLESS_SHEET_PROVIDER.fromExport(request.sheet);
-    await sheet.loadFromDataManager(dataManager);
-    if (request.jobType === "generateGearset") {
-        let gearsetGen = new GearsetGenerationWorker(sheet, jobInfo);
-        await gearsetGen.execute(request);
-        // TODO
-        gearsetGen = undefined;
-        return;
-    }
-    if (request.jobType === "solverSimulation") {
-        await new SolverSimulationRunner(sheet, jobInfo).execute(request);
-        return;
+    catch (e) {
+        postMsg({
+            jobId: jobId,
+            res: {
+                responseType: 'error',
+                data: e,
+            },
+        });
     }
 };

--- a/packages/frontend/src/scripts/workers/worker_main.ts
+++ b/packages/frontend/src/scripts/workers/worker_main.ts
@@ -1,7 +1,7 @@
 import {HEADLESS_SHEET_PROVIDER} from "@xivgear/core/sheet";
 import {registerDefaultSims} from "@xivgear/core/sims/default_sims";
 import {GearsetGenerationWorker} from "./meld_generation_worker";
-import {AnyWorkRequest, AnyWorkResponse, MainToWorkerMessage, PingResponse, WorkerToMainMessage} from "./worker_pool";
+import {AnyWorkRequest, AnyWorkResponse, MainToWorkerMessage, WorkerToMainMessage} from "./worker_pool";
 import {SolverSimulationRunner} from "./simulation_worker";
 import {makeDataManager} from "@xivgear/core/datamanager";
 import {JobInfo} from "./worker_common";

--- a/packages/frontend/src/scripts/workers/worker_main.ts
+++ b/packages/frontend/src/scripts/workers/worker_main.ts
@@ -1,39 +1,56 @@
 import {HEADLESS_SHEET_PROVIDER} from "@xivgear/core/sheet";
 import {registerDefaultSims} from "@xivgear/core/sims/default_sims";
 import {GearsetGenerationWorker} from "./meld_generation_worker";
-import {AnyWorkRequest, InitializationRequest, GearsetGenerationRequest, AnyWorkResponse, SolverSimulationRequest} from "./worker_pool";
+import {AnyWorkRequest, AnyWorkResponse, MainToWorkerMessage, PingResponse, WorkerToMainMessage} from "./worker_pool";
 import {SolverSimulationRunner} from "./simulation_worker";
 import {makeDataManager} from "@xivgear/core/datamanager";
+import {JobInfo} from "./worker_common";
+import {PingWorker} from "./ping_worker";
 
 registerDefaultSims();
 let dataManager = null;
 onmessage = async function (event) {
 
-    let request = event.data as AnyWorkRequest;
+    const msg = event.data as MainToWorkerMessage;
+    const request: AnyWorkRequest = msg.req;
     if (request.jobType === "workerInitialization") {
-        request = event.data as InitializationRequest;
+        // This "sheet" is only used to get everything into the cache - it is never actually used.
+        // We re-use the DataManager only.
         const sheet = HEADLESS_SHEET_PROVIDER.fromExport(request.sheet);
         dataManager = makeDataManager(sheet.classJobName, sheet.level, sheet.ilvlSync);
         await dataManager.loadData();
+
         const response: AnyWorkResponse = {
             responseType: "done",
             data: null,
         };
-        this.postMessage(response);
+        this.postMessage({
+            res: response,
+            jobId: msg.jobId,
+        } satisfies WorkerToMainMessage);
         return;
     }
+
+    const jobInfo: JobInfo = {
+        jobId: msg.jobId,
+    };
+    if (request.jobType === 'ping') {
+        const pinger = new PingWorker(jobInfo);
+        await pinger.execute(request);
+        return;
+    }
+    // This sheet is fresh for each work request, but it re-uses an already-loaded DataManager.
     const sheet = HEADLESS_SHEET_PROVIDER.fromExport(request.sheet);
     await sheet.loadFromDataManager(dataManager);
     if (request.jobType === "generateGearset") {
-        request = event.data as GearsetGenerationRequest;
-        let gearsetGen = new GearsetGenerationWorker(sheet);
+        let gearsetGen = new GearsetGenerationWorker(sheet, jobInfo);
         await gearsetGen.execute(request);
+        // TODO
         gearsetGen = undefined;
         return;
     }
     if (request.jobType === "solverSimulation") {
-        request = event.data as SolverSimulationRequest;
-        await new SolverSimulationRunner(sheet).execute(request);
+        await new SolverSimulationRunner(sheet, jobInfo).execute(request);
         return;
     }
 };

--- a/packages/frontend/src/scripts/workers/worker_pool.ts
+++ b/packages/frontend/src/scripts/workers/worker_pool.ts
@@ -1,7 +1,6 @@
 import {GearPlanSheet} from "@xivgear/core/sheet";
 import {GearsetGenerationSettingsExport} from "@xivgear/core/solving/gearset_generation";
 import {SolverSimulationSettingsExport} from "@xivgear/core/solving/sim_runner";
-import {range} from "@xivgear/core/util/array_utils";
 import {SheetExport} from "@xivgear/xivmath/geartypes";
 
 type ResolveReject = {
@@ -19,25 +18,36 @@ export type InitializationRequest = WorkRequest<'workerInitialization', SheetExp
 export type GearsetGenerationRequest = WorkRequest<'generateGearset', GearsetGenerationSettingsExport>
 export type SolverSimulationRequest = WorkRequest<'solverSimulation', SolverSimulationSettingsExport>
 
+export type PingData = {
+    pingId: unknown,
+    waitMs: number,
+}
+
+export type PingRequest = WorkRequest<'ping', PingData>
+export type PingResponse = WorkResponse<'ping'>
+
 export type AnyWorkRequest =
     InitializationRequest
     | GearsetGenerationRequest
-    | SolverSimulationRequest;
+    | SolverSimulationRequest
+    | PingRequest;
+
+export type MainToWorkerMessage = {
+    req: AnyWorkRequest,
+    jobId: number,
+}
 
 type WorkRequestInternal = {
     jobId: number,
-    request: AnyWorkRequest,
+    workerMessage: AnyWorkRequest,
+    updateCallback: (upd: unknown) => void,
+    promiseControl: ResolveReject,
+    promise: Promise<unknown>,
 }
 
 type WorkResponse<ResponseType extends string> = {
     responseType: ResponseType;
     data: unknown;
-}
-
-export type JobContext<Req extends AnyWorkRequest, Upd, Resp> = {
-    dummyReq: Req,
-    dummyUpd: Upd,
-    dummyResp: Resp,
 }
 
 export type RequestTypeOf<X> = X extends JobContext<infer R, unknown, unknown> ? R : never;
@@ -46,95 +56,288 @@ export type ResponseTypeOf<X> = X extends JobContext<AnyWorkRequest, unknown, in
 
 export type AnyWorkResponse = WorkResponse<'update'> | WorkResponse<'done'> | WorkResponse<'error'>;
 
-export class WorkerPool {
+export type WorkerToMainMessage = {
+    res: AnyWorkResponse,
+    jobId: number,
+}
 
-    workers: Worker[] = [];
-    activeJobIds: Map<Worker, number> = new Map;
-    messageQueue: WorkRequestInternal[] = [];
-    resolves: Map<number, ResolveReject> = new Map;
-    freeWorkers: Worker[] = [];
-    updateCallbacks: Map<number, (data: unknown) => void> = new Map;
+export type JobContext<Req extends AnyWorkRequest, Upd, Resp> = {
+    dummyReq: Req,
+    dummyUpd: Upd,
+    dummyResp: Resp,
+}
 
-    get numFreeWorkers() {
-        console.log(this.freeWorkers);
-        return this.freeWorkers.length;
-    }
+type WorkerStatus = 'uninitialized' | 'idle' | 'processing' | 'terminated' | 'initializing';
 
-    constructor(numWorkers: number) {
+let currJobId: number = 0;
 
-        this.currJobId = 0;
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const _i of range(0, numWorkers)) {
-            const worker = this.makeActualWorker();
-            this.workers.push(worker);
-            this.freeWorkers.push(worker);
-        }
-    }
+function nextJobId(): number {
+    return currJobId++;
+}
 
-    private onWorkerMessage(worker: Worker, jobId: number, response: AnyWorkResponse) {
+function makeWorkRequest(request: AnyWorkRequest, updateCallback?: (upd: unknown) => void): {
+    promise: Promise<unknown>,
+    jobId: number,
+    internalRequest: WorkRequestInternal
+} {
+    const jobId = nextJobId();
+    let outerResolve: (value: unknown) => void;
+    let outerReject: (reason?: never) => void;
+    const promise = new Promise((resolve, reject) => {
+        outerResolve = resolve;
+        outerReject = reject;
+    });
+    const internalRequest: WorkRequestInternal = {
+        jobId: jobId,
+        workerMessage: request,
+        updateCallback: updateCallback,
+        promiseControl: {
+            resolve: outerResolve,
+            reject: outerReject,
+        },
+        promise: promise,
+    };
+    return {
+        internalRequest: internalRequest,
+        jobId: jobId,
+        promise: promise,
+    };
+}
 
-        if (response.responseType === 'update') {
-            this.updateCallbacks.get(jobId)?.(response.data);
-            return;
-        }
+class SheetWorker {
 
-        if (response.responseType === 'done') {
-            this.resolves.get(jobId)?.resolve(response.data ?? null);
-        }
-        else { // response type === 'error'
-            this.resolves.get(jobId)?.reject(response.data ?? null);
-        }
+    private _status: WorkerStatus = 'uninitialized';
+    private _activeWorkRequest: WorkRequestInternal | null = null;
 
-        if (this.messageQueue.length !== 0) {
-            const msg = this.messageQueue.pop();
-            this.assignWorker(msg, worker);
-            return;
-        }
-
-        this.activeJobIds.delete(worker);
-        this.freeWorkers.push(worker);
-    }
-
-    private assignWorkerWithId(request: WorkRequestInternal, worker: Worker) {
-
-    }
-
-    private assignWorker(request: WorkRequestInternal, worker: Worker) {
-        if (!worker) {
-            console.error("assignWorker() called with null worker.");
-            return;
-        }
-
-        this.activeJobIds.set(worker, request.jobId);
-
-        worker.postMessage(request.request);
-    }
-
-    public requestWork(request: AnyWorkRequest, updateCallback?: (upd: unknown) => void): { promise: Promise<unknown>, jobId: number } {
-        const internalRequest: WorkRequestInternal = {
-            jobId: this.createJobId(),
-            request: request,
+    constructor(private readonly worker: Worker, readonly name: string, private readonly readyCallback: () => void) {
+        worker.onmessage = (event) => {
+            this.onMessage(event);
         };
-        if (updateCallback) {
-            this.updateCallbacks.set(internalRequest.jobId, updateCallback);
+
+        worker.onerror = (_event: ErrorEvent) => {
+            this.onError(_event);
+        };
+    }
+
+    terminate(): void {
+        console.log(`${this.name}: Worker terminating - current status is '${this.status}'`);
+        this._status = 'terminated';
+        this.worker.terminate();
+    }
+
+    get status(): WorkerStatus {
+        return this._status;
+    }
+
+    get isFree(): boolean {
+        return this.status === 'idle';
+    }
+
+    get isInitializing(): boolean {
+        return this.status === 'initializing';
+    }
+
+    startWork(request: WorkRequestInternal, isInitializer: boolean = false) {
+        if (!this.isFree && !isInitializer) {
+            throw new Error(`Cannot assign work to worker when it is not ready (state '${this.status}')`);
         }
-        if (this.freeWorkers.length > 0) {
-            this.assignWorker(internalRequest, this.freeWorkers.pop());
+        this._status = isInitializer ? 'initializing' : 'processing';
+        this._activeWorkRequest = request;
+        console.debug(`${this.name}: startWork for ${request.workerMessage.jobType}`);
+        this.post({
+            jobId: request.jobId,
+            req: request.workerMessage,
+        });
+    }
+
+    post(msg: MainToWorkerMessage) {
+        this.worker.postMessage(msg);
+    }
+
+    async setSheet(sheet: GearPlanSheet): Promise<void> {
+        console.debug(`${this.name}: setSheet`);
+        this.reset();
+        const innerReq: InitializationRequest = {
+            sheet: sheet.exportSheet(),
+            jobType: "workerInitialization",
+            data: undefined,
+        };
+        const req = makeWorkRequest(innerReq);
+        this.startWork(req.internalRequest, true);
+        await req.promise;
+    }
+
+    private onMessage(event: MessageEvent) {
+
+        console.debug(`${this.name}: onMessage`);
+        // TODO: move jobId somewhere
+        const msg = event.data as WorkerToMainMessage;
+        const response = msg.res;
+        console.debug(`response type: ${response.responseType}`);
+
+        if (this._activeWorkRequest === null || this._activeWorkRequest?.jobId !== msg.jobId) {
+            // Job was already re-assigned, ignore result
+            console.warn(`${this.name}: Ignoring obsolete job`);
+            return;
+        }
+        if (response.responseType === 'update') {
+            this._activeWorkRequest.updateCallback(response.data);
+            return;
+        }
+        else if (response.responseType === 'done') {
+            this._activeWorkRequest.promiseControl.resolve(response.data ?? null);
+            this.jobDone();
+            return;
+        }
+        else if (response.responseType === 'error') {
+            this._activeWorkRequest.promiseControl.reject(response.data ?? null);
+            this.jobDone();
+            return;
         }
         else {
-            this.messageQueue.push(internalRequest);
+            // @ts-expect-error fallback in case of unknown value
+            console.error(`${this.name}: Unknown worker response type, terminating: '${response.responseType}'`);
+        }
+    }
+
+    private jobDone() {
+        console.debug(`${this.name}: jobDone`);
+        this._status = 'idle';
+        this._activeWorkRequest = null;
+        this.readyCallback();
+    }
+
+    private onError(_event: ErrorEvent) {
+        console.debug(`${this.name}: onError`);
+        this._activeWorkRequest.promiseControl.reject(_event ?? null);
+        this.jobDone();
+    }
+
+    private reset() {
+        console.debug(`${this.name}: reset`);
+        this._status = 'uninitialized';
+        if (this._activeWorkRequest !== null) {
+            this._activeWorkRequest.promiseControl.reject("worker reset");
+            this._activeWorkRequest = null;
+        }
+    }
+
+    get activeJobId(): number | null {
+        return this._activeWorkRequest?.jobId ?? null;
+    }
+}
+
+export class WorkerPool {
+
+    workers: SheetWorker[] = [];
+    messageQueue: WorkRequestInternal[] = [];
+    currentSheet: GearPlanSheet | null = null;
+
+    constructor(readonly minWorkers: number, readonly maxWorkers: number) {
+        this.stateUpdate();
+    }
+
+    get numFreeWorkers() {
+        return this.workers.filter(worker => worker.isFree).length;
+    }
+
+    get numInitializingWorkers() {
+        return this.workers.filter(worker => worker.isInitializing).length;
+    }
+
+    /**
+     * Get a free worker, or null if there are no free workers.
+     * @private
+     */
+    private getFreeWorker(): SheetWorker | null {
+        return this.workers.find(worker => worker.isFree) ?? null;
+    }
+
+    /**
+     * Add a new worker. The worker will initially be in "initializing" state, but it is immediately added to the
+     * list.
+     *
+     * @private
+     */
+    private addNewWorker(doStateUpdate: boolean = true): void {
+        const worker = this.makeActualWorker();
+        this.workers.push(worker);
+        if (this.currentSheet !== null) {
+            worker.setSheet(this.currentSheet).then(() => this.stateUpdate());
+        }
+        if (doStateUpdate) {
+            this.stateUpdate();
+        }
+    }
+
+    /**
+     * stateUpdate must be called any time that work is added to the queue, or a worker becomes available.
+     * @private
+     */
+    private stateUpdate() {
+        // First, remove any workers in terminated state
+        let i = this.workers.length;
+        while (i--) {
+            if (this.workers[i].status === 'terminated') {
+                this.workers.splice(i, 1);
+            }
         }
 
+        // Then, if the number of current workers is fewer than the minWorkers param (e.g. due to termination),
+        // add new workers.
+        while (this.workers.length < this.minWorkers) {
+            this.addNewWorker(false);
+        }
+        // Try assigning messages to workers
+        while (this.messageQueue.length > 0) {
+            const worker: SheetWorker | null = this.getFreeWorker();
+            if (worker === null) {
+                // No more free workers, break the loop.
+                break;
+            }
+            const msg = this.messageQueue.pop();
+            worker.startWork(msg);
+        }
+
+        // If the number of pending tasks is greater than the number of free + initializing workers, add more workers,
+        // up to the maximum.
+        // Number of ready workers
+        const freeWorkers = this.numFreeWorkers;
+        // Number of initializing workers. If we have 5 tasks in queue, we would initialize 5, but we shouldn't try to
+        // initialize another 5 just because those 5 aren't ready yet.
+        const initializingWorkers = this.numInitializingWorkers;
+        // Number of pending tasks.
+        const pendingTasks = this.messageQueue.length;
+        // Current number of workers.
+        const currentNumWorkers = this.workers.length;
+        // How many additional workers we would like.
+        const additionalDesiredWorkers = pendingTasks - (freeWorkers + initializingWorkers);
+        if (additionalDesiredWorkers > 0) {
+            // How many new workers to create
+            const desiredNewWorkers = Math.min(this.maxWorkers - currentNumWorkers, additionalDesiredWorkers);
+            console.log(`creating ${desiredNewWorkers} new workers (current: ${currentNumWorkers}); free: ${freeWorkers}; init: ${initializingWorkers}; pending: ${pendingTasks})`);
+            for (let j = 0; j < desiredNewWorkers; j++) {
+                this.addNewWorker(false);
+            }
+        }
+    }
+
+    public submitTask(request: AnyWorkRequest, updateCallback?: (upd: unknown) => void): {
+        promise: Promise<unknown>,
+        jobId: number
+    } {
+        const inner = makeWorkRequest(request, updateCallback);
+        this.messageQueue.push(inner.internalRequest);
+        this.stateUpdate();
         return {
-            promise: new Promise((resolve, reject) => {
-                this.resolves.set(internalRequest.jobId, { resolve: resolve, reject: reject });
-            }),
-            jobId: internalRequest.jobId,
+            promise: inner.promise,
+            jobId: inner.jobId,
         };
     }
 
     // Webpack sees this and it causes it to generate a separate js file for the worker.
     // import.meta.url doesn't actually work for this - we need to use document.location as shown in the ctor.
+    // noinspection JSUnusedLocalSymbols
     private makeUselessWorker() {
         new Worker(new URL(
             // @ts-expect-error idk
@@ -144,95 +347,56 @@ export class WorkerPool {
 
     workerId = 0;
 
-    private makeActualWorker(): Worker {
-        const worker = new Worker(new URL(
-            'src_scripts_workers_worker_main_ts.js', document.location.toString())
-        , {
-            name: 'worker-' + this.workerId++,
-        });
-        worker.onmessage = (event) => {
-            const id = this.activeJobIds.get(worker);
-            this.onWorkerMessage(worker, id, event.data);
-        };
-
-        worker.onerror = (_event: ErrorEvent) => {
-            this.freeWorkers.push(worker);
-        };
-
-        return worker;
+    private makeActualWorker(): SheetWorker {
+        const name = 'worker-' + this.workerId++;
+        console.log(`Creating worker ${name}`);
+        const worker = new Worker(
+            new URL('src_scripts_workers_worker_main_ts.js',
+                document.location.toString()),
+            {
+                name: name,
+            });
+        return new SheetWorker(worker, name, () => this.stateUpdate());
     }
 
-    public async initializeWorkers(sheet: GearPlanSheet) {
+    public async setSheet(sheet: GearPlanSheet) {
+        this.currentSheet = sheet;
         const promises = [];
-        if (this.freeWorkers.length !== this.workers.length) {
-            console.error(`Can't initialize workers: Worker busy. Workers: ${this.workers.length}, free: ${this.freeWorkers.length}`);
-            return;
-        }
-        const initReq: InitializationRequest = {
-            jobType: 'workerInitialization',
-            sheet: sheet.exportSheet(),
-            data: undefined,
-        };
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const _w of this.workers) {
-
-            promises.push(this.requestWork(initReq));
-        }
-
-        for (const promise of promises) {
-            await promise;
-            console.log("Promise done");
-        }
+        this.workers.forEach((worker: SheetWorker) => {
+            promises.push(worker.setSheet(sheet).then(() => this.stateUpdate()));
+        });
+        await Promise.all(promises);
     }
 
-    currJobId: number = 0;
-    private createJobId() {
-        return this.currJobId++;
-    }
-
-    public async cancelJob(id: number, sheet: GearPlanSheet) {
-        const worker = this.getWorkerByJobId(id);
-
-        if (!worker) {
-            return;
-        }
-        const idx = this.workers.indexOf(worker);
-
-        worker.terminate();
-        this.resolves.delete(this.activeJobIds.get(worker));
-        this.updateCallbacks.delete(this.activeJobIds.get(worker));
-        console.log("workers: ", this.workers);
-        this.workers[idx] = this.makeActualWorker();
-
-        /**Remove the worker in place. */
-
-        //this.workers.push(worker);
-
-        const initReq: InitializationRequest = {
-            jobType: 'workerInitialization',
-            sheet: sheet.exportSheet(),
-            data: undefined,
-        };
-
-        // Kinda hacky, but it works.
-        //requestWork() pulls off the back of freeWorkers so we have a guarantee that the right worker gets init'ed
-        this.freeWorkers.push(this.workers[idx]);
-        await this.requestWork(initReq).promise;
-    }
-
-    getWorkerByJobId(idToGet: number): Worker | null {
-        for (const [worker, id] of this.activeJobIds) {
-            if (id === idToGet) {
-                return worker;
+    public async cancelJob(id: number) {
+        for (const wrk of this.workers) {
+            if (wrk.activeJobId === id) {
+                wrk.terminate();
             }
         }
-
-        return null;
+        this.stateUpdate();
     }
+
+    public async ping<X>(value: X, waitMs: number) {
+        const req: PingRequest = {
+            data: {
+                pingId: value,
+                waitMs: waitMs,
+            },
+            jobType: "ping",
+            sheet: undefined,
+        };
+        const requested = this.submitTask(req);
+        return requested.promise;
+    }
+
 }
 
 // set maxWorkers to the number of logical processors (minimum 4)
 // defaults to 4 on browsers that don't support hardwareConcurrency (widely supported)
 // some browsers (e.g. Safari, Brave) clamp or randomize hardwareConcurrency to prevent device fingerprinting
 const maxWorkers = Math.max((navigator.hardwareConcurrency || 4), 4);
-export const workerPool: WorkerPool = new WorkerPool(maxWorkers);
+export const workerPool: WorkerPool = new WorkerPool(1, maxWorkers);
+
+// Debugging
+window['workerPool'] = workerPool;

--- a/packages/frontend/src/scripts/workers/worker_pool.ts
+++ b/packages/frontend/src/scripts/workers/worker_pool.ts
@@ -2,6 +2,7 @@ import {GearPlanSheet} from "@xivgear/core/sheet";
 import {GearsetGenerationSettingsExport} from "@xivgear/core/solving/gearset_generation";
 import {SolverSimulationSettingsExport} from "@xivgear/core/solving/sim_runner";
 import {SheetExport} from "@xivgear/xivmath/geartypes";
+import {SETTINGS} from "@xivgear/common-ui/settings/persistent_settings";
 
 type ResolveReject = {
     resolve: (res: unknown) => void,
@@ -392,11 +393,13 @@ export class WorkerPool {
 
 }
 
-// set maxWorkers to the number of logical processors (minimum 4)
-// defaults to 4 on browsers that don't support hardwareConcurrency (widely supported)
-// some browsers (e.g. Safari, Brave) clamp or randomize hardwareConcurrency to prevent device fingerprinting
-const maxWorkers = Math.max((navigator.hardwareConcurrency || 4), 4);
-export const workerPool: WorkerPool = new WorkerPool(1, maxWorkers);
+// Logic for maxWorkers:
+// If explicit override exists, use that.
+// If navigator.hardwareConcurrency is not available, default to 4. Some browsers clamp or randomize hardwareConcurrency to prevent device fingerprinting.
+// If it is, then clamp its value to between 4 and 24.
+// Intensive meld solving frequently crashes on Chrome if the worker pool size is greater than 24.
+const maxWorkers = SETTINGS.workersOverride ?? Math.min(24, Math.max((navigator.hardwareConcurrency || 4)), 4);
+export const WORKER_POOL: WorkerPool = new WorkerPool(1, maxWorkers);
 
 // Debugging
-window['workerPool'] = workerPool;
+window['workerPool'] = WORKER_POOL;


### PR DESCRIPTION
- Refactors worker pool.
- Only one worker is created by default. The rest are spun up as needed.
- Adds a secondary "simulateSimple" method to sims to provide a lighter-weight code path for when you do not care about anything other than the singular final DPS number (e.g. meld solving)
- Display total number of sets in solver modal
- Adds a "Ping worker" and some console debug things to allow you to check if the worker pool is functional
- Reconfigures `@typescript-eslint/no-unused-vars` to allow `_` to be used as an unused variable name.