### PR TITLE
Add monk 7.2 potency bumps

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -560,7 +560,7 @@ export const WindsReply: MnkGcdAbility = {
     type: 'gcd',
     attackType: 'Weaponskill',
     gcd: 2.5,
-    potency: 900,
+    potency: 1040,
 };
 export const FiresReply: MnkGcdAbility = {
     name: "Fire's Reply",
@@ -568,7 +568,7 @@ export const FiresReply: MnkGcdAbility = {
     type: 'gcd',
     attackType: 'Weaponskill',
     gcd: 2.5,
-    potency: 1200,
+    potency: 1400,
     activatesBuffs: [FormlessFist],
 };
 


### PR DESCRIPTION
Wind's Reply
	Potency has been increased from 900 to 1,040.
Reduction in potency after the first target has been changed from 50% to 40%.
Fire's Reply
		Potency has been increased from 1,200 to 1,400.
Reduction in potency after the first target has been changed from 50% to 40%.