### PR TITLE
Add the ability to specify a single-folder BiS link

### DIFF
--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -134,8 +134,8 @@ function resolveNavData(nav: NavPath | null): NavResult | null {
             };
         case "bis":
             return {
-                preloadUrl: getBisSheetFetchUrl(nav.job, nav.folder ? nav.folder : "", nav.sheet),
-                sheetData: getBisSheet(nav.job, nav.folder ? nav.folder : "", nav.sheet).then(JSON.parse),
+                preloadUrl: getBisSheetFetchUrl(nav.job, nav.folder ?? "", nav.sheet),
+                sheetData: getBisSheet(nav.job, nav.folder ?? "", nav.sheet).then(JSON.parse),
             };
     }
     throw Error(`Unable to resolve nav result: ${nav.type}`);

--- a/packages/core/src/external/static_bis.ts
+++ b/packages/core/src/external/static_bis.ts
@@ -23,8 +23,11 @@ export function setServerOverride(server: string) {
     localStorage.setItem(STORAGE_KEY, server);
 }
 
-export function getBisSheetFetchUrl(job: JobName, expac: string, sheetFileName: string): URL {
-    return new URL(`/${encodeURIComponent(job)}/${encodeURIComponent(expac)}/${encodeURIComponent(sheetFileName)}.json`, getServer());
+export function getBisSheetFetchUrl(job: JobName, folder: string, sheetFileName: string): URL {
+    if (folder) {
+        return new URL(`/${encodeURIComponent(job)}/${encodeURIComponent(folder)}/${encodeURIComponent(sheetFileName)}.json`, getServer());
+    }
+    return new URL(`/${encodeURIComponent(job)}/${encodeURIComponent(sheetFileName)}.json`, getServer());
 }
 
 export async function getBisSheet(...params: Parameters<typeof getBisSheetFetchUrl>): Promise<string> {

--- a/packages/core/src/imports/imports.ts
+++ b/packages/core/src/imports/imports.ts
@@ -114,7 +114,7 @@ export function parseImport(text: string): ImportSpec {
                     case "bis":
                         return {
                             importType: 'bis',
-                            path: [parsed.job, parsed.expac, parsed.sheet],
+                            path: [parsed.job, parsed.folder, parsed.sheet],
                             onlySetIndex: parsed.onlySetIndex,
                         };
                     default:

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -82,7 +82,7 @@ export type NavPath = {
     // TODO: is this being used anywhere?
     path: string[],
     job: JobName,
-    expac: string,
+    folder?: string,
     sheet: string,
     onlySetIndex?: number,
     defaultSelectionIndex?: number,
@@ -205,12 +205,24 @@ export function parsePath(state: NavState): NavPath | null {
     }
     else if (mainNav === BIS_HASH) {
         embedWarn();
+        if (path.length === 3) {
+            return {
+                type: 'bis',
+                path: [path[1], path[2]],
+                job: path[1] as JobName,
+                sheet: path[2],
+                viewOnly: true,
+                embed: false,
+                onlySetIndex: state.onlySetIndex,
+                defaultSelectionIndex: state.selectIndex,
+            };
+        }
         if (path.length >= 4) {
             return {
                 type: 'bis',
                 path: [path[1], path[2], path[3]],
                 job: path[1] as JobName,
-                expac: path[2],
+                folder: path[2],
                 sheet: path[3],
                 viewOnly: true,
                 embed: false,

--- a/packages/core/src/test/common_nav_test.ts
+++ b/packages/core/src/test/common_nav_test.ts
@@ -246,7 +246,7 @@ describe('parsePath', () => {
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
                 job: 'sge',
-                expac: 'endwalker',
+                folder: 'endwalker',
                 sheet: 'anabaseios',
                 embed: false,
                 viewOnly: true,
@@ -260,7 +260,7 @@ describe('parsePath', () => {
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
                 job: 'sge',
-                expac: 'endwalker',
+                folder: 'endwalker',
                 sheet: 'anabaseios',
                 embed: false,
                 viewOnly: true,
@@ -274,7 +274,7 @@ describe('parsePath', () => {
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
                 job: 'sge',
-                expac: 'endwalker',
+                folder: 'endwalker',
                 sheet: 'anabaseios',
                 embed: false,
                 viewOnly: true,
@@ -288,7 +288,7 @@ describe('parsePath', () => {
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
                 job: 'sge',
-                expac: 'endwalker',
+                folder: 'endwalker',
                 sheet: 'anabaseios',
                 embed: false,
                 viewOnly: true,
@@ -296,11 +296,19 @@ describe('parsePath', () => {
                 defaultSelectionIndex: undefined,
             });
         });
-        it('returns null if incomplete url', () => {
-            const result = parsePath(new NavState(['bis', 'sge', 'endwalker']));
-            expect(result).to.be.null;
+        it('can resolve bis without a folder', () => {
+            const result = parsePath(new NavState(['bis', 'war', 'current'], 4, undefined));
+            expect(result).to.deep.equals({
+                type: 'bis',
+                path: ['war', 'current'],
+                job: 'war',
+                sheet: 'current',
+                embed: false,
+                viewOnly: true,
+                onlySetIndex: 4,
+                defaultSelectionIndex: undefined,
+            });
         });
-
     });
 
 });

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -169,15 +169,15 @@ async function doNav(navState: NavState) {
         case "bis": {
             showLoadingScreen();
             try {
-                const resolved: string | null = await getBisSheet(nav.job, nav.expac, nav.sheet);
+                const resolved: string | null = await getBisSheet(nav.job, nav.folder, nav.sheet);
                 if (resolved) {
                     const json = JSON.parse(resolved);
                     openExport(json, true, nav.onlySetIndex, nav.defaultSelectionIndex);
                     return;
                 }
                 else {
-                    console.error('Non-existent bis, or other error', [nav.job, nav.expac, nav.sheet]);
-                    recordError("load", `Non-existent bis, or other error: ${nav.job}, ${nav.expac}, ${nav.sheet}`);
+                    console.error('Non-existent bis, or other error', [nav.job, nav.folder, nav.sheet]);
+                    recordError("load", `Non-existent bis, or other error: ${nav.job}, ${nav.folder}, ${nav.sheet}`);
                 }
             }
             catch (e) {


### PR DESCRIPTION
This PR does two things:
- Renames 'expac' to 'folder' for static bis sets
- Allows static BiS sets to not require a folder, e.g. `bis/drk/set` will be permissable, as well as `bis/drk/foo/set`

It works:

![image](https://github.com/user-attachments/assets/994fa1cd-2296-4897-b372-6b868f81a830)

![image](https://github.com/user-attachments/assets/7cfe0226-c82e-4f62-a759-138bbc4d752f)
