### PR TITLE
Fix backlink click completely reloading the page

### DIFF
--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -52,7 +52,7 @@ import {
     STAT_ABBREVIATIONS,
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
-import {getCurrentHash, getCurrentState} from "../nav_hash";
+import {getCurrentHash, getCurrentState, manipulateUrlParams, processNav} from "../nav_hash";
 import {MateriaTotalsDisplay} from "./materia";
 import {FoodItemsTable, FoodItemViewTable, GearItemsTable, GearItemsViewTable} from "./items";
 import {SetViewToolbar} from "./totals_display";
@@ -1976,6 +1976,18 @@ export class GearPlanSheetGui extends GearPlanSheet {
         if (isInIframe()) {
             linkElement.target = '_blank';
         }
+        else {
+            // Don't fully reload the page for no reason
+            linkElement.addEventListener('click', (e) => {
+                const existingUrl = new URL(document.location.toString());
+                if (existingUrl.origin === sheetUrl.origin
+                    && existingUrl.pathname === sheetUrl.pathname) {
+                    e.preventDefault();
+                    history.pushState(null, null, sheetUrl);
+                    processNav();
+                }
+            });
+        }
         area.replaceChildren("This set is part of a sheet: ", linkElement);
         area.style.display = '';
     }
@@ -2272,7 +2284,7 @@ function formatSyncInfo(si: SyncInfo, level: SupportedLevel): string | null {
         if (isLvlSynced) {
             text += `lv${si.lvlSync} `;
         }
-        // If level sync isn't explicitly set, show the level anyway
+            // If level sync isn't explicitly set, show the level anyway
         // if item level sync is present in any way to avoid confusion.
         else if (si.ilvlSync !== null) {
             text += `lv${level} `;

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -52,7 +52,7 @@ import {
     STAT_ABBREVIATIONS,
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
-import {getCurrentHash, getCurrentState, manipulateUrlParams, processNav} from "../nav_hash";
+import {getCurrentHash, getCurrentState, processNav} from "../nav_hash";
 import {MateriaTotalsDisplay} from "./materia";
 import {FoodItemsTable, FoodItemViewTable, GearItemsTable, GearItemsViewTable} from "./items";
 import {SetViewToolbar} from "./totals_display";
@@ -2284,7 +2284,7 @@ function formatSyncInfo(si: SyncInfo, level: SupportedLevel): string | null {
         if (isLvlSynced) {
             text += `lv${si.lvlSync} `;
         }
-            // If level sync isn't explicitly set, show the level anyway
+        // If level sync isn't explicitly set, show the level anyway
         // if item level sync is present in any way to avoid confusion.
         else if (si.ilvlSync !== null) {
             text += `lv${level} `;


### PR DESCRIPTION
This makes it so that clicking the backlink on an `onlySetIndex` URL will not try to completely reload the page.