### PR TITLE
Configure input types and patterns so that you get the numeric keypad on iOS

### DIFF
--- a/packages/common-ui/src/components/util.ts
+++ b/packages/common-ui/src/components/util.ts
@@ -167,9 +167,14 @@ export interface FbctArgs<ObjType, FieldType> {
      */
     type?: string;
     /**
-     * The HTML input inputmode.
+     * The HTML input inputmode. Common values include 'decimal', 'email', 'none', 'numeric', 'search', 'tel', 'text',
+     * and 'url'.
      */
     inputMode?: string;
+    /**
+     * Sets the pattern attribute
+     */
+    pattern?: string;
 }
 
 export interface FieldBoundFloatFieldFbctArgs<ObjType, FieldType> extends FbctArgs<ObjType, FieldType> {
@@ -194,6 +199,9 @@ export class FieldBoundConvertingTextField<ObjType, FieldType> extends HTMLInput
         this.type = extraArgs.type ?? 'text';
         if (extraArgs.inputMode) {
             this.inputMode = extraArgs.inputMode;
+        }
+        if (extraArgs.pattern) {
+            this.pattern = extraArgs.pattern;
         }
         // @ts-expect-error - not sure how to do type def correctly
         this.reloadValue = () => this.value = valueToString(obj[field]);
@@ -359,10 +367,14 @@ export class FieldBoundIntField<ObjType> extends FieldBoundConvertingTextField<O
         };
         extraArgs.preValidators = [skipMinus, ...(extraArgs.preValidators ?? [])];
         extraArgs.postValidators = [intValidator, ...(extraArgs.postValidators ?? [])];
+        const defaultSettings: Partial<FbctArgs<ObjType, number>> = {
+            pattern: "\\d*",
+            inputMode: 'number',
+        };
         // Spinner arrows aren't styleable. Love CSS!
         // extraArgs.type = extraArgs.type ?? 'number';
         // extraArgs.inputMode = extraArgs.inputMode ?? 'numeric';
-        super(obj, field, (s) => s.toString(), (s) => Number(s), extraArgs);
+        super(obj, field, (s) => s.toString(), (s) => Number(s), {...defaultSettings, ...extraArgs});
         if (this.type === 'numeric') {
             if (!this.step) {
                 this.step = '1';
@@ -380,10 +392,14 @@ export class FieldBoundOrUndefIntField<ObjType> extends FieldBoundConvertingText
         };
         extraArgs.preValidators = [skipMinus, ...(extraArgs.preValidators ?? [])];
         extraArgs.postValidators = [intValidator, ...(extraArgs.postValidators ?? [])];
+        const defaultSettings: Partial<FbctArgs<ObjType, number | undefined>> = {
+            pattern: "\\d*",
+            inputMode: 'number',
+        };
         // Spinner arrows aren't styleable. Love CSS!
         // extraArgs.type = extraArgs.type ?? 'number';
         // extraArgs.inputMode = extraArgs.inputMode ?? 'numeric';
-        super(obj, field, (s) => s === undefined ? "" : s.toString(), (s) => s.trim() === "" ? undefined : Number(s), extraArgs);
+        super(obj, field, (s) => s === undefined ? "" : s.toString(), (s) => s.trim() === "" ? undefined : Number(s), {...extraArgs, ...defaultSettings});
         if (this.type === 'numeric') {
             if (!this.step) {
                 this.step = '1';
@@ -403,11 +419,18 @@ export class FieldBoundFloatField<ObjType> extends FieldBoundConvertingTextField
         };
         extraArgs.preValidators = [skipMinus, ...(extraArgs.preValidators ?? [])];
         extraArgs.postValidators = [numberValidator, ...(extraArgs.postValidators ?? [])];
+        const defaultSettings: Partial<FbctArgs<ObjType, number | undefined>> = {
+            // pattern: "\\d*",
+            inputMode: 'decimal',
+        };
         // Spinner arrows aren't styleable. Love CSS!
         // extraArgs.type = extraArgs.type ?? 'number';
         // extraArgs.inputMode = extraArgs.inputMode ?? 'numeric';
         const toStringFunc = extraArgs.fixDecimals ? (x: number) => x.toFixed(extraArgs.fixDecimals) : (x: number) => x.toString();
-        super(obj, field, (s) => toStringFunc(s), (s) => Number(s), extraArgs);
+        if (extraArgs.fixDecimals !== undefined) {
+            defaultSettings.pattern = `[0-9]*\\.?[0-9]{0,${extraArgs.fixDecimals}}`;
+        }
+        super(obj, field, (s) => toStringFunc(s), (s) => Number(s), {...defaultSettings, ...extraArgs});
     }
 }
 

