### PR TITLE
Implement the triple lunar rotation

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_types.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_types.ts
@@ -22,7 +22,7 @@ export type MnkOgcdAbility = OgcdAbility & MnkAbility;
 /** Abilities may cost or gain balls, as well as build beast chakras while blitzing */
 export type FuryType = 'opo' | 'raptor' | 'coeurl';
 
-export type Opener = "SL" | "LL";
+export type Opener = "SL" | "LL" | "LLL";
 
 /** Represents the Monk gauge state */
 export type MNKGaugeState = {


### PR DESCRIPTION
Another rotation for long encounters. Now that rotations can be selected by the end user I thought it would be valuable to have the 3rd monk rotation displayed. Previously I didn't think it was worth including as if it simmed the highest it would not be representative of "average play".