### PR TITLE
Improve cycle sim result display

### DIFF
--- a/packages/common-ui/src/table/tables.ts
+++ b/packages/common-ui/src/table/tables.ts
@@ -368,13 +368,13 @@ export interface RefreshableRow<X> {
     get element(): HTMLElement;
 }
 
-// TODO: there is a redundant copy of this in math-frontend, put these in common-ui
 export class CustomTable<RowDataType, SelectionType extends TableSelectionModel<RowDataType, unknown, unknown, unknown> = TableSelectionModel<RowDataType, unknown, unknown, never>> extends HTMLTableElement {
     _data: (RowDataType | HeaderRow | TitleRow)[] = [];
     dataRowMap: Map<RowDataType, CustomRow<RowDataType>> = new Map<RowDataType, CustomRow<RowDataType>>();
     selectionRefreshables: SelectionRefresh[] = [];
     _rows: RefreshableRow<RowDataType>[] = [];
     _columns!: CustomColumn<RowDataType, unknown, unknown>[];
+    // TODO: should changing selection model also refresh the current selection?
     selectionModel: SelectionType = noopSelectionModel as SelectionType;
 
     constructor() {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2889,99 +2889,6 @@ buff-settings-area {
     }
   }
 
-  .abilities-used-table {
-
-    .ability-cell {
-      height: 100%;
-      max-height: var(--abilities-row-height);
-      display: flex;
-      align-items: center;
-
-      .ffxiv-ability-icon {
-        max-height: 100%;
-        display: block;
-        aspect-ratio: 1;
-      }
-
-      .ability-name {
-        overflow-x: hidden;
-        text-overflow: ellipsis;
-        line-height: initial;
-        flex-shrink: 1;
-        flex-grow: 1;
-      }
-    }
-
-    th {
-      text-align: center;
-    }
-
-    td {
-      overflow: hidden;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      line-height: 1px;
-      height: var(--abilities-row-height);
-
-      &[col-id='time'] {
-        text-align: right;
-      }
-
-      &[col-id='buffs'] {
-        padding-top: 0;
-
-        .active-buffs-list {
-          height: 100%;
-          width: 100%;
-          display: inline-flex;
-          align-items: center;
-          max-height: var(--abilities-row-height);
-
-          img {
-            height: 100%;
-            flex-shrink: 0;
-            padding-right: 2px;
-          }
-
-          span {
-            flex-shrink: 1;
-            display: block;
-            min-width: 1px;
-            overflow-x: hidden;
-            text-overflow: ellipsis;
-            line-height: var(--abilities-row-height);
-          }
-        }
-      }
-    }
-
-    td, th {
-      &[col-id='time'] {
-        width: 75px;
-        max-width: 75px;
-      }
-
-      &[col-id='ability'] {
-        min-width: 150px;
-        max-width: 400px;
-      }
-
-      &[col-id='unbuffed-pot'] {
-        width: 40px;
-        max-width: 40px;
-      }
-
-      &[col-id='expected-damage'] {
-        width: 100px;
-        max-width: 100px;
-      }
-
-      &[col-id='buffs'] {
-        width: 400px;
-        max-width: 400px;
-      }
-    }
-  }
 }
 
 
@@ -3577,3 +3484,156 @@ button.narrow-button {
 }
 
 @import 'gauge.less';