--- a/packages/frontend/src/scripts/components/custom_item_manager.ts
+++ b/packages/frontend/src/scripts/components/custom_item_manager.ts
@@ -74,7 +74,6 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: (item: CustomItem) => {
                     const ilvlInput = new FieldBoundIntField(item, 'ilvl', {
                         postValidators: [nonNegative],
-                        inputMode: 'number',
                     });
                     const capBox = new FieldBoundCheckBox(item, 'respectCaps');
                     const recheck = (ilvl: number) => {
@@ -102,7 +101,6 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: (item: CustomItem) => {
                     return new FieldBoundIntField(item.customData, 'largeMateriaSlots', {
                         postValidators: [clampValues(0, 5)],
-                        inputMode: 'number',
                     });
                 },
                 initialWidth: 60,
@@ -113,7 +111,6 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: (item: CustomItem) => {
                     return new FieldBoundIntField(item.customData, 'smallMateriaSlots', {
                         postValidators: [clampValues(0, 5)],
-                        inputMode: 'number',
                     });
                 },
                 initialWidth: 60,
@@ -126,7 +123,6 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                     renderer: (item: CustomItem) => {
                         return new FieldBoundIntField(item.customData.stats, stat, {
                             postValidators: [nonNegative],
-                            inputMode: 'number',
                         });
                     },
                     initialWidth: 40,
@@ -139,7 +135,6 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: ifWeapon((item: CustomItem) => {
                     return new FieldBoundIntField(item.customData.stats, "wdPhys", {
                         postValidators: [nonNegative],
-                        inputMode: 'number',
                     });
                 }),
                 initialWidth: 40,
@@ -150,7 +145,6 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: ifWeapon((item: CustomItem) => {
                     return new FieldBoundIntField(item.customData.stats, "wdMag", {
                         postValidators: [nonNegative],
-                        inputMode: 'number',
                     });
                 }),
                 initialWidth: 40,
@@ -162,7 +156,6 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: ifWeapon((item: CustomItem) => {
                     const out = new FieldBoundFloatField(item.customData.stats, "weaponDelay", {
                         postValidators: [nonNegative],
-                        inputMode: 'number',
                     });
                     out.title = 'Enter weapon delay in seconds (e.g. 3.125)';
                     return out;
@@ -267,7 +260,6 @@ export class CustomFoodTable extends CustomTable<CustomFood> {
                 renderer: (item: CustomFood) => {
                     return new FieldBoundIntField(item.customData, 'ilvl', {
                         postValidators: [nonNegative],
-                        inputMode: 'number',
                     });
                 },
                 initialWidth: 60,

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -485,7 +485,6 @@ export class MateriaPriorityPicker extends HTMLElement {
                 gcd: val,
             });
         });
-        minGcdInput.pattern = '\\d\\.\\d\\d?';
         minGcdInput.title = 'Enter the minimum desired GCD in the form x.yz.\nSkS/SpS materia will be de-prioritized once this target GCD is met.';
         minGcdInput.classList.add('min-gcd-input');
         this.replaceChildren(header, drag,

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -261,7 +261,6 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
 
         this.useTargetGcdCheckBox = new FieldBoundCheckBox(this.gearsetGenSettings, 'useTargetGcd');
         this.useTargetGcdCheckBox.classList.add('meld-solver-settings');
-        this.targetGcdInput.pattern = '\\d\\.\\d\\d?';
         this.targetGcdInput.title = 'Solve for the best set with this GCD';
         this.targetGcdInput.classList.add('meld-solver-target-gcd-input');
 

--- a/packages/frontend/src/scripts/sims/components/cycle_settings_components.ts
+++ b/packages/frontend/src/scripts/sims/components/cycle_settings_components.ts
@@ -11,7 +11,6 @@ import {NamedSection} from "../../components/section";
 export function cycleSettingsGui(cycleSettings: CycleSettings) {
     const out = new NamedSection('Cycle Settings');
     const timeField = new FieldBoundFloatField(cycleSettings, 'totalTime', {
-        inputMode: 'number',
         // 1 hour of sim time should be enough for any application
         postValidators: [clampValues(0, 60 * 60)],
     });

--- a/packages/frontend/src/scripts/sims/components/result_settings.ts
+++ b/packages/frontend/src/scripts/sims/components/result_settings.ts
@@ -5,9 +5,7 @@ import {ResultSettings} from "@xivgear/core/sims/cycle_sim";
 export class ResultSettingsArea extends NamedSection {
     constructor(resultSettings: ResultSettings) {
         super("Result Settings");
-        const inputField = new FieldBoundFloatField(resultSettings, 'stdDevs', {
-            inputMode: 'number',
-        });
+        const inputField = new FieldBoundFloatField(resultSettings, 'stdDevs');
         const label = labelFor('+/- Standard Deviations', inputField);
         label.style.display = 'block';
         this.appendChild(label);


### PR DESCRIPTION
Closes #538 

This also makes `inputMode: decimal` the default for `FieldBoundFloatField`, and makes `inputMode: number` plus an appropriate `pattern` attribute the defaults for `FieldBoundIntField` and variants.