### PR TITLE
Nq items

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,10 +72,13 @@ export default [
             "eqeqeq": "error",
             "no-var": "error",
             "@stylistic/js/indent": ["error", 4, {
-                "SwitchCase": 1,
+                SwitchCase: 1,
                 // This makes it ignore continuation indents for when a long class declaration (e.g. lots of
                 // 'implements') causes it to wrap to a second line.
-                "ignoredNodes": ["ClassDeclaration"],
+                ignoredNodes: ["ClassDeclaration"],
+                FunctionExpression: {
+                    parameters: "first"
+                }
             }],
             "prefer-const": "error",
             "camelcase": "error",

--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -20,6 +20,7 @@ import {RawStatsPart} from "@xivgear/util/types";
 
 export class CustomItem implements GearItem {
 
+    isNqVersion: boolean = false;
     unsyncedVersion: GearItem = this;
     isCustomRelic: boolean = false;
     isSyncedDown: boolean = false;

--- a/packages/core/src/datamanager.ts
+++ b/packages/core/src/datamanager.ts
@@ -29,7 +29,7 @@ export interface DataManager {
     readonly ilvlSync: number;
     readonly level: number;
 
-    itemById(id: number): GearItem | undefined;
+    itemById(id: number, forceNq?: boolean): GearItem | undefined;
 
     materiaById(id: number): Materia | undefined;
 

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -543,6 +543,9 @@ export class GearPlanSheet {
                 if (inSlot.relicStats && Object.entries(inSlot.relicStats)) {
                     exportedItem.relicStats = {...inSlot.relicStats};
                 }
+                if (inSlot.gearItem.isNqVersion) {
+                    exportedItem.forceNq = true;
+                }
                 items[equipmentKey] = exportedItem;
             }
         }
@@ -575,13 +578,13 @@ export class GearPlanSheet {
         return out;
     }
 
-    itemById(id: number): GearItem {
+    itemById(id: number, forceNq: boolean = false): GearItem {
         const custom = this._customItems.find(ci => ci.id === id);
         if (custom) {
             return custom;
         }
         else {
-            return this.dataManager.itemById(id);
+            return this.dataManager.itemById(id, forceNq);
         }
     }
 
@@ -682,7 +685,7 @@ export class GearPlanSheet {
                 if (!importedItem) {
                     continue;
                 }
-                const baseItem = this.itemById(importedItem.id);
+                const baseItem = this.itemById(importedItem.id, importedItem.forceNq);
                 if (!baseItem) {
                     continue;
                 }
@@ -855,11 +858,13 @@ export class GearPlanSheet {
     }
 
     get itemsForDisplay(): GearItem[] {
+        const settings = this._itemDisplaySettings;
         return [
             ...this.dataManager.allItems.filter(item => {
-                return item.ilvl >= this._itemDisplaySettings.minILvl
-                    && (item.ilvl <= this._itemDisplaySettings.maxILvl
-                        || item.isCustomRelic && this._itemDisplaySettings.higherRelics);
+                return item.ilvl >= settings.minILvl
+                    && (item.ilvl <= settings.maxILvl
+                        || item.isCustomRelic && settings.higherRelics)
+                    && (!item.isNqVersion || settings.showNq);
             }),
             ...this._customItems];
     }

--- a/packages/core/src/workers/worker_utils.ts
+++ b/packages/core/src/workers/worker_utils.ts
@@ -20,6 +20,7 @@ export function setToMicroExport(set: CharacterGearSet): MicroSetExport {
                     // TODO: determine if it makes more sense to just serialize empty materia slots as {}
                     // The advantage is that {} is a lot smaller than {"id":-1}, and exports are already long
                     // On the other hand, *most* real exports would have slots filled (BiS etc)
+                    // To indicate NQ items, add .5 to the item ID
                     inSlot.gearItem.id,
                     "relic",
                     (inSlot.relicStats && Object.entries(inSlot.relicStats)) ? {...inSlot.relicStats} : null,
@@ -33,7 +34,7 @@ export function setToMicroExport(set: CharacterGearSet): MicroSetExport {
                     // TODO: determine if it makes more sense to just serialize empty materia slots as {}
                     // The advantage is that {} is a lot smaller than {"id":-1}, and exports are already long
                     // On the other hand, *most* real exports would have slots filled (BiS etc)
-                    inSlot.gearItem.id,
+                    inSlot.gearItem.id + (inSlot.gearItem.isNqVersion ? 0.5 : 0),
                     ...inSlot.melds.map(meld => {
                         return meld.equippedMateria?.id ?? null;
                     }),
@@ -65,10 +66,21 @@ export function microExportToFullExport(s: MicroSetExport): SetExport {
                 };
             }
             else {
-                fakeItemsImport[slotName] = {
-                    id: s[1],
-                    materia: s.slice(2).map(m => ({id: (m as number) ?? -1})),
-                };
+                const itemIdRaw = s[1];
+                const mod = itemIdRaw % 1;
+                if (mod !== 0) {
+                    fakeItemsImport[slotName] = {
+                        id: Math.floor(s[1]),
+                        forceNq: true,
+                        materia: s.slice(2).map(m => ({id: (m as number) ?? -1})),
+                    };
+                }
+                else {
+                    fakeItemsImport[slotName] = {
+                        id: s[1],
+                        materia: s.slice(2).map(m => ({id: (m as number) ?? -1})),
+                    };
+                }
             }
         }
     });

--- a/packages/frontend/src/scripts/components/gear_edit_toolbar.ts
+++ b/packages/frontend/src/scripts/components/gear_edit_toolbar.ts
@@ -3,18 +3,24 @@ import {ItemDisplaySettings, MateriaAutoFillController} from "@xivgear/xivmath/g
 import {MateriaPriorityPicker} from "./materia";
 import {StatTierDisplay} from "./stat_tier_display";
 import {CharacterGearSet} from "@xivgear/core/gear";
-import {makeActionButton, redoIcon, undoIcon} from "@xivgear/common-ui/components/util";
+import {
+    FieldBoundCheckBox,
+    labeledCheckbox,
+    makeActionButton,
+    redoIcon,
+    undoIcon
+} from "@xivgear/common-ui/components/util";
 import {GearPlanSheetGui} from "./sheet";
 import {recordSheetEvent} from "../analytics/analytics";
 import {recordEvent} from "@xivgear/common-ui/analytics/analytics";
 
-function makeIlvlArea(
+function makeGearFiltersArea(
     sheet: GearPlanSheetGui,
     itemDisplaySettings: ItemDisplaySettings,
     displayUpdateCallback: () => void
 ) {
-    const ilvlDiv = document.createElement('div');
-    ilvlDiv.classList.add('ilvl-picker-area');
+    const filtersDiv = document.createElement('div');
+    filtersDiv.classList.add('ilvl-picker-area');
     const itemIlvlRange = new ILvlRangePicker(itemDisplaySettings, 'minILvl', 'maxILvl', 'Gear:');
     itemIlvlRange.addListener(displayUpdateCallback);
     itemIlvlRange.addListener((min, max) => {
@@ -23,7 +29,7 @@ function makeIlvlArea(
             max: max,
         });
     });
-    ilvlDiv.appendChild(itemIlvlRange);
+    filtersDiv.appendChild(itemIlvlRange);
 
     const foodIlvlRange = new ILvlRangePicker(itemDisplaySettings, 'minILvlFood', 'maxILvlFood', 'Food:');
     foodIlvlRange.addListener(displayUpdateCallback);
@@ -33,8 +39,14 @@ function makeIlvlArea(
             max: max,
         });
     });
