### PR TITLE
Materia improvements

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1394,6 +1394,9 @@ slot-materia-manager.editable:hover {
 
 slot-materia-manager {
   cursor: pointer;
+  slot-materia-popup {
+    cursor: unset;
+  }
 }
 
 slot-materia-manager, single-materia-view-only {
@@ -1432,6 +1435,10 @@ slot-materia-manager, single-materia-view-only {
     width: 100%;
     height: 100%;
     display: block;
+  }
+
+  &.materia-slot-locked {
+    box-shadow: 0 0 2px 2px #777 inset;
   }
 
   &.materia-manager-active {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1395,6 +1395,7 @@ slot-materia-manager.editable:hover {
 
 slot-materia-manager {
   cursor: pointer;
+
   slot-materia-popup {
     cursor: unset;
   }
@@ -1989,6 +1990,11 @@ div.gear-set-editor-toolbar, set-view-toolbar {
 
       // When a drag is active, THIS needs to be the target of pointer events so that
       // the math works right.
+    }
+
+    .meld-solver-tips {
+      width: 200px;
+      padding: 5px;
     }
   }
 

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -3565,4 +3565,9 @@ input {
   border: none !important;
 }
 
+button.narrow-button {
+  width: min-content;
+  height: fit-content;
+}
+
 @import 'gauge.less';

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -22,6 +22,7 @@ import {
     ItemDisplaySettings,
     ItemSlotExport,
     JobData,
+    JobDataConst,
     Materia,
     MateriaAutoFillController,
     MateriaAutoFillPrio,
@@ -55,6 +56,9 @@ import {isMateriaAllowed} from "./materia/materia_utils";
 export type SheetCtorArgs = ConstructorParameters<typeof GearPlanSheet>
 export type SheetContstructor<SheetType extends GearPlanSheet> = (...values: SheetCtorArgs) => SheetType;
 
+/**
+ * SheetProvider is the base class for turning sheet exports or fresh sheets into rehydrated sheet objects.
+ */
 export class SheetProvider<SheetType extends GearPlanSheet> {
 
     constructor(private readonly sheetConstructor: SheetContstructor<SheetType>) {
@@ -64,10 +68,20 @@ export class SheetProvider<SheetType extends GearPlanSheet> {
         return this.sheetConstructor(...args);
     }
 
+    /**
+     * Produce a sheet from a SheetExport
+     *
+     * @param importedData
+     */
     fromExport(importedData: SheetExport): SheetType {
         return this.construct(undefined, importedData);
     }
 
+    /**
+     * Produce a sheet from a single-set export.
+     *
+     * @param importedData
+     */
     fromSetExport(...importedData: SetExportExternalSingle[]): SheetType {
         if (importedData.length === 0) {
             throw Error("Imported sets cannot be be empty");
@@ -95,6 +109,15 @@ export class SheetProvider<SheetType extends GearPlanSheet> {
         return gearPlanSheet;
     }
 
+    /**
+     * Create a new sheet from scratch
+     *
+     * @param sheetKey The save key for the sheet
+     * @param sheetName The name of the sheet
+     * @param classJob The class/job of the sheet
+     * @param level The level of the sheet
+     * @param ilvlSync The ilvl sync of the sheet, or undefined if the sheet should not have an ilvl sync.
+     */
     fromScratch(sheetKey: string, sheetName: string, classJob: JobName, level: SupportedLevel, ilvlSync: number | undefined): SheetType {
         const fakeExport: SheetExport = {
             job: classJob,
@@ -143,6 +166,9 @@ function loadSaved(sheetKey: string): SheetExport | null {
     }
 }
 
+/**
+ * Base class for a sheet. For graphical usage, see GearPlanSheetGui.
+ */
 export class GearPlanSheet {
     // General sheet properties
     _sheetName: string;
@@ -237,10 +263,16 @@ export class GearPlanSheet {
         this.saveTimer = new Inactivitytimer(1_000, () => this.saveData());
     }
 
+    /**
+     * The key under which this sheet should be saved in LocalStorage.
+     */
     get saveKey() {
         return this._saveKey;
     }
 
+    /**
+     * Whether to show advanced stats.
+     */
     get showAdvancedStats() {
         return this._showAdvancedStats;
     }
@@ -249,15 +281,25 @@ export class GearPlanSheet {
         this._showAdvancedStats = show;
     }
 
+    /**
+     * Whether setup/loading is done.
+     */
     get setupDone() {
         return this._setupDone;
     }
 
+    /**
+     * Whether this sheet is in view-only mode.
+     */
     get isViewOnly() {
         return this._isViewOnly;
     }
 
-    // Does not actually support any filling since the top-level sheet does not support selection
+    /**
+     * The materia autofill controller for this sheet.
+     *
+     * This only has a real implementation in GearPlanSheetGui, since materia autofilling is a gui-only feature.
+     */
     get materiaAutoFillController(): MateriaAutoFillController {
         const outer = this;
         return {
@@ -280,23 +322,44 @@ export class GearPlanSheet {
             fillEmpty(): void {
                 console.log('fillEmpty not implemented');
             },
-            refreshOnly(): void {
-                console.log('nothing to refresh');
+            lockEmpty(): void {
+                console.log('lockEmpty not implemented');
+            },
+            lockFilled(): void {
+                console.log('lockFilled not implemented');
+            },
+            unequipUnlocked(): void {
+                console.log('unequipUnlocked not implemented');
+            },
+            unlockAll(): void {
+                console.log('unlockAll not implemented');
             },
 
         };
     }
 
+    /**
+     * Enable view-only mode. Cannot be disabled once enabled.
+     */
     setViewOnly() {
         this._isViewOnly = true;
     }
 
+    /**
+     * Load the sheet data fully. Create a DataManager internally.
+     */
     async load() {
         const dataManager = makeDataManager(this.classJobName, this.level, this.ilvlSync);
         await dataManager.loadData();
         await this.loadFromDataManager(dataManager);
     }
 
+    /**
+     * Load the sheet data from a DataManager. The DataManager must already be loaded before calling this method.
+     * This can be used for things like meld solving, where a worker can load a DM once and then re-use it.
+     *
+     * @param dataManager The DataManager to use.
+     */
     async loadFromDataManager(dataManager: DataManager) {
         console.log("Loading sheet...");
         console.log("Reading data");
@@ -338,6 +401,9 @@ export class GearPlanSheet {
         this.recheckCustomItems();
     }
 
+    /**
+     * Save data for this sheet now.
+     */
     saveData() {
         if (!this.setupDone) {
             // Don't clobber a save with empty data because the sheet hasn't loaded!
@@ -353,10 +419,18 @@ export class GearPlanSheet {
         }
     }
 
+    /**
+     * Request a save to be completed asynchronously. The actual save is only performed once no more requestSave() calls
+     * have happened for a certain timeout, thus allowing multiple modifications to be coalesced into a single save
+     * operation.
+     */
     requestSave() {
         this.saveTimer.ping();
     }
 
+    /**
+     * The name of the sheet.
+     */
     get sheetName() {
         return this._sheetName;
     }
@@ -366,6 +440,9 @@ export class GearPlanSheet {
         this.requestSave();
     }
 
+    /**
+     * The description of the sheet.
+     */
     get description() {
         return this._description;
     }
@@ -417,6 +494,14 @@ export class GearPlanSheet {
     exportSheet(external: boolean, fullStats: false): SheetExport;
     exportSheet(external: boolean, fullStats: true): SheetStatsExport;
 
+    /**
+     * Export the sheet to serialized form.
+     *
+     * @param external  Whether this is an external (shared publicly) or internal (saved locally). Certain properties,
+     * such as the save key, are not useful for external exports, so they are omitted.
+     * @param fullStats Whether to include the computedStats in the result. If true, returns SheetStatsExport instead
+     * of the plain SheetExport.
+     */
     exportSheet(external: boolean = false, fullStats: boolean = false): SheetExport | SheetStatsExport {
         const sets = this._sets.map(set => {
             const rawExport = this.exportGearSet(set, false);
@@ -454,6 +539,12 @@ export class GearPlanSheet {
 
     }
 
+    /**
+     * Add a new gear set.
+     *
+     * @param gearSet The set to add.
+     * @param index The index at which to insert the set. If omitted, it is added to the end.
+     */
     addGearSet(gearSet: CharacterGearSet, index?: number) {
         if (index === undefined) {
             this._sets.push(gearSet);
@@ -467,11 +558,22 @@ export class GearPlanSheet {
         this.saveData();
     }
 
+    /**
+     * Delete a gear set.
+     *
+     * @param gearSet
+     */
     delGearSet(gearSet: CharacterGearSet) {
         this._sets = this._sets.filter(gs => gs !== gearSet);
         this.saveData();
     }
 
+    /**
+     * Move a gear set to a new index.
+     *
+     * @param gearSet The set to move.
+     * @param to      The index to which the gearset should be re-ordered.
+     */
     reorderSet(gearSet: CharacterGearSet, to: number) {
         const sets = [...this._sets];
         const from = sets.indexOf(gearSet);
@@ -501,6 +603,12 @@ export class GearPlanSheet {
         this.addGearSet(cloned, toIndex);
     }
 
+    /**
+     * Determine the placement index for a cloned set. Helper method of {@link #cloneAndAddGearSet}.
+     *
+     * @param originalSet The set being cloned.
+     * @protected
+     */
     protected clonedSetPlacement(originalSet: CharacterGearSet): number | undefined {
         const originalIndex = this.sets.indexOf(originalSet);
         if (originalIndex >= 0) {
@@ -581,6 +689,12 @@ export class GearPlanSheet {
         return out;
     }
 
+    /**
+     * Return an item from the DataManager by its ID. Returns undefined if the item could not be found.
+     *
+     * @param id The item ID. For custom items, use the custom item's fake ID.
+     * @param forceNq If true, searches for an NQ version of an otherwise-HQ item.
+     */
     itemById(id: number, forceNq: boolean = false): GearItem {
         const custom = this._customItems.find(ci => ci.id === id);
         if (custom) {
@@ -591,6 +705,11 @@ export class GearPlanSheet {
         }
     }
 
+    /**
+     * Return a food item from the DataManager by its ID. Returns undefined if the item could not be found.
+     *
+     * @param id The item IJD. FOr custom items, use the custom item's fake ID.
+     */
     foodById(id: number): FoodItem {
         const custom = this._customFoods.find(cf => cf.id === id);
         if (custom) {
@@ -601,10 +720,19 @@ export class GearPlanSheet {
         }
     }
 
+    /**
+     * Return the ilvl sync info for a particular level.
+     *
+     * @param ilvl
+     */
     ilvlSyncInfo(ilvl: number): IlvlSyncInfo | undefined {
         return this.dataManager?.getIlvlSyncInfo(ilvl);
     }
 
+    /**
+     * Get the next free custom item ID.
+     * @private
+     */
     private get nextCustomItemId() {
         if (this._customItems.length === 0) {
             return 10_000_000_000_000 + Math.floor(Math.random() * 1_000_000);
@@ -614,6 +742,10 @@ export class GearPlanSheet {
         }
     }
 
+    /**
+     * Returns the starting set of data for a new custom item.
+     * @param slot The slot for which to make the custom item.
+     */
     newCustomItem(slot: OccGearSlotKey): CustomItem {
         const item = CustomItem.fromScratch(this.nextCustomItemId, slot, this);
         this._customItems.push(item);
@@ -622,6 +754,9 @@ export class GearPlanSheet {
         return item;
     }
 
+    /**
+     * Returns the starting set of data for a new custom food.
+     */
     newCustomFood(): CustomFood {
         const food = CustomFood.fromScratch(this.nextCustomItemId);
         this._customFoods.push(food);
@@ -629,14 +764,28 @@ export class GearPlanSheet {
         return food;
     }
 
+    /**
+     * All custom items in this sheet.
+     */
     get customItems() {
         return [...this._customItems];
     }
 
+    /**
+     * All custom food items in this sheet.
+     */
     get customFood() {
         return [...this._customFoods];
     }
 
+    /**
+     * Delete the given custom item.
+     *
+     * Warning: currently DOES NOT check that the item is not equipped. Deleting an item while it is still equipped
+     * in one or more sets can cause undefined behavior!
+     *
+     * @param item The item to delete.
+     */
     deleteCustomItem(item: CustomItem) {
         // TODO: this should check if you have this item equipped on any sets, or ask
         const idx = this._customItems.indexOf(item);
@@ -647,6 +796,14 @@ export class GearPlanSheet {
         this.recalcAll();
     }
 
+    /**
+     * Delete the given custom food item.
+     *
+     * Warning: currently DOES NOT check that the item is not equipped. Deleting an item while it is still equipped
+     * in one or more sets can cause undefined behavior!
+     *
+     * @param item The food item to delete
+     */
     deleteCustomFood(item: CustomFood) {
         // TODO: this should check if you have this item equipped on any sets, or ask
         const idx = this._customFoods.indexOf(item);
@@ -656,6 +813,12 @@ export class GearPlanSheet {
         this.recalcAll();
     }
 
+    /**
+     * Import a sim from a sim export. Does not add it to the simulations - you still need to do that if you would like
+     * the sim to appear on the sheet (see {@link #addSim}).
+     *
+     * @param simExport The data to import.
+     */
     importSim(simExport: SimExport): Simulation<any, any, any> {
         const simSpec = getSimSpecByStub(simExport.stub);
         if (simSpec === undefined) {
@@ -754,20 +917,32 @@ export class GearPlanSheet {
         return out;
     }
 
+    /**
+     * Force a full recalc of every set. For example, this should be called after a custom item is edited, or
+     * after a race/party size change.
+     */
     recalcAll() {
         for (const set of this._sets) {
             set.forceRecalc();
         }
     }
 
-    get classJobStats() {
+    /**
+     * Get the class/job stats for the sheet's class/job.
+     */
+    get classJobStats(): JobData {
         return this.statsForJob(this.classJobName);
     }
 
-    private get classJobEarlyStats() {
+    private get classJobEarlyStats(): JobDataConst {
         return getClassJobStats(this.classJobName);
     }
 
+    /**
+     * Get the class/job stats for a different class/job.
+     *
+     * @param job
+     */
     statsForJob(job: JobName): JobData {
         return {
             ...getClassJobStats(job),
@@ -775,7 +950,11 @@ export class GearPlanSheet {
         };
     }
 
-    isStatRelevant(stat: RawStatKey) {
+    /**
+     * Determine whether a stat is relevant to this sheet based on its job.
+     * @param stat
+     */
+    isStatRelevant(stat: RawStatKey): boolean {
         if (!this.classJobEarlyStats) {
             // Not sure what the best way to handle this is
             return true;
@@ -791,14 +970,23 @@ export class GearPlanSheet {
         }
     }
 
+    /**
+     * Get sims which might be relevant to this sheet.
+     */
     get relevantSims() {
         return getRegisteredSimSpecs().filter(simSpec => simSpec.supportedJobs === undefined ? true : simSpec.supportedJobs.includes(this.dataManager.classJob));
     }
 
+    /**
+     * Get the currently-selected race's stats.
+     */
     get raceStats() {
         return getRaceStats(this._race);
     }
 
+    /**
+     * Get the currently-selected race.
+     */
     get race() {
         return this._race;
     }
@@ -808,32 +996,53 @@ export class GearPlanSheet {
         this.recalcAll();
     }
 
+    /**
+     * Get all sets on this sheet.
+     */
     get sets(): CharacterGearSet[] {
         return this._sets;
     }
 
+    /**
+     * Get all sims on this sheet.
+     */
     get sims(): Simulation<any, any, any>[] {
         return this._sims;
     }
 
+    /**
+     * Add a sim to this sheet.
+     *
+     * @param sim
+     */
     addSim(sim: Simulation<any, any, any>) {
         this._sims.push(sim);
         this.saveData();
     }
 
+    /**
+     * Delete a sim from this sheet.
+     *
+     * @param sim
+     */
     delSim(sim: Simulation<any, any, any>) {
         this._sims = this._sims.filter(s => s !== sim);
         this.saveData();
     }
 
-    get relevantFood(): FoodItem[] {
-        return [...this._dmRelevantFood, ...this._customFoods];
-    }
-
+    /**
+     * Get materia which are relevant to this sheet.
+     */
     get relevantMateria(): Materia[] {
         return this._relevantMateria;
     }
 
+    /**
+     * Get materia which are relevant within a specific slot. On top of needing to be class-relevant, it must fit
+     * in the slot.
+     *
+     * @param slot
+     */
     getRelevantMateriaFor(slot: MeldableMateriaSlot) {
         const materia = this._relevantMateria.filter(mat => mat.ilvl <= slot.materiaSlot.ilvl);
         // Sort materia from highest to lowest
@@ -857,6 +1066,9 @@ export class GearPlanSheet {
         return materia.filter(mat => mat.materiaGrade >= minDisplayGrade);
     }
 
+    /**
+     * Get the current party bonus amount.
+     */
     get partyBonus(): PartyBonusAmount {
         return this._partyBonus;
     }
@@ -866,6 +1078,10 @@ export class GearPlanSheet {
         this.recalcAll();
     }
 
+    /**
+     * Get all items which are relevant, and are not filtered out by display settings. Custom items are always displayed
+     * regardless of filtering.
+     */
     get itemsForDisplay(): GearItem[] {
         const settings = this._itemDisplaySettings;
         return [
@@ -878,18 +1094,34 @@ export class GearPlanSheet {
             ...this._customItems];
     }
 
+    /**
+     * Overridable hook for when gear display settings are updated.
+     */
     onGearDisplaySettingsUpdate() {
 
     }
 
+    /**
+     * The item display settings. Uses a proxy which automatically calls {@link #onGearDisplaySettingsUpdate} after
+     * any fields are modified.
+     */
     get itemDisplaySettings(): ItemDisplaySettings {
         return writeProxy(this._itemDisplaySettings, () => this.onGearDisplaySettingsUpdate());
     }
 
+    /**
+     * Food items which are relevant and pass the filter. Custom foods will be displayed regardless of filtering.
+     */
     get foodItemsForDisplay(): FoodItem[] {
         return [...this._dmRelevantFood.filter(item => item.ilvl >= this._itemDisplaySettings.minILvlFood && item.ilvl <= this._itemDisplaySettings.maxILvlFood), ...this._customFoods];
     }
 
+    /**
+     * Get the best possible materia for a particular slot of the given stat.
+     *
+     * @param stat
+     * @param meldSlot
+     */
     getBestMateria(stat: MateriaSubstat, meldSlot: MeldableMateriaSlot): Materia | undefined {
         const materiaFilter = (materia: Materia) => {
             return isMateriaAllowed(materia, meldSlot.materiaSlot) && materia.primaryStat === stat;
@@ -898,10 +1130,18 @@ export class GearPlanSheet {
         return sortedOptions.length >= 1 ? sortedOptions[0] : undefined;
     }
 
+    /**
+     * Retrieve a particular materia by its item ID. Returns undefined if the materia does not exist.
+     *
+     * @param materiaId
+     */
     getMateriaById(materiaId: number): Materia | undefined {
         return this.dataManager.materiaById(materiaId);
     }
 
+    /**
+     * Add any sims which are considered to be "default" sims for this class and level.
+     */
     addDefaultSims() {
         const sims = getDefaultSims(this.classJobName, this.level);
         for (const simSpec of sims) {
@@ -914,6 +1154,11 @@ export class GearPlanSheet {
         }
     }
 
+    /**
+     * Recompute custom item stats, and force a recalc of sets.
+     *
+     * This should be called after custom items are modified.
+     */
     recheckCustomItems() {
         for (const customItem of this._customItems) {
             customItem.recheckStats();
@@ -944,6 +1189,9 @@ export class GearPlanSheet {
         });
     }
 
+    /**
+     * Get the consolidated level/ilevel sync info.
+     */
     get syncInfo(): SyncInfo {
         const levelSync = this.level === CURRENT_MAX_LEVEL ? null : this.level;
         const explicitIlvlSync = this.ilvlSync ?? null;

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -537,7 +537,10 @@ export class GearPlanSheet {
                     // On the other hand, *most* real exports would have slots filled (BiS etc)
                     id: inSlot.gearItem.id,
                     materia: inSlot.melds.map(meld => {
-                        return {id: meld.equippedMateria?.id ?? -1};
+                        return {
+                            id: meld.equippedMateria?.id ?? -1,
+                            locked: meld.locked,
+                        };
                     }),
                 };
                 if (inSlot.relicStats && Object.entries(inSlot.relicStats)) {
@@ -691,12 +694,18 @@ export class GearPlanSheet {
                 }
                 const equipped = new EquippedItem(baseItem);
                 for (let i = 0; i < Math.min(equipped.melds.length, importedItem.materia.length); i++) {
-                    const id = importedItem.materia[i].id;
+                    const importedMateria = importedItem.materia[i];
+                    const id = importedMateria.id;
                     const mat = this.dataManager.materiaById(id);
+                    const slot = equipped.melds[i];
+                    if (slot === undefined) {
+                        console.error(`mismatched materia slot! i == ${i}, slots length == ${equipped.melds.length}`);
+                    }
+                    slot.locked = importedMateria.locked ?? false;
                     if (!mat) {
                         continue;
                     }
-                    equipped.melds[i].equippedMateria = mat;
+                    slot.equippedMateria = mat;
                 }
                 if (importedItem.relicStats && equipped.gearItem.isCustomRelic) {
                     Object.assign(equipped.relicStats, importedItem.relicStats);

--- a/packages/core/src/solving/gearset_generation.ts
+++ b/packages/core/src/solving/gearset_generation.ts
@@ -292,6 +292,11 @@ export class GearsetGenerator {
         }
     }
 
+    /**
+     * Given an item, find all possible combinations of materia, minus those that have exactly the same resulting stats
+     * as another combination.
+     * @param equippedItem
+     */
     public getAllMeldCombinationsForGearItem(equippedItem: EquippedItem): ItemWithStats[] {
 
         const basePiece = new ItemWithStats(this.cloneEquippedItem(equippedItem), this.getPieceEffectiveStats(equippedItem));

--- a/packages/core/src/solving/gearset_generation.ts
+++ b/packages/core/src/solving/gearset_generation.ts
@@ -120,7 +120,12 @@ export class GearsetGenerator {
                 const equipSlot = equipment[slotKey] as EquippedItem | null;
                 const gearItem = equipSlot?.gearItem;
                 if (gearItem) {
-                    equipSlot.melds.forEach(meldSlot => meldSlot.equippedMateria = null);
+                    equipSlot.melds.forEach(meldSlot => {
+                        // Don't overwrite locked slots
+                        if (!meldSlot.locked) {
+                            meldSlot.equippedMateria = null;
+                        }
+                    });
                 }
             }
         }
@@ -297,8 +302,10 @@ export class GearsetGenerator {
 
         for (let slotNum = 0; slotNum < equippedItem.gearItem.materiaSlots.length; slotNum += 1) {
 
-            // We are presuming that any pre-existing materia is locked. Skip this slot and continue from next.
-            if (equippedItem.melds[slotNum].equippedMateria !== null && equippedItem.melds[slotNum].equippedMateria !== undefined) {
+            // Skip a slot if it is either explicitly locked, or it has something in it already (which would imply that
+            // the user did not wish to overwrite existing materia)
+            const slot = equippedItem.melds[slotNum];
+            if (slot.locked || slot.equippedMateria !== null && slot.equippedMateria !== undefined) {
                 continue;
             }
 
@@ -340,7 +347,6 @@ export class GearsetGenerator {
             for (const [key, item] of itemsToAdd) {
                 meldCombinations.set(key, item);
             }
-
         }
 
         return Array.from(meldCombinations.values());

--- a/packages/core/src/test/materia_memory_test.ts
+++ b/packages/core/src/test/materia_memory_test.ts
@@ -1,5 +1,13 @@
 import {MateriaMemory} from "../gear";
-import {EquippedItem, GearItem, Materia, MateriaSlot, MeldableMateriaSlot, RawStats} from "@xivgear/xivmath/geartypes";
+import {
+    EquippedItem,
+    GearItem,
+    Materia,
+    MateriaMemoryExport,
+    MateriaSlot,
+    MeldableMateriaSlot,
+    RawStats, SlotMateriaMemoryExport
+} from "@xivgear/xivmath/geartypes";
 import {expect} from "chai";
 import {toTranslatable} from "@xivgear/i18n/translation";
 
@@ -52,14 +60,14 @@ describe("Materia Memory", () => {
             {
                 materiaSlot: slot,
                 equippedMateria: mat2,
-                locked: false,
+                locked: true,
             },
         ];
         const slots2: MeldableMateriaSlot[] = [
             {
                 materiaSlot: slot,
                 equippedMateria: undefined,
-                locked: false,
+                locked: true,
             },
             {
                 materiaSlot: slot,
@@ -74,20 +82,71 @@ describe("Materia Memory", () => {
         mem.set("RingRight", eq2);
 
         // Verify behavior
-        expect(mem.get("RingLeft", eq1.gearItem)).to.deep.equal([mat1.id, mat2.id]);
-        expect(mem.get("RingRight", eq2.gearItem)).to.deep.equal([-1, mat1.id]);
+        expect(mem.get("RingLeft", eq1.gearItem)).to.deep.equal([{
+            id: mat1.id,
+            locked: false,
+        }, {
+            id: mat2.id,
+            locked: true,
+        }]);
+        expect(mem.get("RingRight", eq2.gearItem)).to.deep.equal([{
+            id: -1,
+            locked: true,
+        }, {
+            id: mat1.id,
+            locked: false,
+        }]);
 
         const exported = mem.export();
 
-        expect(exported.RingLeft).to.deep.equal([[1234, [mat1.id, mat2.id]]]);
-        expect(exported.RingRight).to.deep.equal([[1234, [-1, mat1.id]]]);
+        expect(exported.RingLeft).to.deep.equal([[1234, [mat1.id, mat2.id], [false, true]]]);
+        expect(exported.RingRight).to.deep.equal([[1234, [-1, mat1.id], [true, false]]]);
 
         const imported = new MateriaMemory();
         // serialize and deserialize to check that it isn't dependent on anything else
         imported.import(JSON.parse(JSON.stringify(exported)));
 
-        expect(imported.get("RingLeft", eq1.gearItem)).to.deep.equal([mat1.id, mat2.id]);
-        expect(imported.get("RingRight", eq2.gearItem)).to.deep.equal([-1, mat1.id]);
+        // Verify behavior after reimporting
+        expect(imported.get("RingLeft", eq1.gearItem)).to.deep.equal([{
+            id: mat1.id,
+            locked: false,
+        }, {
+            id: mat2.id,
+            locked: true,
+        }]);
+        expect(imported.get("RingRight", eq2.gearItem)).to.deep.equal([{
+            id: -1,
+            locked: true,
+        }, {
+            id: mat1.id,
+            locked: false,
+        }]);
+
+        // Verify that older exported sets can still be imported
+        const legacyImported = new MateriaMemory();
+        for (const slotKey in exported) {
+            // @ts-expect-error indexing
+            const exportedSlotMaterias: SlotMateriaMemoryExport[] = exported[slotKey];
+            for (const exportedSlotMateria of exportedSlotMaterias) {
+                exportedSlotMateria.splice(2, 1);
+            }
+        }
+        legacyImported.import(JSON.parse(JSON.stringify(exported)));
+        // Verify behavior after reimporting
+        expect(legacyImported.get("RingLeft", eq1.gearItem)).to.deep.equal([{
+            id: mat1.id,
+            locked: false,
+        }, {
+            id: mat2.id,
+            locked: false,
+        }]);
+        expect(legacyImported.get("RingRight", eq2.gearItem)).to.deep.equal([{
+            id: -1,
+            locked: false,
+        }, {
+            id: mat1.id,
+            locked: false,
+        }]);
 
     });
 });

--- a/packages/core/src/test/materia_memory_test.ts
+++ b/packages/core/src/test/materia_memory_test.ts
@@ -42,24 +42,29 @@ describe("Materia Memory", () => {
             }),
             ilvl: 690,
         };
+        // TODO: when 'locked' becomes part of the export, update this test
         const slots1: MeldableMateriaSlot[] = [
             {
                 materiaSlot: slot,
                 equippedMateria: mat1,
+                locked: false,
             },
             {
                 materiaSlot: slot,
                 equippedMateria: mat2,
+                locked: false,
             },
         ];
         const slots2: MeldableMateriaSlot[] = [
             {
                 materiaSlot: slot,
                 equippedMateria: undefined,
+                locked: false,
             },
             {
                 materiaSlot: slot,
                 equippedMateria: mat1,
+                locked: false,
             },
         ];
         // Equip the same item in both slots

--- a/packages/core/src/test/materia_memory_test.ts
+++ b/packages/core/src/test/materia_memory_test.ts
@@ -3,7 +3,6 @@ import {
     EquippedItem,
     GearItem,
     Materia,
-    MateriaMemoryExport,
     MateriaSlot,
     MeldableMateriaSlot,
     RawStats, SlotMateriaMemoryExport

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -452,10 +452,12 @@ export class MateriaPriorityPicker extends HTMLElement {
         }, 'Unlock all slots');
         unlockAll.classList.add('narrow-button');
 
-        const unequipAll = makeActionButton('Unequip Unlocked', () => {
+        const unequipAll = makeActionButton('Remove Unlocked', () => {
             prioController.unequipUnlocked();
         }, 'Unequip all unlocked materia');
         unequipAll.classList.add('narrow-button');
+
+        const tips = quickElement('div', ['meld-solver-tips'], ['Tip: Ctrl-click a materia slot to lock/unlock it. Alt-click to remove materia.']);
 
         const solveMelds = makeActionButton('Solve', () => sheet.showMeldSolveDialog(), "Solve for the highest damage melds for your chosen gear");
 
@@ -496,7 +498,10 @@ export class MateriaPriorityPicker extends HTMLElement {
             document.createElement('br'),
             solveMelds, fillEmptyNow, fillAllNow,
             document.createElement('br'),
-            lockAllEquipped, lockAllEmpty, unlockAll, unequipAll);
+            lockAllEquipped, lockAllEmpty, unlockAll, unequipAll,
+            document.createElement('br'),
+            tips
+        );
     }
 }
 

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -436,6 +436,22 @@ export class MateriaPriorityPicker extends HTMLElement {
             recordEvent("fillAll");
         }, 'Empty out and re-fill all materia slots according to the chosen priority.');
 
+        const lockAllEquipped = makeActionButton('Lock Filled', () => {
+            // TODO
+        }, 'Lock all equipped materia');
+
+        const lockAllEmpty = makeActionButton('Lock Empty', () => {
+            // TODO
+        }, 'Lock all empty materia slots');
+
+        const unlockAll = makeActionButton('Unlock All', () => {
+            // TODO
+        }, 'Unlock all slots');
+
+        const unequipAll = makeActionButton('Unequip All', () => {
+            // TODO
+        }, 'Unequip all unlocked materia');
+
         const solveMelds = makeActionButton('Solve', () => sheet.showMeldSolveDialog(), "Solve for the highest damage melds for your chosen gear");
 
         const drag = new MateriaDragList(prioController);

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -194,6 +194,7 @@ export class SlotMateriaManager extends HTMLElement {
 
     reformat() {
         const currentMat = this.materiaSlot.equippedMateria;
+        // TODO: can the ordering be improved here?
         let title: string;
         if (currentMat) {
             this.image.src = currentMat.iconUrl.toString();

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -138,8 +138,16 @@ export class SlotMateriaManager extends HTMLElement {
         this.classList.add("slot-materia-manager");
         if (editable) {
             this.addEventListener('mousedown', (ev) => {
-                this.showPopup();
+                if (ev.altKey) {
+                    this.materiaSlot.equippedMateria = null;
+                    callback();
+                    this.reformat();
+                }
+                else {
+                    this.showPopup();
+                }
                 ev.stopPropagation();
+                ev.preventDefault();
             });
             this.classList.add('editable');
         }
@@ -189,7 +197,7 @@ export class SlotMateriaManager extends HTMLElement {
             this.text.textContent = `+${displayedNumber} ${STAT_ABBREVIATIONS[currentMat.primaryStat]}`;
             this.classList.remove("materia-slot-empty");
             this.classList.add("materia-slot-full");
-            this.title = formatMateriaTitle(currentMat);
+            this.title = `${formatMateriaTitle(currentMat)}\nAlt-click to remove.`;
         }
         else {
             this.image.style.display = 'none';
@@ -197,7 +205,7 @@ export class SlotMateriaManager extends HTMLElement {
             this.classList.remove('materia-normal', 'materia-overcap', 'materia-overcap-major', 'materia-slot-full');
             // this.classList.remove('materia-slot-full', 'materia-normal', 'materia-overcap', 'materia-overcap-major')
             this.classList.add("materia-slot-empty");
-            delete this.title;
+            this.title = 'Click to select materia';
         }
     }
 

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -13,11 +13,11 @@ import {
 import {MateriaSubstat, MAX_GCD, STAT_ABBREVIATIONS, STAT_FULL_NAMES} from "@xivgear/xivmath/xivconstants";
 import {closeModal, setModal} from "@xivgear/common-ui/modalcontrol";
 import {
-    faIcon,
     FieldBoundDataSelect,
     FieldBoundFloatField,
     labelFor,
-    makeActionButton, makeTrashIcon,
+    makeActionButton,
+    makeTrashIcon,
     quickElement
 } from "@xivgear/common-ui/components/util";
 import {GearPlanSheet} from "@xivgear/core/sheet";
@@ -145,6 +145,7 @@ export class SlotMateriaManager extends HTMLElement {
                 }
                 else if (ev.ctrlKey) {
                     this.materiaSlot.locked = !this.materiaSlot.locked;
+                    sheet.requestSave();
                     this.reformat();
                 }
                 else {
@@ -437,20 +438,24 @@ export class MateriaPriorityPicker extends HTMLElement {
         }, 'Empty out and re-fill all materia slots according to the chosen priority.');
 
         const lockAllEquipped = makeActionButton('Lock Filled', () => {
-            // TODO
+            prioController.lockFilled();
         }, 'Lock all equipped materia');
+        lockAllEquipped.classList.add('narrow-button');
 
         const lockAllEmpty = makeActionButton('Lock Empty', () => {
-            // TODO
+            prioController.lockEmpty();
         }, 'Lock all empty materia slots');
+        lockAllEmpty.classList.add('narrow-button');
 
         const unlockAll = makeActionButton('Unlock All', () => {
-            // TODO
+            prioController.unlockAll();
         }, 'Unlock all slots');
+        unlockAll.classList.add('narrow-button');
 
-        const unequipAll = makeActionButton('Unequip All', () => {
-            // TODO
+        const unequipAll = makeActionButton('Unequip Unlocked', () => {
+            prioController.unequipUnlocked();
         }, 'Unequip all unlocked materia');
+        unequipAll.classList.add('narrow-button');
 
         const solveMelds = makeActionButton('Solve', () => sheet.showMeldSolveDialog(), "Solve for the highest damage melds for your chosen gear");
 
@@ -483,10 +488,15 @@ export class MateriaPriorityPicker extends HTMLElement {
         minGcdInput.pattern = '\\d\\.\\d\\d?';
         minGcdInput.title = 'Enter the minimum desired GCD in the form x.yz.\nSkS/SpS materia will be de-prioritized once this target GCD is met.';
         minGcdInput.classList.add('min-gcd-input');
-        this.replaceChildren(header, drag, document.createElement('br'),
-            minGcdText, minGcdInput, document.createElement('br'),
-            fillModeLabel, fillModeDropdown, document.createElement('br'),
-            solveMelds, fillEmptyNow, fillAllNow);
+        this.replaceChildren(header, drag,
+            document.createElement('br'),
+            minGcdText, minGcdInput,
+            document.createElement('br'),
+            fillModeLabel, fillModeDropdown,
+            document.createElement('br'),
+            solveMelds, fillEmptyNow, fillAllNow,
+            document.createElement('br'),
+            lockAllEquipped, lockAllEmpty, unlockAll, unequipAll);
     }
 }
 

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -437,7 +437,7 @@ class MeldSolverConfirmationDialog extends BaseModal {
         this.applyButton = makeActionButton("Apply", (ev) => {
 
             if (this.newSet) {
-                this.applyResult(newSet);
+                this.applyResult();
                 this.oldSet.forceRecalc();
                 this.sheet.refreshMateria();
                 this.close();
@@ -554,14 +554,22 @@ class MeldSolverConfirmationDialog extends BaseModal {
         return result;
     }
 
-    applyResult(newSet: CharacterGearSet) {
+    applyResult() {
 
         for (const slotKey of EquipSlots) {
-            if (!this.oldSet.equipment[slotKey] || !this.newSet.equipment[slotKey]) {
+            const oldEq = this.oldSet.equipment[slotKey];
+            const newEq = this.newSet.equipment[slotKey];
+            if (!oldEq || !newEq) {
                 continue;
             }
 
-            this.oldSet.equipment[slotKey].melds = newSet.equipment[slotKey].melds;
+            for (let i = 0; i < oldEq.melds.length; i++) {
+                const oldSlot = oldEq.melds[i];
+                const newSlot = newEq.melds[i];
+                oldSlot.equippedMateria = newSlot.equippedMateria;
+            }
+
+            oldEq.melds = newEq.melds;
         }
     }
 }

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1421,7 +1421,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
     }
 
 
-    setupRealGui() {
+    private setupRealGui() {
         const buttonsArea = this.buttonsArea;
         const showHideButton = makeActionButton('≡', () => {
             const cls = 'showing';
@@ -1642,6 +1642,17 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
 
         const outer = this;
+
+        function doSet(f: (set: CharacterGearSet) => void): void {
+            let set;
+            if ((set = outer._editorItem) instanceof CharacterGearSet) {
+                f(set);
+                if (outer._editorAreaNode instanceof GearSetEditor) {
+                    outer._editorAreaNode.refreshMateria();
+                }
+            }
+        }
+
         const matFillCtrl: MateriaAutoFillController = {
 
             get autoFillMode() {
@@ -1658,30 +1669,50 @@ export class GearPlanSheetGui extends GearPlanSheet {
                 outer.requestSave();
             },
             fillAll(): void {
-                let set;
-                if ((set = outer._editorItem) instanceof CharacterGearSet) {
-                    set.fillMateria(outer.materiaAutoFillPrio, true);
-                    if (outer._editorAreaNode instanceof GearSetEditor) {
-                        outer._editorAreaNode.refreshMateria();
-                    }
-                }
+                doSet(set => set.fillMateria(outer.materiaAutoFillPrio, true));
             },
             fillEmpty(): void {
-                let set;
-                if ((set = outer._editorItem) instanceof CharacterGearSet) {
-                    set.fillMateria(outer.materiaAutoFillPrio, false);
-                    if (outer._editorAreaNode instanceof GearSetEditor) {
-                        outer._editorAreaNode.refreshMateria();
-                    }
-                }
+                doSet(set => set.fillMateria(outer.materiaAutoFillPrio, false));
             },
-            // TODO: remove?
-            refreshOnly() {
-                if (outer._editorAreaNode instanceof GearSetEditor) {
-                    // outer._editorAreaNode.refreshMateria();
-                }
+            lockEmpty(): void {
+                doSet(set => {
+                    set.forEachMateriaSlot((_key, _item, slot) => {
+                        if (!slot.equippedMateria) {
+                            slot.locked = true;
+                        }
+                    });
+                    // Only save - no recalc
+                    set.nonRecalcNotify();
+                });
             },
-
+            lockFilled(): void {
+                doSet(set => {
+                    set.forEachMateriaSlot((_key, _item, slot) => {
+                        if (slot.equippedMateria) {
+                            slot.locked = true;
+                        }
+                    });
+                    set.nonRecalcNotify();
+                });
+            },
+            unequipUnlocked(): void {
+                doSet(set => {
+                    set.forEachMateriaSlot((_key, _item, slot) => {
+                        if (!slot.locked) {
+                            slot.equippedMateria = null;
+                        }
+                    });
+                    set.forceRecalc();
+                });
+            },
+            unlockAll(): void {
+                doSet(set => {
+                    set.forEachMateriaSlot((_key, _item, slot) => {
+                        slot.locked = false;
+                    });
+                    set.nonRecalcNotify();
+                });
+            },
         };
         this._materiaAutoFillController = matFillCtrl;
         this._gearEditToolBar = new GearEditToolbar(
@@ -1777,12 +1808,18 @@ export class GearPlanSheetGui extends GearPlanSheet {
         this._sheetSetupDone = true;
     }
 
+    /**
+     * Refresh all materia widgets on the current sheet.
+     */
     public refreshMateria() {
         if (this._editorAreaNode instanceof GearSetEditor) {
             this._editorAreaNode.refreshMateria();
         }
     }
 
+    /**
+     * The top-level element which is to be added to the page.
+     */
     get topLevelElement() {
         return this.element;
     }
@@ -1792,6 +1829,10 @@ export class GearPlanSheetGui extends GearPlanSheet {
         this.setupRealGui();
     }
 
+    /**
+     * Called when gear filters have been changed. It will eventually result in gear lists being refreshed, but with
+     * a delay such that multiple successive updates are coalesced into a single refresh.
+     */
     onGearDisplaySettingsUpdate() {
         this.gearUpdateTimer.ping();
     }
@@ -1874,6 +1915,9 @@ export class GearPlanSheetGui extends GearPlanSheet {
         }
     }
 
+    /**
+     * Refreshes the toolbar. Should be called when switching sets.
+     */
     refreshToolbar() {
         if (this._editorItem instanceof CharacterGearSet) {
             if (this.toolbarNode !== undefined && 'refresh' in this.toolbarNode && typeof this.toolbarNode.refresh === 'function') {
@@ -1915,12 +1959,18 @@ export class GearPlanSheetGui extends GearPlanSheet {
         this.gearPlanTable?.simsChanged();
     }
 
+    /**
+     * Show the add simulation modal.
+     */
     showAddSimDialog() {
         const addSimDialog = new AddSimDialog(this);
         document.querySelector('body').appendChild(addSimDialog);
         addSimDialog.show();
     }
 
+    /**
+     * Show the meld solving modal.
+     */
     showMeldSolveDialog() {
         if (!(this._editorItem instanceof CharacterGearSet)) {
             return;
@@ -1930,6 +1980,9 @@ export class GearPlanSheetGui extends GearPlanSheet {
         meldSolveDialog.show();
     }
 
+    /**
+     * The gear sheets table.
+     */
     get gearPlanTable(): GearPlanTable {
         return this._gearPlanTable;
     }
@@ -2284,9 +2337,9 @@ function formatSyncInfo(si: SyncInfo, level: SupportedLevel): string | null {
         if (isLvlSynced) {
             text += `lv${si.lvlSync} `;
         }
-        // If level sync isn't explicitly set, show the level anyway
-        // if item level sync is present in any way to avoid confusion.
         else if (si.ilvlSync !== null) {
+            // If level sync isn't explicitly set, show the level anyway
+            // if item level sync is present in any way to avoid confusion.
             text += `lv${level} `;
         }
         if (si.ilvlSync !== null) {

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -374,6 +374,7 @@ export interface ComputedSetStats extends RawStats {
 export interface MeldableMateriaSlot {
     materiaSlot: MateriaSlot;
     equippedMateria: Materia | null;
+    locked: boolean;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
@@ -1091,6 +1092,7 @@ export class EquippedItem {
                 this.melds.push({
                     materiaSlot: materiaSlot,
                     equippedMateria: null,
+                    locked: false,
                 });
             }
         }

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -748,7 +748,7 @@ export type RelicStatMemoryExport = {
 };
 
 
-export type SlotMateriaMemoryExport = [item: number, materiaIds: number[]];
+export type SlotMateriaMemoryExport = [item: number, materiaIds: number[], locked?: boolean[]];
 
 export type MateriaMemoryExport = {
     [slot in EquipSlotKey]?: SlotMateriaMemoryExport[]
@@ -877,7 +877,8 @@ export interface ItemSlotExport {
         /**
          * The item ID of this materia. -1 indicates no materia equipped in this slot.
          */
-        id: number
+        id: number,
+        locked?: boolean,
     } | undefined)[],
     /**
      * If this is a relic, represents the current stats of the relic.

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -742,7 +742,6 @@ export type CustomFoodExport = {
 }
 
 
-
 export type RelicStatMemoryExport = {
     [p: number]: RelicStats;
 };
@@ -897,17 +896,48 @@ export type RelicStatsExport = {
 export type PartyBonusAmount = 0 | 1 | 2 | 3 | 4 | 5;
 
 
-export interface MateriaAutoFillController {
+/**
+ * MateriaAutoFillController is the interface for bulk materia actions and some
+ * settings related to them.
+ */
+export type MateriaAutoFillController = {
     readonly prio: MateriaAutoFillPrio;
     autoFillMode: MateriaFillMode;
 
+    /**
+     * callback() should be called after changing settings to ensure they get saved.
+     */
     callback(): void;
 
+    /**
+     * Fill empty slots according to priority.
+     */
     fillEmpty(): void;
 
+    /**
+     * Fill all slots according to priority, overwriting existing materia if needed.
+     */
     fillAll(): void;
 
-    refreshOnly(): void;
+    /**
+     * Lock all filled slots.
+     */
+    lockFilled(): void;
+
+    /**
+     * Lock all empty slots.
+     */
+    lockEmpty(): void;
+
+    /**
+     * Unlock all slots.
+     */
+    unlockAll(): void;
+
+    /**
+     * Unequip materia in unlocked slots.
+     */
+    unequipUnlocked(): void;
 }
 
 export interface MateriaAutoFillPrio {
@@ -1079,6 +1109,10 @@ export type RelicStats = {
     [K in Substat]?: number
 }
 
+/**
+ * EquippedItem represents an item as it is actually equipped, not just a base item. Thus includes customizations such
+ * as equipped materia, materia locking, and custom relic stats.
+ */
 export class EquippedItem {
 
     gearItem: GearItem;
@@ -1105,6 +1139,9 @@ export class EquippedItem {
         }
     }
 
+    /**
+     * Clone creates a deep clone of this EquippedItem.
+     */
     clone(): EquippedItem {
         const out = new EquippedItem(
             this.gearItem
@@ -1112,6 +1149,7 @@ export class EquippedItem {
         // Deep clone the materia slots
         this.melds.forEach((slot, index) => {
             out.melds[index].equippedMateria = slot.equippedMateria;
+            out.melds[index].locked = slot.locked;
         });
         if (this.relicStats !== undefined && out.relicStats !== undefined) {
             Object.assign(out.relicStats, this.relicStats);


### PR DESCRIPTION
- [X] Faster way to remove a single materia
- [x] Faster way(s) to remove materia in bulk
- [X] Create way to lock a slot such that auto-fill and solver won't affect the slot (including empties)
- [X] Visual indicator of locked slot
- [x] Save this data in local storage
- [x] Save this data in materia memory so it persists across switching items
- [X] Make meld filler ignore the slot
- [x] Make meld solver ignore the slot
- [x] Update tests


Closes #507, #499, #348 (effectively)