### PR TITLE
Fix BiS link embeds and improve new bis paths

### DIFF
--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -138,8 +138,8 @@ function resolveNavData(nav: NavPath | null): NavResult | null {
             };
         case "bis":
             return {
-                preloadUrl: getBisSheetFetchUrl(nav.job, nav.folder ?? "", nav.sheet),
-                sheetData: getBisSheet(nav.job, nav.folder ?? "", nav.sheet).then(JSON.parse),
+                preloadUrl: getBisSheetFetchUrl(nav.path),
+                sheetData: getBisSheet(nav.path).then(JSON.parse),
             };
     }
     throw Error(`Unable to resolve nav result: ${nav.type}`);
@@ -260,7 +260,7 @@ export function buildStatsServer() {
             embed: false,
             viewOnly: true,
         };
-        const rawData = await getBisSheet(request.params['job'] as JobName, "", request.params['sheet'] as string);
+        const rawData = await getBisSheet([request.params['job'] as JobName, request.params['sheet'] as string]);
         const out = await importExportSheet(request, JSON.parse(rawData), nav);
         reply.header("cache-control", "max-age=7200, public");
         reply.send(out);
@@ -280,7 +280,7 @@ export function buildStatsServer() {
             embed: false,
             viewOnly: true,
         };
-        const rawData = await getBisSheet(request.params['job'] as JobName, request.params['folder'] as string, request.params['sheet'] as string);
+        const rawData = await getBisSheet([request.params['job'], request.params['folder'], request.params['sheet']]);
         const out = await importExportSheet(request, JSON.parse(rawData), nav);
         reply.header("cache-control", "max-age=7200, public");
         reply.send(out);

