### PR TITLE
Have MNK sim run full simulation when simulateSimple is called

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -439,6 +439,16 @@ export class MnkSim extends BaseMultiCycleSim<CycleSimResult, MnkSettings, MNKCy
     }
 
     /**
+     * It is rotationally important for monk abilities to be recorded with all of their buffs, and simulateSimple
+     * doesn't store those for other sims as an optimization. We don't get that optimization.
+     * This is because chakra gain is important to our DPS, and at the time of writing this is only recorded based
+     * on the Buffs that are snapshotted in addAbilityUse.
+     */
+    override async simulateSimple(set: CharacterGearSet): Promise<number> {
+        return (await this.simulate(set)).mainDpsResult;
+    }
+
+    /**
      * Because monk has a probabilistic chakra generation, the rotation changes due to crit chance.
      * Preserving crit chance at the same GCD tier leads to inaccurate DPS estimates.
      * This means monk sim doesn't get to use the cache behavior much at all.


### PR DESCRIPTION
Because the sim needs to inspect the buffs recorded on each ability that is used, the `simpleMode` CycleProcessor cannot be used or the meld solver may generate the incorrect result in some cases.

Without the buffs, we can't estimate chakra gain properly, and so the meld solver's simmed DPS will differ wildly from the full simulation's DPS.