### PR TITLE
Improve solver results, fix a bug, and change meld totals

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1100,6 +1100,7 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
           font-size: 30px;
           text-align: center;
         }
+
         &[col-id="name"] {
           padding-top: 10px;
           padding-bottom: 10px;
@@ -1108,6 +1109,7 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
             font-weight: bold;
             font-size: 17px;
           }
+
           div.bis-sheet-description {
             font-size: 15px;
             opacity: 75%;
@@ -2528,6 +2530,7 @@ food-stat-bonus {
         padding-right: var(--slash-padding);
 
       }
+
       opacity: 50%;
     }
   }
@@ -2585,7 +2588,8 @@ table.food-items-table {
 
     food-stat-bonus {
       flex-direction: column;
-      >* {
+
+      > * {
         text-align: left;
       }
     }
@@ -2663,12 +2667,12 @@ gear-set-viewer {
     .standard-round-border;
     background-color: var(--table-bg-color);
     padding: 5px;
-    display: grid;
-    grid-template-columns: repeat(var(--materia-total-cols, 4), auto);
     text-align: left;
     margin-left: auto;
     margin-right: auto;
     max-width: 556px;
+    min-height: 22px;
+    display: block;
     @media screen and (max-width: 550px) {
       --materia-total-cols: 3;
     }
@@ -2676,8 +2680,26 @@ gear-set-viewer {
       --materia-total-cols: 2;
     }
 
-    span.materia-totals-label {
-      padding-left: 40px;
+    .materia-totals-label {
+      text-align: center;
+      margin: auto;
+    }
+
+    &.materia-totals-expanded {
+      display: grid;
+      grid-template-columns: repeat(var(--materia-total-cols, 4), auto);
+      .materia-totals-label {
+        display: none;
+      }
+    }
+
+    &.materia-totals-collapsed {
+      &:hover {
+        background-color: var(--input-hover-background-color);
+      }
+      materia-count-display {
+        display: none;
+      }
     }
 
     materia-count-display {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2666,44 +2666,41 @@ gear-set-viewer {
   materia-totals-display {
     .standard-round-border;
     background-color: var(--table-bg-color);
-    padding: 5px;
+    padding: 10px;
     text-align: left;
     margin-left: auto;
     margin-right: auto;
     max-width: 556px;
     min-height: 22px;
-    display: block;
-    @media screen and (max-width: 550px) {
-      --materia-total-cols: 3;
-    }
-    @media screen and (max-width: 400px) {
+    display: flex;
+    flex-direction: row;
+    --materia-total-cols: auto;
+    @media screen and (max-width: 600px) {
       --materia-total-cols: 2;
     }
 
+
     .materia-totals-label {
-      text-align: center;
+      flex-basis: min-content;
+      flex-grow: 0;
       margin: auto;
     }
+    .materia-totals-inner {
+      &:has(:nth-last-child(4):first-child) {
+        --materia-total-cols: 2;
+      }
+      flex-basis: max-content;
+      flex-grow: 1;
 
-    &.materia-totals-expanded {
-      display: grid;
-      grid-template-columns: repeat(var(--materia-total-cols, 4), auto);
-      .materia-totals-label {
-        display: none;
-      }
-    }
-
-    &.materia-totals-collapsed {
-      &:hover {
-        background-color: var(--input-hover-background-color);
-      }
-      materia-count-display {
-        display: none;
-      }
+      columns: auto;
+      column-width: 150px;
+      column-gap: 3px;
+      column-fill: balance;
     }
 
     materia-count-display {
-      display: inline-block;
+      display: block;
+      padding: 3px;
 
       .materia-count-quantity {
         text-align: right;

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -691,11 +691,21 @@ export class MateriaTotalsDisplay extends HTMLElement {
             }
             return primary;
         });
-        const totalsText = document.createElement('span');
+        this.classList.add('materia-totals-collapsed');
+        const totalsText = document.createElement('div');
         totalsText.classList.add('materia-totals-label');
-        totalsText.textContent = 'Totals: ';
+        totalsText.textContent = 'Show Materia Totals';
         this.appendChild(totalsText);
-        elements.forEach(element => this.appendChild(element));
+        elements.forEach(element => {
+            this.appendChild(element);
+        });
+        const listener = () => {
+            this.classList.add('materia-totals-expanded');
+            this.classList.remove('materia-totals-collapsed');
+            this.removeEventListener('click', listener);
+        };
+        this.addEventListener('click', listener);
+
         this.empty = elements.length === 0;
     }
 

--- a/packages/frontend/src/scripts/components/materia.ts
+++ b/packages/frontend/src/scripts/components/materia.ts
@@ -691,21 +691,9 @@ export class MateriaTotalsDisplay extends HTMLElement {
             }
             return primary;
         });
-        this.classList.add('materia-totals-collapsed');
-        const totalsText = document.createElement('div');
-        totalsText.classList.add('materia-totals-label');
-        totalsText.textContent = 'Show Materia Totals';
-        this.appendChild(totalsText);
-        elements.forEach(element => {
-            this.appendChild(element);
-        });
-        const listener = () => {
-            this.classList.add('materia-totals-expanded');
-            this.classList.remove('materia-totals-collapsed');
-            this.removeEventListener('click', listener);
-        };
-        this.addEventListener('click', listener);
-
+        const totalsText = quickElement('div', ['materia-totals-label'], ['Totals:']);
+        const inner = quickElement('div', ['materia-totals-inner'], elements);
+        this.replaceChildren(totalsText, inner);
         this.empty = elements.length === 0;
     }
 

--- a/packages/frontend/src/scripts/components/meld_solver_modal.ts
+++ b/packages/frontend/src/scripts/components/meld_solver_modal.ts
@@ -359,10 +359,9 @@ class MeldSolverSettingsMenu extends HTMLDivElement {
 }
 
 class MateriaEntry extends HTMLDivElement {
-    materiaImgHolder: HTMLDivElement;
-    textContainer: HTMLSpanElement;
-    statText: HTMLSpanElement;
-    countText: HTMLSpanElement;
+    private readonly materiaImgHolder: HTMLDivElement;
+    private readonly statText: HTMLSpanElement;
+    private readonly countText: HTMLSpanElement;
 
     constructor(materia: Materia, count: number) {
         super();
@@ -382,18 +381,24 @@ class MateriaEntry extends HTMLDivElement {
         this.countText.textContent = `× ${count}`;
         this.countText.classList.add('meld-solver-result-materia-entry-count');
 
-        this.textContainer = document.createElement('div');
-        this.textContainer.replaceChildren(this.statText, this.countText);
-        this.textContainer.classList.add('meld-solver-result-materia-entry-text');
-
-        this.replaceChildren(this.materiaImgHolder, this.textContainer);
+        this.replaceChildren(this.materiaImgHolder, this.statText, this.countText);
     }
+}
+
+// @ts-expect-error asdfsadfdsafdsafa
+window['srt'] = () => {
+    new MeldSolverConfirmationDialog(window.currentSheet, window.currentGearSet, window.currentGearSet, [12345, 13579], () => {
+    }).attachAndShow();
+};
+
+type RowElements = {
+    newEle: HTMLElement;
+    oldEle: HTMLElement;
+    deltaEle: HTMLElement | null;
 }
 
 class MeldSolverConfirmationDialog extends BaseModal {
 
-    newMateriaTotalsList: HTMLDivElement;
-    oldMateriaTotalsList: HTMLDivElement;
     newSet: CharacterGearSet;
     oldSet: CharacterGearSet;
     sheet: GearPlanSheetGui;
@@ -407,14 +412,6 @@ class MeldSolverConfirmationDialog extends BaseModal {
         this.oldSet = oldSet;
         this.newSet = newSet;
 
-        this.headerText = "Solver Results";
-        const form = document.createElement("form");
-        form.method = 'dialog';
-        form.classList.add('meld-solver-result');
-        // this.inner.style.maxWidth = "35%";
-        // this.inner.style.width = "35%"
-        //this.inner.style.maxWidth = "4%"; // idk why this doesn't work in common-css but it don't.
-
         if (!newSet) {
             this.headerText = "No Results Found";
 
@@ -425,13 +422,22 @@ class MeldSolverConfirmationDialog extends BaseModal {
             return;
         }
 
+        this.headerText = "Solver Results";
+        // This holds the results
+        const form = document.createElement("form");
+        form.method = 'dialog';
+        form.classList.add('meld-solver-result');
+
         const materiaTotals = MeldSolverConfirmationDialog.getMateriaTotals(oldSet, newSet);
 
-        [this.oldMateriaTotalsList, this.newMateriaTotalsList] = this.buildMateriaLists([`"${oldSet.name}"`, "Solved Set"], materiaTotals, [oldSimResult, newsimResult]);
+        const elements = this.buildMateriaLists([`"${oldSet.name}"`, "Solved Set"], materiaTotals, [oldSimResult, newsimResult]);
 
         const arrow = document.createElement('span');
         arrow.textContent = "→";
-        arrow.classList.add("arrow");
+        arrow.classList.add("arrow", 'meld-results-arrow');
+        arrow.style.gridRow = '1';
+        arrow.style.gridColumn = '4';
+        arrow.style.gridRowEnd = '-1';
 
         this.applyButton = makeActionButton("Apply", (ev) => {
 
@@ -452,19 +458,39 @@ class MeldSolverConfirmationDialog extends BaseModal {
         this.addButton(this.applyButton);
         this.addButton(this.discardButton);
 
-        form.replaceChildren(this.oldMateriaTotalsList, arrow, this.newMateriaTotalsList);
+        const all = [arrow];
+        elements.forEach((elems, idx) => {
+            const oldEle = elems.oldEle;
+            oldEle.classList.add('cols-left');
+            oldEle.style.gridRow = `${idx + 1}`;
+            all.push(oldEle);
+            const newEle = elems.newEle;
+            newEle.classList.add('cols-right');
+            newEle.style.gridRow = `${idx + 1}`;
+            all.push(newEle);
+            const deltaEle = elems.deltaEle;
+            if (deltaEle) {
+                deltaEle.classList.add('cols-middle');
+                deltaEle.style.gridRow = `${idx + 1}`;
+                all.push(deltaEle);
+            }
+        });
+        form.replaceChildren(...all);
         this.contentArea.append(form);
     }
 
-    buildMateriaLists([oldName, newName]: [string, string], matTotals: Map<Materia, [number, number]>, [oldSimResult, newSimResult]: [number, number]): [HTMLDivElement, HTMLDivElement] {
-        const [oldSet, newSet] = [document.createElement('div'), document.createElement('div')];
-        oldSet.classList.add("meld-solver-result-set");
-        newSet.classList.add("meld-solver-result-set");
+    buildMateriaLists([oldName, newName]: [string, string], matTotals: Map<Materia, [number, number]>, [oldSimResult, newSimResult]: [number, number]): RowElements[] {
+        const out: RowElements[] = [];
         const [oldHead, newHead] = [document.createElement('h3'), document.createElement('h3')];
         oldHead.textContent = oldName;
         newHead.textContent = newName;
-        oldSet.appendChild(oldHead);
-        newSet.appendChild(newHead);
+        oldHead.classList.add('cols-left');
+        newHead.classList.add('cols-right');
+        out.push({
+            oldEle: oldHead,
+            newEle: newHead,
+            deltaEle: null,
+        });
 
         const [oldResultElem, newResultElem] = [document.createElement('span'), document.createElement('span')];
         oldResultElem.textContent = oldSimResult.toFixed(2);
@@ -475,22 +501,28 @@ class MeldSolverConfirmationDialog extends BaseModal {
             delta = newSimResult * 0.001;
         }
 
-        oldResultElem.classList.add(`meld-solver-result-set-sim`);
-        newResultElem.classList.add(`meld-solver-result-set-sim`);
+        oldResultElem.classList.add(`meld-solver-result-set-sim`, 'cols-left');
+        newResultElem.classList.add(`meld-solver-result-set-sim`, 'cols-right');
         oldResultElem.style.setProperty("--sim-result-relative", 0 + '%');
         newResultElem.style.setProperty("--sim-result-relative", ((newSimResult - oldSimResult) / delta * 100).toFixed(1) + '%');
         if (newSimResult > oldSimResult) {
-            newResultElem.style.fontWeight = "bold";
+            newResultElem.classList.add('sim-best', 'cols-right');
+        }
+        else if (newSimResult < oldSimResult) {
+            oldResultElem.classList.add('sim-best', 'cols-right');
         }
         //newResultElem.classList.add(`meld-solver-result-set-sim-${newBetter ? "better" : "worse"}`);
 
-        oldSet.appendChild(oldResultElem);
-        newSet.appendChild(newResultElem);
+        out.push({
+            oldEle: oldResultElem,
+            newEle: newResultElem,
+            deltaEle: null,
+        });
 
-        const oldList = document.createElement('ul');
-        const newList = document.createElement('ul');
         for (const [mat, [oldTotal, newTotal]] of matTotals) {
-            const [oldItem, newItem] = [document.createElement('li'), document.createElement('li')];
+            const [oldItem, newItem] = [document.createElement('div'), document.createElement('div')];
+            oldItem.classList.add('solve-result-mat-entry-holder', 'cols-left');
+            newItem.classList.add('solve-result-mat-entry-holder', 'cols-right');
 
             const [oldEntry, newEntry] = [new MateriaEntry(mat, oldTotal), new MateriaEntry(mat, newTotal)];
 
@@ -508,14 +540,14 @@ class MeldSolverConfirmationDialog extends BaseModal {
 
             oldItem.appendChild(oldEntry);
             newItem.appendChild(newEntry);
-            newItem.appendChild(deltaElem);
-            oldList.appendChild(oldItem);
-            newList.appendChild(newItem);
+            out.push({
+                oldEle: oldItem,
+                newEle: newItem,
+                deltaEle: deltaElem,
+            });
         }
 
-        oldSet.appendChild(oldList);
-        newSet.appendChild(newList);
-        return [oldSet, newSet];
+        return out;
     }
 
     static getMateriaTotals(oldSet: CharacterGearSet, newSet: CharacterGearSet): Map<Materia, [number, number]> {

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -2007,6 +2007,10 @@ export class GearPlanSheetGui extends GearPlanSheet {
         if (!(this._editorItem instanceof CharacterGearSet)) {
             return;
         }
+        if (this.sims.length === 0) {
+            alert('You must add a simulation to the sheet before you can use the meld solver.');
+            return;
+        }
         const meldSolveDialog = new MeldSolverDialog(this, this.editorItem as CharacterGearSet);
         document.querySelector('body').appendChild(meldSolveDialog);
         meldSolveDialog.show();

--- a/packages/frontend/src/style.less
+++ b/packages/frontend/src/style.less
@@ -49,20 +49,33 @@ sim-result-detail-display {
 }
 
 meld-solver-result-dialog {
+  // The main body of the results
   .meld-solver-result {
-    display: flex;
-    flex-direction: row;
+    --img-col-width: 40px;
+    --bonus-col-width: 1fr;
+    --count-col-width: 50px;
+    --arrow-col-width: 60px;
+    display: grid;
+    // Columns:
+    // Left materia image
+    // Left materia bonus
+    // Left materia count
+    // Arrow/Delta
+    // Right materia image
+    // Right materia bonus
+    // Right materia count
+    grid-template-columns: var(--img-col-width) var(--bonus-col-width) var(--count-col-width) var(--arrow-col-width) var(--img-col-width) var(--bonus-col-width) var(--count-col-width);
+    gap: 15px 5px;
 
     span.arrow {
-      margin: 20px;
+      margin: 10px;
       font-size: xx-large;
     }
-  }
 
-  .meld-solver-result-set {
-    width: 40%;
-    padding: 0;
-    margin: 0;
+    .meld-results-arrow {
+      grid-column: 4;
+      grid-row: 1/-1;
+    }
 
     .meld-solver-result-set-sim {
       color: color-mix(in srgb, currentColor var(--sim-color-mix-percent), color-mix(in hsl, #00ff00 var(--sim-result-relative, 50%), #ff0000));
@@ -71,69 +84,70 @@ meld-solver-result-dialog {
     .sim-best {
       font-weight: bold;
     }
-  }
 
-  ul {
-    display: flex;
-    flex-direction: column;
-
-    li {
-      display: flex;
-      margin-top: 5px;
-      margin-bottom: 5px;
+    .cols-left {
+      grid-column: 1 / span 3;
     }
 
-    list-style-type: none;
-    padding-inline-start: 0px;
-  }
-
-  .meld-solver-result-materia-entry {
-    display: contents;
-
-    --image-size: 25px;
-
-    div.meld-solver-result-image {
-      overflow: clip;
-      width: var(--image-size);
-      height: var(--image-size);
-      margin-right: 3%;
-      border-radius: 100%;
+    .cols-right {
+      grid-column: 5 / span 3;
     }
 
-    img {
-      //width: 100%;
-      height: 100%;
-      display: block;
-      aspect-ratio: 1;
+    .cols-middle {
+      grid-column: 4;
     }
 
-    .meld-solver-result-materia-entry-text {
-      width: 100%;
-      text-align: left;
-      display: flex;
-      flex-direction: row;
+    .solve-result-mat-entry-holder {
+      display: grid;
+      grid-template-columns: subgrid;
+      grid-template-rows: subgrid;
 
-      .meld-solver-result-materia-entry-count {
-        width: 35%;
-        margin-left: 5%;
-        text-align: left;
+
+      .meld-solver-result-materia-entry {
+        display: contents;
+
+        --image-size: 25px;
+
+        .meld-solver-result-image {
+          grid-column: 1;
+          overflow: clip;
+          width: var(--image-size);
+          height: var(--image-size);
+          margin-right: 3%;
+          border-radius: 100%;
+          text-align: right;
+          margin-left: auto;
+
+          img {
+            //width: 100%;
+            height: 100%;
+            display: block;
+            aspect-ratio: 1;
+          }
+        }
+
+        .meld-solver-result-materia-entry-stat {
+          text-align: left;
+          grid-column: 2;
+        }
+
+        .meld-solver-result-materia-entry-count {
+          margin-left: 5%;
+          text-align: left;
+          grid-column: 3;
+        }
+
       }
-
-      .meld-solver-result-materia-entry-stat {
-        width: 60%;
-        text-align: left;
-      }
     }
   }
+
 
   .meld-solver-result-materia-entry-delta {
-    width: 20%;
-    text-align: left;
+    text-align: center;
   }
 
   .meld-solver-result-materia-entry-zero {
     color: var(--border-color-default);
-    //background-color: var(--scrollbar-bg);
   }
 
   .meld-solver-result-materia-entry-diff {
@@ -150,6 +164,7 @@ meld-solver-area, meld-solver-result-dialog {
 
 img.item-icon {
   border-radius: 10%;
+
   &.loaded {
     border-radius: unset;
     background: unset;
@@ -165,7 +180,7 @@ img.item-rarity-green {
 }
 
 img.item-rarity-blue {
-  background: radial-gradient(circle at 35% 35%,#63a0c9, #203c8b 50%);
+  background: radial-gradient(circle at 35% 35%, #63a0c9, #203c8b 50%);
 }
 
 img.item-rarity-relic {


### PR DESCRIPTION
- Improves the solver results dialog. Layout same except for moving the delta column to the middle, under the arrow. Internally, it uses a CSS flex grid to make sure things stay aligned even if cell heights vary due to text wrapping.
- Display an alert if the user attempts to open the meld solve dialog when the sheet has no sims, rather than silently failing.
- The materia totals is collapsed by default and expands after being clicked (might revert or rethink this)