### PR TITLE
Double click a row to hide all slots

### DIFF
--- a/packages/common-ui/src/components/show_hide_chevron.ts
+++ b/packages/common-ui/src/components/show_hide_chevron.ts
@@ -1,9 +1,11 @@
 import {makeChevronDown} from "./util";
 
+export type ShowHideCallback = (newState: boolean, clickCount: number) => void;
+
 export class ShowHideButton extends HTMLElement {
     private _hidden: boolean;
 
-    constructor(initiallyHidden: boolean = false, private setter: (newValue: boolean) => void) {
+    constructor(initiallyHidden: boolean = false, private callback: ShowHideCallback) {
         super();
         this._hidden = initiallyHidden;
         this.appendChild(makeChevronDown());
@@ -17,11 +19,16 @@ export class ShowHideButton extends HTMLElement {
     set isHidden(hide: boolean) {
         this._hidden = hide;
         this.setStyles();
-        this.setter(hide);
+        this.callback(hide, 1);
     }
 
-    toggle(): void {
-        this.isHidden = !this.isHidden;
+    toggle(clickCount: number = 1): void {
+        if (clickCount === 1) {
+            this.isHidden = !this.isHidden;
+        }
+        else {
+            this.callback(this.isHidden, clickCount);
+        }
     }
 
     private setStyles() {

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -170,6 +170,11 @@ export class SetDisplaySettings {
         this.hiddenSlots.set(slot, hidden);
     }
 
+    setAllHidden(hidden: boolean) {
+        console.log("setAllHidden: " + hidden);
+        EquipSlots.forEach(slot => this.setSlotHidden(slot, hidden));
+    }
+
     export(): SetDisplaySettingsExport {
         const hiddenSlots: EquipSlotKey[] = [];
         this.hiddenSlots.forEach((value, key) => {
@@ -887,8 +892,6 @@ export class CharacterGearSet {
         return this._sheet.isStatRelevant(stat);
     }
 
-    private collapsed: boolean;
-
     /**
      * Whether a particular slot should be collapsed on the UI.
      * @param slotId
@@ -899,6 +902,10 @@ export class CharacterGearSet {
 
     setSlotCollapsed(slotId: EquipSlotKey, val: boolean) {
         this.displaySettings.setSlotHidden(slotId, val);
+    }
+
+    setAllSlotsCollapsed(val: boolean) {
+        this.displaySettings.setAllHidden(val);
     }
 
     /*

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -906,19 +906,23 @@ export class GearSetEditor extends HTMLElement {
         const leftSideSlots = ['Head', 'Body', 'Hand', 'Legs', 'Feet'] as const;
         const rightSideSlots = ['Ears', 'Neck', 'Wrist', 'RingLeft', 'RingRight'] as const;
 
-        const weaponTable = new GearItemsTable(this.sheet, this.gearSet, itemMapping, this.sheet.classJobStats.offhand ? ['Weapon', 'OffHand'] : ['Weapon']);
+        const showHideAllCallback = () => {
+            this.gearTables.forEach(tbl => tbl.recheckHiddenSlots());
+        };
+
+        const weaponTable = new GearItemsTable(this.sheet, this.gearSet, itemMapping, this.sheet.classJobStats.offhand ? ['Weapon', 'OffHand'] : ['Weapon'], showHideAllCallback);
         const leftSideDiv = document.createElement('div');
         const rightSideDiv = document.createElement('div');
 
         this.gearTables = [weaponTable];
 
         for (const slot of leftSideSlots) {
-            const table = new GearItemsTable(this.sheet, this.gearSet, itemMapping, [slot]);
+            const table = new GearItemsTable(this.sheet, this.gearSet, itemMapping, [slot], showHideAllCallback);
             leftSideDiv.appendChild(table);
             this.gearTables.push(table);
         }
         for (const slot of rightSideSlots) {
-            const table = new GearItemsTable(this.sheet, this.gearSet, itemMapping, [slot]);
+            const table = new GearItemsTable(this.sheet, this.gearSet, itemMapping, [slot], showHideAllCallback);
             rightSideDiv.appendChild(table);
             this.gearTables.push(table);
         }


### PR DESCRIPTION
Fixes #474 

If you double-click a show/hide thing for a gear slot instead of single-clicking, it will show/hide every gear slot at once.