+
+// TODO: narrow version of this
+// TODO: table is a bit too wide normally
+.cycle-sim-results-full {
+  display: grid;
+  grid-template-columns: 50% 50%;
+  grid-template-rows: auto auto;
+  grid-gap: 20px;
+
+  .cycle-sim-abilities-holder {
+    grid-column-start: 1;
+    grid-column-end: span 2;
+  }
+
+  .cycle-sim-rotations-holder {
+    min-height: 0;
+  }
+
+  .cycle-sim-main-holder {
+    > table > * > tr > td {
+     min-width: 150px;
+    }
+  }
+
+  .scroll-table-holder {
+    overflow-y: auto;
+    min-height: 0;
+    scrollbar-gutter: stable;
+    max-height: 200px;
+
+    > table {
+      position: relative;
+
+      > * > tr > th {
+        position: sticky;
+        top: 0;
+        z-index: var(--zi-sets-table-header-row);
+        background: color-mix(in srgb, var(--table-bg-color) 80%, transparent);
+
+      }
+    }
+  }
+
+  .cycle-sim-table-holder {
+    background-color: var(--table-bg-color);
+    .standard-round-border;
+    .shadow-big;
+    width: fit-content;
+    margin: auto;
+    padding: 10px;
+    height: 100%;
+    box-sizing: border-box;
+
+    table {
+      background: none;
+      padding: 0;
+    }
+  }
+}
+
+.abilities-used-table {
+
+  .ability-cell {
+    height: 100%;
+    max-height: var(--abilities-row-height);
+    display: flex;
+    align-items: center;
+
+    .ffxiv-ability-icon {
+      max-height: 100%;
+      display: block;
+      aspect-ratio: 1;
+    }
+
+    .ability-name {
+      overflow-x: hidden;
+      text-overflow: ellipsis;
+      line-height: initial;
+      flex-shrink: 1;
+      flex-grow: 1;
+    }
+  }
+
+  th {
+    text-align: center;
+  }
+
+  td {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    line-height: 1px;
+    height: var(--abilities-row-height);
+
+    &[col-id='time'] {
+      text-align: right;
+    }
+
+    &[col-id='buffs'] {
+      padding-top: 0;
+
+      .active-buffs-list {
+        height: 100%;
+        width: 100%;
+        display: inline-flex;
+        align-items: center;
+        max-height: var(--abilities-row-height);
+
+        img {
+          height: 100%;
+          flex-shrink: 0;
+          padding-right: 2px;
+        }
+
+        span {
+          flex-shrink: 1;
+          display: block;
+          min-width: 1px;
+          overflow-x: hidden;
+          text-overflow: ellipsis;
+          line-height: var(--abilities-row-height);
+        }
+      }
+    }
+  }
+
+  td, th {
+    &[col-id='time'] {
+      width: 75px;
+      max-width: 75px;
+    }
+
+    &[col-id='ability'] {
+      min-width: 150px;
+      max-width: 400px;
+    }
+
+    &[col-id='unbuffed-pot'] {
+      width: 40px;
+      max-width: 40px;
+    }
+
+    &[col-id='expected-damage'] {
+      width: 100px;
+      max-width: 100px;
+    }
+
+    &[col-id='buffs'] {
+      width: 400px;
+      max-width: 400px;
+    }
+  }
+}

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2865,7 +2865,7 @@ buff-settings-area {
   }
 }
 