--- a/packages/core/src/external/static_bis.ts
+++ b/packages/core/src/external/static_bis.ts
@@ -26,9 +26,9 @@ export function setServerOverride(server: string) {
 export function getBisSheetFetchUrl(path: string[]): URL {
     let current: URL = new URL(getServer());
     for (let i = 0; i < path.length - 1; i++) {
-        current = new URL(`./${path[i]}/`, current);
+        current = new URL(`./${encodeURIComponent(path[i])}/`, current);
     }
-    current = new URL(`./${path[path.length - 1]}.json`, current);
+    current = new URL(`./${encodeURIComponent(path[path.length - 1])}.json`, current);
     return current;
 }
 

--- a/packages/core/src/external/static_bis.ts
+++ b/packages/core/src/external/static_bis.ts
@@ -1,5 +1,3 @@
-import {JobName} from "@xivgear/xivmath/xivconstants";
-
 const STATIC_SERVER: URL = new URL("https://staticbis.xivgear.app/");
 
 const STORAGE_KEY = 'staticbis-server-override';

--- a/packages/core/src/external/static_bis.ts
+++ b/packages/core/src/external/static_bis.ts
@@ -23,11 +23,13 @@ export function setServerOverride(server: string) {
     localStorage.setItem(STORAGE_KEY, server);
 }
 
-export function getBisSheetFetchUrl(job: JobName, folder: string, sheetFileName: string): URL {
-    if (folder) {
-        return new URL(`/${encodeURIComponent(job)}/${encodeURIComponent(folder)}/${encodeURIComponent(sheetFileName)}.json`, getServer());
+export function getBisSheetFetchUrl(path: string[]): URL {
+    let current: URL = new URL(getServer());
+    for (let i = 0; i < path.length - 1; i++) {
+        current = new URL(`./${path[i]}/`, current);
     }
-    return new URL(`/${encodeURIComponent(job)}/${encodeURIComponent(sheetFileName)}.json`, getServer());
+    current = new URL(`./${path[path.length - 1]}.json`, current);
+    return current;
 }
 
 export async function getBisSheet(...params: Parameters<typeof getBisSheetFetchUrl>): Promise<string> {

--- a/packages/core/src/imports/imports.ts
+++ b/packages/core/src/imports/imports.ts
@@ -1,4 +1,3 @@
-import {getBisSheet} from "../external/static_bis";
 import {JobName} from "@xivgear/xivmath/xivconstants";
 import {
     HASH_QUERY_PARAM,

--- a/packages/core/src/imports/imports.ts
+++ b/packages/core/src/imports/imports.ts
@@ -26,7 +26,7 @@ export type EtroImportSpec = {
 }
 export type BisImportSpec = {
     importType: 'bis',
-    path: Parameters<typeof getBisSheet>,
+    path: string[],
     onlySetIndex?: number,
 }
 
@@ -35,6 +35,7 @@ export type ImportSpec = JsonImportSpec | ShortlinkImportSpec | EtroImportSpec |
 const importSheetUrlRegex = RegExp(".*/(?:viewsheet|importsheet)/(.*)$");
 const importSetUrlRegex = RegExp(".*/(?:viewset|importset)/(.*)$");
 const importShortlinkRegex = RegExp(".*/(?:sl|share)/(.*)$");
+// This can remain only supporting the old form, because no legacy URLs would have existed with the new URL style
 const bisRegex = RegExp(".*/bis/(.*?)/(.*?)/(.*?)$");
 const newStyleUrl = RegExp(".*[&?]page=(.*)$");
 const etroRegex = RegExp("https://etro\\.gg/gearset/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})");
@@ -114,7 +115,7 @@ export function parseImport(text: string): ImportSpec {
                     case "bis":
                         return {
                             importType: 'bis',
-                            path: [parsed.job, parsed.folder, parsed.sheet],
+                            path: parsed.path,
                             onlySetIndex: parsed.onlySetIndex,
                         };
                     default:

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -204,7 +204,6 @@ export function parsePath(state: NavState): NavPath | null {
         }
     }
     else if (mainNav === BIS_HASH) {
-        embedWarn();
         if (path.length === 3) {
             return {
                 type: 'bis',
@@ -212,7 +211,7 @@ export function parsePath(state: NavState): NavPath | null {
                 job: path[1] as JobName,
                 sheet: path[2],
                 viewOnly: true,
-                embed: false,
+                embed: embed,
                 onlySetIndex: state.onlySetIndex,
                 defaultSelectionIndex: state.selectIndex,
             };
@@ -223,9 +222,9 @@ export function parsePath(state: NavState): NavPath | null {
                 path: [path[1], path[2], path[3]],
                 job: path[1] as JobName,
                 folder: path[2],
-                sheet: path[3],
+                sheet: path[path.length - 1],
                 viewOnly: true,
-                embed: false,
+                embed: embed,
                 onlySetIndex: state.onlySetIndex,
                 defaultSelectionIndex: state.selectIndex,
             };

--- a/packages/core/src/test/common_nav_test.ts
+++ b/packages/core/src/test/common_nav_test.ts
@@ -254,17 +254,17 @@ describe('parsePath', () => {
                 defaultSelectionIndex: undefined,
             });
         });
-        it('does not try to embed bis', () => {
-            const result = parsePath(new NavState(['embed', 'bis', 'sge', 'endwalker', 'anabaseios']));
+        it('can embed bis', () => {
+            const result = parsePath(new NavState(['embed', 'bis', 'sge', 'endwalker', 'anabaseios'], 1));
             expect(result).to.deep.equals({
                 type: 'bis',
                 path: ['sge', 'endwalker', 'anabaseios'],
                 job: 'sge',
                 folder: 'endwalker',
                 sheet: 'anabaseios',
-                embed: false,
+                embed: true,
                 viewOnly: true,
-                onlySetIndex: undefined,
+                onlySetIndex: 1,
                 defaultSelectionIndex: undefined,
             });
         });

--- a/packages/frontend/src/scripts/components/import_sheet.ts
+++ b/packages/frontend/src/scripts/components/import_sheet.ts
@@ -92,7 +92,7 @@ export class ImportSheetArea extends NamedSection {
                     });
                     return;
                 case "bis":
-                    this.doAsyncImport(() => getBisSheet(...parsed.path), parsed.onlySetIndex);
+                    this.doAsyncImport(() => getBisSheet(parsed.path), parsed.onlySetIndex);
                     return;
             }
         }

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -2181,7 +2181,7 @@ export class ImportSetsModal extends BaseModal {
                     });
                     return;
                 case "bis":
-                    this.doAsyncImport(() => getBisSheet(...parsed.path), parsed.onlySetIndex);
+                    this.doAsyncImport(() => getBisSheet(parsed.path), parsed.onlySetIndex);
                     return;
             }
         }


### PR DESCRIPTION
- Changes getBisSheet/getBisSheetFetchUrl to accept a single `path: string[]` argument instead of the old-style.
- Make embedding work correctly with BiS links
- Fix importing for new BiS paths
- Fix a few missing error cases
Fixes https://github.com/xiv-gear-planner/static-bis-sets/issues/9