### PR TITLE
Make Meld Solver button first-class, rename materia fill/solve to materia fill/lock

### DIFF
--- a/packages/frontend/src/scripts/components/gear_edit_toolbar.ts
+++ b/packages/frontend/src/scripts/components/gear_edit_toolbar.ts
@@ -144,6 +144,15 @@ export class ToolbarButtonsArea extends HTMLDivElement {
         this.panelButtons.push(button);
     }
 
+    addPanelButtonModal(label: (string | Node)[], showModalFunc: () => void) {
+        const button = makeActionButton(label, (ev) => {
+            showModalFunc();
+        });
+        button.classList.add('popout-button');
+        this.appendChild(button);
+        this.panelButtons.push(button);
+    }
+
     closePopout(): void {
         const attr = 'popout-active';
         this.panelButtons.forEach(btn => {
@@ -197,11 +206,6 @@ export class GearEditToolbar extends HTMLDivElement {
         super();
         this.classList.add('gear-set-editor-toolbar');
 
-        // const leftDrag = quickElement('div', ['toolbar-float-left'], [document.createTextNode('≡')])
-        // const rightDrag = quickElement('div', ['toolbar-float-right'], [document.createTextNode('≡')])
-        // this.appendChild(leftDrag);
-        // this.appendChild(rightDrag);
-
         this.buttonsArea = new ToolbarButtonsArea();
 
         const ilvlDiv = makeGearFiltersArea(sheet, itemDisplaySettings, updateGearDisplayNow, () => {
@@ -214,7 +218,9 @@ export class GearEditToolbar extends HTMLDivElement {
 
         const materiaPriority = new MateriaPriorityPicker(matFillCtrl, sheet);
 
-        this.buttonsArea.addPanelButton(["Materia", document.createElement('br'), "Fill/Solve"], materiaPriority);
+        this.buttonsArea.addPanelButton(["Materia", document.createElement('br'), "Fill/Lock"], materiaPriority);
+
+        this.buttonsArea.addPanelButtonModal(["Meld", document.createElement('br'), "Solver"], () => sheet.showMeldSolveDialog());
 
         this.statTierDisplay = new StatTierDisplay(sheet);
         this.appendChild(this.statTierDisplay);

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -459,8 +459,6 @@ export class MateriaPriorityPicker extends HTMLElement {
 
         const tips = quickElement('div', ['meld-solver-tips'], ['Tip: Ctrl-click a materia slot to lock/unlock it. Alt-click to remove materia.']);
 
-        const solveMelds = makeActionButton('Solve', () => sheet.showMeldSolveDialog(), "Solve for the highest damage melds for your chosen gear");
-
         const drag = new MateriaDragList(prioController);
 
         const minGcdText = document.createElement('span');
@@ -496,7 +494,7 @@ export class MateriaPriorityPicker extends HTMLElement {
             document.createElement('br'),
             fillModeLabel, fillModeDropdown,
             document.createElement('br'),
-            solveMelds, fillEmptyNow, fillAllNow,
+            fillEmptyNow, fillAllNow,
             document.createElement('br'),
             lockAllEquipped, lockAllEmpty, unlockAll, unequipAll,
             document.createElement('br'),

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1986,10 +1986,8 @@ export class GearPlanSheetGui extends GearPlanSheet {
             return;
         }
         const meldSolveDialog = new MeldSolverDialog(this, this.editorItem as CharacterGearSet);
-        if (meldSolveDialog) {
-            document.querySelector('body').appendChild(meldSolveDialog);
-            meldSolveDialog.show();
-        }
+        document.querySelector('body').appendChild(meldSolveDialog);
+        meldSolveDialog.show();
     }
 
     /**

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1986,8 +1986,10 @@ export class GearPlanSheetGui extends GearPlanSheet {
             return;
         }
         const meldSolveDialog = new MeldSolverDialog(this, this.editorItem as CharacterGearSet);
-        document.querySelector('body').appendChild(meldSolveDialog);
-        meldSolveDialog.show();
+        if (meldSolveDialog) {
+            document.querySelector('body').appendChild(meldSolveDialog);
+            meldSolveDialog.show();
+        }
     }
 
     /**


### PR DESCRIPTION
There are a few problems with including the meld solver in the fill/lock button in my eyes:
- Users get confused that the fill priority affects the meld solver
- This is one of the most awesome features of the site, and hiding it in a sub-menu can cause people to not know about it

This PR makes the meld solver button first-class, and moves it out of the fill/lock button. Making it more obviously disconnected from the 'fill' capabilities, as well as being more obvious to users.

![image](https://github.com/user-attachments/assets/1d2f1d9c-9bef-4976-bd42-f713b2868cf9)
![image](https://github.com/user-attachments/assets/88aa2838-3642-4981-98d6-83fd2daf424a)
![image](https://github.com/user-attachments/assets/175cd0fa-e036-4d0e-9ea1-ddd50759b4bd)