-.cycle-sim-results-table {
+.count-sim-results-area {
   width: 100%;
 
   > table {
@@ -3487,45 +3487,10 @@ button.narrow-button {
 
 // TODO: narrow version of this
 // TODO: table is a bit too wide normally
-.cycle-sim-results-full {
+.cycle-sim-results {
   display: grid;
-  grid-template-columns: 50% 50%;
-  grid-template-rows: auto auto;
   grid-gap: 20px;
-
-  .cycle-sim-abilities-holder {
-    grid-column-start: 1;
-    grid-column-end: span 2;
-  }
-
-  .cycle-sim-rotations-holder {
-    min-height: 0;
-  }
-
-  .cycle-sim-main-holder {
-    > table > * > tr > td {
-     min-width: 150px;
-    }
-  }
-
-  .scroll-table-holder {
-    overflow-y: auto;
-    min-height: 0;
-    scrollbar-gutter: stable;
-    max-height: 200px;
-
-    > table {
-      position: relative;
-
-      > * > tr > th {
-        position: sticky;
-        top: 0;
-        z-index: var(--zi-sets-table-header-row);
-        background: color-mix(in srgb, var(--table-bg-color) 80%, transparent);
-
-      }
-    }
-  }
+  padding: 20px 20px 20px 10px;
 
   .cycle-sim-table-holder {
     background-color: var(--table-bg-color);
@@ -3541,6 +3506,55 @@ button.narrow-button {
       background: none;
       padding: 0;
     }
+  }
+
+  &.cycle-sim-results-full {
+    grid-template-columns: 50% 50%;
+    grid-template-rows: auto auto;
+
+    @media screen and (max-width: 725px) {
+      grid-template-columns: 100%;
+      grid-template-rows: auto auto auto;
+      .cycle-sim-abilities-holder {
+        grid-column-start: 1;
+        grid-column-end: span 1 !important;
+      }
+    }
+
+    .cycle-sim-abilities-holder {
+      grid-column-start: 1;
+      grid-column-end: span 2;
+    }
+
+    .cycle-sim-rotations-holder {
+      min-height: 0;
+    }
+
+    .cycle-sim-main-holder {
+      > table > * > tr > td {
+        min-width: 150px;
+      }
+    }
+
+    .scroll-table-holder {
+      overflow-y: auto;
+      min-height: 0;
+      scrollbar-gutter: stable;
+      max-height: 200px;
+
+      > table {
+        position: relative;
+
+        > * > tr > th {
+          position: sticky;
+          top: 0;
+          z-index: var(--zi-sets-table-header-row);
+          background: color-mix(in srgb, var(--table-bg-color) 80%, transparent);
+
+        }
+      }
+    }
+
   }
 }
 

--- a/packages/frontend/src/scripts/sims/components/ability_used_table.ts
+++ b/packages/frontend/src/scripts/sims/components/ability_used_table.ts
@@ -6,6 +6,7 @@ import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/
 import {AutoAttack, Buff, CombinedBuffEffect, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
 import {ItemIcon} from "../../components/item_icon";
 import {quickElement} from "@xivgear/common-ui/components/util";
+import {abilityToDamageNew} from "@xivgear/core/sims/sim_utils";
 
 /**
  * Format a time into the format x:yy.zz
@@ -190,8 +191,11 @@ export class AbilitiesUsedTable extends CustomTable<DisplayRecordFinalized> {
             }),
             ...extraColumns,
         ];
-        this.data = [new HeaderRow(), ...abilitiesUsed];
-        // this.style.tableLayout = 'auto';
+        this.setNewData(abilitiesUsed);
+    }
+
+    setNewData(used: readonly DisplayRecordFinalized[]) {
+        this.data = [new HeaderRow(), ...used];
     }
 }
 

--- a/packages/frontend/src/scripts/sims/components/ability_used_table.ts
+++ b/packages/frontend/src/scripts/sims/components/ability_used_table.ts
@@ -6,7 +6,6 @@ import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/
 import {AutoAttack, Buff, CombinedBuffEffect, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
 import {ItemIcon} from "../../components/item_icon";
 import {quickElement} from "@xivgear/common-ui/components/util";
-import {abilityToDamageNew} from "@xivgear/core/sims/sim_utils";
 
 /**
  * Format a time into the format x:yy.zz

--- a/packages/frontend/src/scripts/sims/count_sim_gui.ts
+++ b/packages/frontend/src/scripts/sims/count_sim_gui.ts
@@ -138,6 +138,6 @@ export class BaseUsageCountSimGui<ResultType extends CountSimResult, InternalSet
 
         bucketsTable.data = [new HeaderRow(), ...transposedData];
 
-        return quickElement('div', ['cycle-sim-results-table'], [mainResultsTable, bucketsTable]);
+        return quickElement('div', ['count-sim-results-area'], [mainResultsTable, bucketsTable]);
     }
 }

--- a/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
+++ b/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
@@ -137,8 +137,8 @@ export class BaseMultiCycleSimGui<ResultType extends CycleSimResult, InternalSet
     makeResultDisplay(result: FullResultType): HTMLElement {
         const mainResultsTable = this.makeMainResultDisplay(result.best, result.all.length > 1);
         const abilitiesUsedTable = this.makeAbilityUsedTable(result.best);
+        const mainHolder = quickElement('div', ['cycle-sim-table-holder', 'cycle-sim-main-holder'], [mainResultsTable]);
         if (result.all.length > 1) {
-            const mainHolder = quickElement('div', ['cycle-sim-table-holder', 'cycle-sim-main-holder'], [mainResultsTable]);
             const rotationsTable = this.makeRotationsTable(result, mainHolder, abilitiesUsedTable);
             return quickElement('div', ['cycle-sim-results', 'cycle-sim-results-full'], [
                 mainHolder,
@@ -149,7 +149,10 @@ export class BaseMultiCycleSimGui<ResultType extends CycleSimResult, InternalSet
             ]);
         }
         else {
-            return quickElement('div', ['cycle-sim-results', 'cycle-sim-results-simple'], [mainResultsTable, abilitiesUsedTable]);
+            return quickElement('div', ['cycle-sim-results', 'cycle-sim-results-simple'], [
+                mainHolder,
+                quickElement('div', ['cycle-sim-table-holder', 'cycle-sim-abilities-holder'], [abilitiesUsedTable]),
+            ]);
         }
     }
 

--- a/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
+++ b/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
@@ -16,7 +16,6 @@ import {
     col, CustomCell, CustomColumn, CustomRow,
     CustomTable,
     HeaderRow, SingleCellRowOrHeaderSelection,
-    SingleRowSelectionModel,
     TableSelectionModel
 } from "@xivgear/common-ui/table/tables";
 


### PR DESCRIPTION
- [X] You can now see how much DPS each rotation produces on the results page
- [X] Selecting another rotation will show the summary and abilities used for that rotation
- [x] Should responsively change layout on a narrow screen to place the rotations table below (above?) the summary table
- [x] Usage count sims are currently using some CSS classes with names that would imply that they are specific to cycle sims - this should be fixed


Possible future PRs:
- Allow enabling/disabling specific rotations on the cycle sim config page