### PR TITLE
Add default sims when none are specified in an import

### DIFF
--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -74,7 +74,16 @@ export class SheetProvider<SheetType extends GearPlanSheet> {
      * @param importedData
      */
     fromExport(importedData: SheetExport): SheetType {
-        return this.construct(undefined, importedData);
+        const sheet = this.construct(undefined, importedData);
+        // If sims are not specified at all in the import, add the defaults.
+        // Note that this will not add sims if they are specified as [], only
+        // if unspecified.
+        // We check the import data here as the sheet will have sims = [] at this
+        // point.
+        if (importedData.sims === undefined) {
+            sheet.addDefaultSims();
+        }
+        return sheet;
     }
 
     /**


### PR DESCRIPTION
This will add the default sims to a sheet if sims are unspecified (i.e. undefined, not set to `[]`). This won't affect users who intentionally want to import/export a set with no sims as sims will be exported as `[]`, this just provides a means to add the default sims for an export that doesn't know what they are.

This also matches other import logic, which does similar checks.