### PR TITLE
Add new default-on option to ignore Gunbreaker Gnashing Fang microclips

### DIFF
--- a/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
@@ -342,8 +342,8 @@ export class GnbSim extends BaseMultiCycleSim<GnbSimResult, GnbSettings, GnbCycl
             return false;
         }
 
-        // (gcdSpeed / 12) is the potential amount it could be delayed by.
-        const shouldUseGCD = relativeCooldown === 0  || relativeCooldown <= (gcdSpeed / 12);
+        // (gcdSpeed / 20) is the potential amount it could be delayed by.
+        const shouldUseGCD = relativeCooldown === 0  || relativeCooldown <= (gcdSpeed / 20);
         if (shouldUseGCD) {
             // We are microclipping
             if (relativeCooldown > 0) {

--- a/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
@@ -348,7 +348,8 @@ export class GnbSim extends BaseMultiCycleSim<GnbSimResult, GnbSettings, GnbCycl
             // We are microclipping
             if (relativeCooldown > 0) {
                 // If we pretend that microclips don't exist and we have perfect
-                // alignment, we will simply use Gnashing Fang early. Otherwise,
+                // alignment, we will simply use Gnashing Fang before it comes off cooldown,
+                // essentially pretending that the SkS scaling is the same. Otherwise,
                 // we should microclip so that Gnashing Fang and Double Down
                 // do not drift.
                 if (!this.settings.pretendThatMicroclipsDontExist) {

--- a/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
@@ -104,6 +104,10 @@ export class GnbSimGui extends BaseMultiCycleSimGui<GnbSimResult, GnbSettings> {
         const potCb = new FieldBoundCheckBox(settings, "usePotion");
 
         configDiv.appendChild(labeledCheckbox("Use Potion", potCb));
+
+        const pretendMicroclipsDontExistCB = new FieldBoundCheckBox(settings, "pretendThatMicroclipsDontExist");
+
+        configDiv.appendChild(labeledCheckbox("Assume that Gnashing Fang microclips don't exist", pretendMicroclipsDontExistCB));
         return configDiv;
     }
 


### PR DESCRIPTION
The current sim will microclip (as expected) for Gunbreaker, i.e. intentionally clip its GCD due to the weird scaling of Gnashing Fang. This isn't 'incorrect' per se, because gaining more of a GCD is better in a vacuum, but the killtime dependency means that, practically, comparing sets at different speeds means the sim results show more value in SkS melds than it probably should.

This might feel like a bit of an ugly solution, but to me it feels like the right one (I first tried the opposite approach, being pessimistic and making all microclips as bad as possible). Due to the fact that FPS/ping/etc exists, this more closely matches the reality of playing the job (i.e. 2.50's fps/ping tax is just raw clipping whereas 2.45s will eat into the microclip and not be as bad as the sim shows), and values things a lot more sensibly for the purposes of comparing gearsets, which is what the sim is for, first and foremost. 

Example (note that the sets are higher than prod because of grade 3 gemdraught):
The first copy of 2.45 has a crit meld removed.
The second copy has a SkS meld added, it has slightly higher DPS (due to auto attack scaling) but not as much as it would have otherwise gained, and not more than a normal meld.
![image](https://github.com/user-attachments/assets/f3ecc128-bd7d-45b2-b398-600a2b38a3a3)
