### PR TITLE
Always show level in sync info it item level is synced

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,15 @@
       "name": "gearplan",
       "version": "1.0.0",
       "workspaces": [
+        "packages/util",
+        "packages/i18n",
+        "packages/data-api-client",
         "packages/xivmath",
         "packages/core",
+        "packages/backend-resolver",
         "packages/common-ui",
         "packages/frontend",
-        "packages/math-frontend",
-        "packages/backend-resolver",
-        "packages/data-api-client",
-        "packages/i18n",
-        "packages/util"
+        "packages/math-frontend"
       ],
       "devDependencies": {
         "@eslint/js": "^9.13.0",
@@ -29,6 +29,7 @@
         "nyc": "^17.1.0",
         "swagger-typescript-api": "^13.0.22",
         "ts-node": "^10.9.2",
+        "tsconfig-paths-webpack-plugin": "^4.2.0",
         "typescript": "^5.6.3",
         "typescript-eslint": "^8.10.0",
         "webpack-dev-server": "^5.1.0"
@@ -12769,19 +12770,10 @@
     "packages/backend-resolver": {
       "name": "@xivgear/backend-resolver",
       "version": "1.0.0",
-      "bundleDependencies": [
-        "@xivgear/gearplan-frontend",
-        "fastify",
-        "global-jsdom",
-        "isomorphic-fetch",
-        "jsdom",
-        "node-fetch-cache",
-        "npm-bundle",
-        "fastify-web-response"
-      ],
       "dependencies": {
         "@fastify/cors": "8.5.0",
-        "@xivgear/gearplan-frontend": "1.0.0",
+        "@xivgear/core": "1.0.0",
+        "@xivgear/xivmath": "1.0.0",
         "fastify": "^4.26.2",
         "fastify-web-response": "^0.1.2",
         "global-jsdom": "^25.0.0",
@@ -12801,7 +12793,8 @@
       "name": "@xivgear/common-ui",
       "version": "1.0.0",
       "dependencies": {
-        "@xivgear/core": "^1.0.0"
+        "@xivgear/core": "^1.0.0",
+        "@xivgear/i18n": "^1.0.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.16",
@@ -12815,7 +12808,10 @@
       "name": "@xivgear/core",
       "version": "1.0.0",
       "dependencies": {
-        "@xivgear/data-api-client": "^1.0.0"
+        "@xivgear/data-api-client": "^1.0.0",
+        "@xivgear/i18n": "^1.0.0",
+        "@xivgear/util": "^1.0.0",
+        "@xivgear/xivmath": "^1.0.0"
       },
       "devDependencies": {
         "@types/chai": "^4.3.16",
@@ -12899,9 +12895,6 @@
     "packages/util": {
       "name": "@xivgear/util",
       "version": "1.0.0",
-      "dependencies": {
-        "@xivgear/data-api-client": "^1.0.0"
-      },
       "devDependencies": {
         "@types/chai": "^4.3.16",
         "@types/jsdom": "^21.1.3",
@@ -12922,8 +12915,7 @@
         "chai": "^4.5.0",
         "ts-loader": "^9.5.1",
         "ts-mocha": "^10.0.0",
-        "ts-node": "^10.9.2",
-        "tsconfig-paths-webpack-plugin": "^4.2.0"
+        "ts-node": "^10.9.2"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "http-server": "^14.1.1",
     "nyc": "^17.1.0",
     "swagger-typescript-api": "^13.0.22",
+    "tsconfig-paths-webpack-plugin": "^4.2.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.6.3",
     "typescript-eslint": "^8.10.0",

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -49,7 +49,8 @@ import {
     MAX_PARTY_BONUS,
     RACE_STATS,
     RaceName,
-    STAT_ABBREVIATIONS
+    STAT_ABBREVIATIONS,
+    SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
 import {getCurrentHash, getCurrentState} from "../nav_hash";
 import {MateriaTotalsDisplay} from "./materia";
@@ -1468,7 +1469,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
             buttonsArea.appendChild(sheetOptions);
         }
 
-        const siFmt = formatSyncInfo(this.syncInfo);
+        const siFmt = formatSyncInfo(this.syncInfo, this.level);
         if (siFmt !== null) {
             const span = quickElement('span', [], [siFmt]);
             const ilvlSyncLabel = quickElement('div', ['like-a-button'], [span]);
@@ -2256,13 +2257,18 @@ export class GraphicalSheetProvider extends SheetProvider<GearPlanSheetGui> {
     }
 }
 
-function formatSyncInfo(si: SyncInfo): string | null {
+function formatSyncInfo(si: SyncInfo, level: SupportedLevel): string | null {
     const isIlvlSynced = si.ilvlSync !== null;
     const isLvlSynced = si.lvlSync !== null;
     if (isIlvlSynced || isLvlSynced) {
         let text = 'Sync: ';
         if (isLvlSynced) {
             text += `lv${si.lvlSync} `;
+        }
+        // If level sync isn't explicitly set, show the level anyway
+        // if item level sync is present in any way to avoid confusion.
+        else if (si.ilvlSync !== null) {
+            text += `lv${level} `;
         }
         if (si.ilvlSync !== null) {
             if (si.ilvlSyncIsExplicit) {


### PR DESCRIPTION
This will always show level in the sync info if the item level is synced. Mostly, this helps prevents silly mistakes like forgetting to sync level and makes everything a lot more explicit, so I think this is generally a positive improvement. I think future work would include making 'strange' syncs' warn users, but I think this is a positive even in that world.

![image](https://github.com/user-attachments/assets/5631e425-0f0c-40ae-8229-ed3720969d45)

(Works in view mode too)

`tsconfig-paths-webpack-plugin` seems to be required to build, and it wasn't present in a package.json (npm install didn't install it) so I added it.