### PR TITLE
Minify JS without breaking webworker

### DIFF
--- a/.github/workflows/frontend_docker.yml
+++ b/.github/workflows/frontend_docker.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build
         run: |
           npm ci
-          npm run build
+          npm run buildprod
           npm run test
           npm run docs
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,6 @@
 {
   "name": "gearplan",
   "version": "1.0.0",
-  "browser": {
-    "[module-name]": false
-  },
   "workspaces": [
     "packages/util",
     "packages/i18n",
@@ -33,6 +30,7 @@
   },
   "scripts": {
     "build": "npm run build --workspaces",
+    "buildprod": "npm run buildprod --workspaces",
     "docs": "npx --workspaces typedoc --json build/docs.json --exclude '**/scripts/test/**/*.ts' --excludePrivate --entryPointStrategy expand src/ && npx typedoc --entryPointStrategy merge packages/*/build/docs.json --readme API_DOC.md --out packages/frontend/dist/docs",
     "test": "npm run --workspaces --if-present test",
     "serve": "npx -w @xivgear/gearplan-frontend webpack serve",

--- a/packages/backend-resolver/package.json
+++ b/packages/backend-resolver/package.json
@@ -5,6 +5,7 @@
   "main": "server.js",
   "scripts": {
     "build": "tsc --build",
+    "buildprod": "tsc --build",
     "test": "ts-mocha --parallel=true src/test/**/*.ts"
   },
   "dependencies": {

--- a/packages/common-ui/package.json
+++ b/packages/common-ui/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "buildprod": "tsc --build"
   },
   "dependencies": {
     "@xivgear/core": "^1.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "build": "tsc --build",
+    "buildprod": "tsc --build",
     "test": "ts-mocha --exit 'src/test/**/*test.ts' 'src/test/**/*tests.ts'"
   },
   "dependencies": {

--- a/packages/data-api-client/package.json
+++ b/packages/data-api-client/package.json
@@ -5,7 +5,8 @@
     "./*": "./src/*.ts"
   },
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "buildprod": "tsc --build"
   },
   "files": [
     "package.json",

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -33,13 +33,10 @@
   },
   "scripts": {
     "build": "tsc --build && lessc --source-map ./src/style.less dist/style.css && webpack --mode=development",
-    "buildprod": "tsc --build && webpack --mode=development && lessc --source-map ./src/style.less dist/style.css",
+    "buildprod": "tsc --build && lessc --source-map ./src/style.less dist/style.css && webpack --mode=production",
     "web": "webpack --mode=development",
     "webprod": "webpack --mode=production",
     "less": "lessc --source-map ./src/style.less dist/style.css",
     "test": "ts-mocha --parallel=true src/scripts/test/**/*test.ts src/scripts/test/**/*tests.ts"
-  },
-  "browser": {
-    "[module-name]": false
   }
 }

--- a/packages/frontend/webpack.config.js
+++ b/packages/frontend/webpack.config.js
@@ -15,8 +15,10 @@ module.exports = (env, argv) => {
         },
         optimization: {
             minimize: prod,
+            chunkIds: 'named',
         },
-        devtool: prod ? 'nosources-source-map' : 'source-map',
+        // devtool: prod ? 'nosources-source-map' : 'source-map',
+        devtool: 'source-map',
         module: {
             rules: [
                 {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "build": "tsc --build"
+    "build": "tsc --build",
+    "buildprod": "tsc --build"
   },
   "devDependencies": {
     "ts-node": "^10.9.2",

--- a/packages/math-frontend/package.json
+++ b/packages/math-frontend/package.json
@@ -29,12 +29,9 @@
   },
   "scripts": {
     "build": "tsc --build && webpack --mode=development && lessc --source-map ./src/style.less dist/style.css",
-    "buildprod": "tsc --build && webpack --mode=development && lessc --source-map ./src/style.less dist/style.css",
+    "buildprod": "tsc --build && webpack --mode=production && lessc --source-map ./src/style.less dist/style.css",
     "web": "webpack --mode=development",
     "webprod": "webpack --mode=production",
     "less": "lessc --source-map ./src/style.less dist/style.css"
-  },
-  "browser": {
-    "[module-name]": false
   }
 }

--- a/packages/util/package.json
+++ b/packages/util/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "build": "tsc --build",
+    "buildprod": "tsc --build",
     "test": "ts-mocha --exit 'src/test/**/*test.ts' 'src/test/**/*tests.ts'"
   },
   "devDependencies": {

--- a/packages/xivmath/package.json
+++ b/packages/xivmath/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "scripts": {
     "build": "tsc --build",
+    "buildprod": "tsc --build",
     "test": "ts-mocha src/test/**/*tests.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
Turns minimization (back) on, without breaking anything (hopefully).
- `chunkIds: 'named',` retains the deterministic filenames so that the webworker script has a fixed filename
- `devtool: 'source-map',` retains working source maps alongside minimized JS, without packing the source map into the JS