### PR TITLE
Add more things for analytics

### DIFF
--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -18,11 +18,13 @@ import {extractSingleSet} from "@xivgear/core/util/sheet_utils";
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {recordSheetEvent} from "./analytics/analytics";
 import {recordError} from "@xivgear/common-ui/analytics/analytics";
+import {isInIframe} from "@xivgear/common-ui/util/detect_iframe";
 
 declare global {
     interface Document {
         planner?: GearPlanSheetGui;
     }
+
     // noinspection JSUnusedGlobalSymbols
     interface Window {
         currentSheet?: GearPlanSheetGui;
@@ -178,6 +180,25 @@ export async function openExport(exportedPre: SheetExport | SetExport, viewOnly:
         sheet.defaultSelectionIndex = defaultSelectionIndex;
     }
     const embed = isEmbed();
+    if (isInIframe()) {
+        const extraData: {
+            topLocation?: string,
+            referrer?: string,
+        } = {};
+        try {
+            extraData['topLocation'] = window.top.location.hostname;
+        }
+        catch (e) {
+            // Ignored
+        }
+        if (document.referrer) {
+            extraData['referrer'] = document.referrer;
+        }
+        recordSheetEvent('iframe', sheet, extraData);
+        if (!isEmbed()) {
+            recordSheetEvent('nonEmbeddedIframe', sheet, extraData);
+        }
+    }
     const analyticsData = {
         'isEmbed': embed,
         'viewOnly': viewOnly,

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -87,6 +87,7 @@ import {MeldSolverDialog} from "./meld_solver_modal";
 import {insertAds} from "./ads";
 import {SETTINGS} from "@xivgear/common-ui/settings/persistent_settings";
 import {isInIframe} from "@xivgear/common-ui/util/detect_iframe";
+import {recordEvent} from "@xivgear/common-ui/analytics/analytics";
 
 const noSeparators = (set: CharacterGearSet) => !set.isSeparator;
 
@@ -1041,6 +1042,9 @@ export class GearSetViewer extends HTMLElement {
             linkUrl.searchParams.delete(ONLY_SET_QUERY_PARAM);
             headingLink.href = linkUrl.toString();
             headingLink.target = '_blank';
+            headingLink.addEventListener('click', () => {
+                recordSheetEvent("openEmbedToFull", this.sheet);
+            });
             headingLink.replaceChildren(this.gearSet.name, faIcon('fa-arrow-up-right-from-square', 'fa'));
             heading.replaceChildren(headingLink);
         }
@@ -1966,6 +1970,9 @@ export class GearPlanSheetGui extends GearPlanSheet {
         const linkElement = document.createElement('a');
         linkElement.href = sheetUrl.toString();
         linkElement.textContent = sheetName;
+        linkElement.addEventListener('click', () => {
+            recordEvent('openNormalBacklink');
+        });
         if (isInIframe()) {
             linkElement.target = '_blank';
         }

--- a/packages/frontend/src/scripts/embed.ts
+++ b/packages/frontend/src/scripts/embed.ts
@@ -48,6 +48,9 @@ export async function openEmbed(sheet: GearPlanSheetGui) {
 }
 
 export function displayEmbedError(reason?: string) {
+    recordEvent('displayEmbedError', reason !== undefined ? {
+        'embedErrorReason': reason,
+    } : undefined);
     setTitle("Error");
     const text = document.createElement('p');
     text.textContent = "Embed failed to load. " + (reason ?? "Make sure the link points to a set (not a full sheet).");


### PR DESCRIPTION
`openNormalBacklink` when you click the link to go back to the full sheet when viewing an onlySetIndex link.

`openEmbedToFull` is the same but when you're looking at an embed.

`displayEmbedError` is whenever the function `displayEmbedError()` is called.

`nonEmbeddedIframe` is fired when using a non-embedded UI in an iframe.

`iframe` is fired whenever the page is in an iframe.

#1 does not work for non-iframes because the page navigation immediately cancels the request. This should be fixed, but is out of scope for this. It works in iframes because the link is set to open in a new tab.