### PR TITLE
Improve separator editor styling

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -19,7 +19,7 @@
     <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myValues">
         <value>
-          <list size="49">
+          <list size="50">
             <item index="0" class="java.lang.String" itemvalue="nobr" />
             <item index="1" class="java.lang.String" itemvalue="noembed" />
             <item index="2" class="java.lang.String" itemvalue="comment" />
@@ -69,6 +69,7 @@
             <item index="46" class="java.lang.String" itemvalue="meld-solver-result-dialog" />
             <item index="47" class="java.lang.String" itemvalue="settings-modal" />
             <item index="48" class="java.lang.String" itemvalue="expandable-text" />
+            <item index="49" class="java.lang.String" itemvalue="separator-editor" />
           </list>
         </value>
       </option>

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1651,7 +1651,7 @@ add-sim-dialog {
   }
 }
 
-gear-set-editor {
+gear-set-editor, separator-editor {
   div.gear-set-editor-button-area {
     width: 100%;
     text-align: center;

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1004,7 +1004,7 @@ export class SeparatorEditor extends HTMLElement {
 
     formatTitleDesc() {
 
-        this.header.textContent = this.gearSet.name;
+        this.header.textContent = this.gearSet.name.trim().length === 0 ? "<No Name>" : this.gearSet.name;
         const trimmedDesc = this.gearSet.description?.trim();
         if (trimmedDesc) {
             this.desc.style.display = '';


### PR DESCRIPTION
- Adds missing button shadow
- Replaces title with `<No Name>` if there is no name specified.