-    ilvlDiv.appendChild(foodIlvlRange);
-    return ilvlDiv;
+    filtersDiv.appendChild(foodIlvlRange);
+
+    const nqCb = new FieldBoundCheckBox(itemDisplaySettings, 'showNq', {
+        id: 'show-nq-cb',
+    });
+    const nqCbWithLabel = labeledCheckbox('Show NQ Items', nqCb);
+    filtersDiv.appendChild(nqCbWithLabel);
+    return filtersDiv;
 }
 
 let currentToolbarPopout: HTMLElement | null = null;
@@ -150,9 +162,9 @@ export class GearEditToolbar extends HTMLDivElement {
     private buttonsArea: ToolbarButtonsArea;
 
     constructor(sheet: GearPlanSheetGui,
-        itemDisplaySettings: ItemDisplaySettings,
-        displayUpdateCallback: () => void,
-        matFillCtrl: MateriaAutoFillController
+                itemDisplaySettings: ItemDisplaySettings,
+                displayUpdateCallback: () => void,
+                matFillCtrl: MateriaAutoFillController
     ) {
         super();
         this.classList.add('gear-set-editor-toolbar');
@@ -164,7 +176,7 @@ export class GearEditToolbar extends HTMLDivElement {
 
         this.buttonsArea = new ToolbarButtonsArea();
 
-        const ilvlDiv = makeIlvlArea(sheet, itemDisplaySettings, displayUpdateCallback);
+        const ilvlDiv = makeGearFiltersArea(sheet, itemDisplaySettings, displayUpdateCallback);
         this.buttonsArea.addPanelButton(["Gear", document.createElement('br'), "Filters"], ilvlDiv);
 
         this.appendChild(this.buttonsArea);

--- a/packages/i18n/src/translation.ts
+++ b/packages/i18n/src/translation.ts
@@ -60,6 +60,20 @@ class TranslatableImpl implements TranslatableString {
 
 }
 
-export function toTranslatable(defaultValue: string, data: Partial<TranslatableString> = {}): TranslatableString {
-    return new TranslatableImpl(defaultValue, data);
+export function toTranslatable(defaultValue: string, data: Partial<TranslatableString> = {}, mapper?: (input: string) => string): TranslatableString {
+    if (mapper) {
+        const adjustedData: typeof data = {};
+        Object.entries(data).forEach(([key, value]) => {
+            if (typeof value === 'string') {
+                adjustedData[key as keyof TranslationData] = mapper(value);
+            }
+            else {
+                adjustedData[key as keyof TranslationData] = value;
+            }
+        });
+        return new TranslatableImpl(mapper(defaultValue), adjustedData);
+    }
+    else {
+        return new TranslatableImpl(defaultValue, data);
+    }
 }

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -1140,13 +1140,16 @@ MicroSetExport has a single TypedArray, where we store items in a flat structure
 e.g. [slot1slotId, slot1itemId, slot1materiaCount, slot1materia1id, ... slot1materiaNid, slot2slotId, ... etc]
 Could even take it a step further and pack multiple sets into one big array.
  */
+
 /**
  * MicroSetExport is a minimal analog to {@link SetExport} which contains the bare minimum information
- * needed for brute force solving. This is useful for reducing memory usage.
+ * needed for brute force solving. This is useful for reducing memory usage. These are meant to be very dense in
+ * terms of memory, so they use hacks like adding 0.5 to item IDs to signify an NQ item.
  */
 export type MicroSetExport = MicroSlotExport[];
 
 export type FoodMicroSlotExport = [slot: "food", foodId: number];
+// The itemId in this case has 0.5 added to it to indicate an NQ item
 export type NormalItemMicroSlotExport = [slot: EquipSlotKey, itemId: number, ...materiaIds: (number | null)[]];
 export type RelicItemMicroSlotExport = [slot: EquipSlotKey, itemId: number, "relic", relicStats: RelicStatsExport];
 export type MicroSlotExport = FoodMicroSlotExport | NormalItemMicroSlotExport | RelicItemMicroSlotExport;

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -196,6 +196,7 @@ export interface GearItem extends XivCombatItem {
     isUnique: boolean;
     acquisitionType: GearAcquisitionSource;
     relicStatModel: RelicStatModel | undefined;
+    isNqVersion: boolean;
 }
 
 export interface FoodStatBonus {
@@ -880,6 +881,10 @@ export interface ItemSlotExport {
      * If this is a relic, represents the current stats of the relic.
      */
     relicStats?: RelicStatsExport,
+    /**
+     * Force this to be an NQ item instead of HQ if available.
+     */
+    forceNq?: boolean,
 }
 
 export type RelicStatsExport = {
@@ -915,7 +920,8 @@ export interface ItemDisplaySettings {
     maxILvl: number,
     minILvlFood: number,
     maxILvlFood: number,
-    higherRelics: boolean
+    higherRelics: boolean,
+    showNq: boolean,
 }
 
 export const AttackTypes = ['Unknown', 'Auto-attack', 'Spell', 'Weaponskill', 'Ability', 'Item'] as const;

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -531,6 +531,12 @@ export const LEVEL_STATS: Record<SupportedLevel, LevelStats> = {
     },
 };
 
+const defaultItemDispBase = {
+    showNq: false,
+    higherRelics: true,
+    maxILvlFood: 999,
+} as const satisfies Partial<ItemDisplaySettings>;
+
 /**
  * Numbers governing the minimum/maximum item levels to request from xivapi, as well as default display settings.
  */
@@ -546,11 +552,10 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
         minMateria: 5,
         maxMateria: 6,
         defaultDisplaySettings: {
+            ...defaultItemDispBase,
             minILvl: 380,
             maxILvl: 405,
             minILvlFood: 640,
-            maxILvlFood: 999,
-            higherRelics: true,
         },
     },
     80: {
@@ -562,6 +567,7 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
         minMateria: 7,
         maxMateria: 8,
         defaultDisplaySettings: {
+            ...defaultItemDispBase,
             // Defaults appropriate for TEA since it is the most common reason to be making
             // a level 80 gear set.
             // There is a BLU-specific override since BLU's only level 80 weapons are 530,
@@ -569,8 +575,6 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
             minILvl: 450,
             maxILvl: 475,
             minILvlFood: 640,
-            maxILvlFood: 999,
-            higherRelics: true,
         },
     },
     // DAWNTRAIL TODO: cap off level 90 items
@@ -584,11 +588,10 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
         minMateria: 7,
         maxMateria: 10,
         defaultDisplaySettings: {
+            ...defaultItemDispBase,
             minILvl: 640,
             maxILvl: 999,
             minILvlFood: 640,
-            maxILvlFood: 999,
-            higherRelics: true,
         },
     },
     100: {
@@ -599,12 +602,11 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
         minMateria: 9,
         maxMateria: 12,
         defaultDisplaySettings: {
+            ...defaultItemDispBase,
             // Raise this when more gear is available
             minILvl: 680,
             maxILvl: 999,
             minILvlFood: 670,
-            maxILvlFood: 999,
-            higherRelics: true,
         },
     },
 };
@@ -874,6 +876,7 @@ export const defaultItemDisplaySettings: ItemDisplaySettings = {
     minILvlFood: 610,
     maxILvlFood: 999,
     higherRelics: true,
+    showNq: false,
 } as const;
 
 export const MAX_PARTY_BONUS: PartyBonusAmount = 5;


### PR DESCRIPTION
PR is a bit scuffed since I pushed to the wrong branch initially and can't undo it with a force push, so I had to make a dummy branch to allow comparison.

The API already exposes the NQ data, it just wasn't used anywhere.

- Add toggle to allow NQ items to be shown
- Add fields to the exported version of a set to indicate that an item is NQ
- Expose NQ items via DataManager
- Plumb NQ item export into Micro Exports for solver
- Fix an eslint rule that was disalloweding aligned arguments on functions

Closes #484 