### PR TITLE
Improve stat tier display on narrow screens

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2142,14 +2142,28 @@ div.gear-set-editor-toolbar, set-view-toolbar {
       margin: 0;
 
       .single-stat-tier-display {
-        min-width: unset;
-        --inner-padding: 2px;
+        min-width: 50px;
+        --inner-padding: 0px;
+        height: auto;
+
+        .single-stat-tier-display-upper-short {
+          display: block;
+        }
+
+        .single-stat-tier-display-upper-long {
+          display: none;
+        }
+
+        .single-stat-tier-display-lower-right {
+          width: unset;
+          display: block;
+        }
       }
     }
 
   }
 
-  div.single-stat-tier-display {
+  .single-stat-tier-display {
     .standard-round-border;
     position: relative;
     padding: 2px;
@@ -2167,9 +2181,16 @@ div.gear-set-editor-toolbar, set-view-toolbar {
       cursor: default;
     }
 
-    div.single-stat-tier-display-upper {
-      display: block;
+    .single-stat-tier-display-upper {
       transition: all var(--transition-time) linear;
+
+      &.single-stat-tier-display-upper-short {
+        display: none;
+      }
+
+      &.single-stat-tier-display-upper-long {
+        display: block;
+      }
     }
 
     border-color: color-mix(in srgb, var(--stat-color) 20%, var(--border-color));
@@ -2685,10 +2706,12 @@ gear-set-viewer {
       flex-grow: 0;
       margin: auto;
     }
+
     .materia-totals-inner {
       &:has(:nth-last-child(4):first-child) {
         --materia-total-cols: 2;
       }
+
       flex-basis: max-content;
       flex-grow: 1;
 

--- a/packages/frontend/src/scripts/components/stat_tier_display.ts
+++ b/packages/frontend/src/scripts/components/stat_tier_display.ts
@@ -30,6 +30,8 @@ interface TieringOffset {
 
 interface TieringDisplay {
     label: string,
+    // Alt short label
+    shortLabel?: string,
     fullName: string,
     description: string,
     tieringFunc: (offset: number) => Tiering,
@@ -40,6 +42,7 @@ export class SingleStatTierDisplay extends HTMLDivElement {
     private readonly lowerLeftDiv: HTMLDivElement;
     private readonly lowerRightDiv: HTMLDivElement;
     private readonly upperDiv: HTMLDivElement;
+    private readonly upperDivShort: HTMLDivElement;
     private readonly expansionDiv: HTMLDivElement;
     private _expanded: boolean;
     private _clickable: boolean;
@@ -50,8 +53,11 @@ export class SingleStatTierDisplay extends HTMLDivElement {
         this.classList.add('single-stat-tier-display');
         this.classList.add('stat-' + stat);
         this.upperDiv = document.createElement('div');
-        this.upperDiv.classList.add('single-stat-tier-display-upper');
+        this.upperDiv.classList.add('single-stat-tier-display-upper', 'single-stat-tier-display-upper-long');
         this.appendChild(this.upperDiv);
+        this.upperDivShort = document.createElement('div');
+        this.upperDivShort.classList.add('single-stat-tier-display-upper', 'single-stat-tier-display-upper-short');
+        this.appendChild(this.upperDivShort);
 
         this.lowerLeftDiv = document.createElement('div');
         // Lower bound
@@ -74,6 +80,8 @@ export class SingleStatTierDisplay extends HTMLDivElement {
         // Formatting of the base element (always visible)
         this.upperDiv.textContent = tiering.label;
         this.upperDiv.title = `${tiering.label}: ${tiering.description}`;
+        this.upperDivShort.textContent = tiering.shortLabel ?? tiering.label;
+        this.upperDivShort.title = `${tiering.label}: ${tiering.description}`;
         {
             const baseTiering = tiering.tieringFunc(0);
             if (baseTiering.lower > 0) {
@@ -338,6 +346,7 @@ export class StatTierDisplay extends HTMLDivElement {
                 else {
                     tierDisplays.push({
                         label: abbrev + ' GCD',
+                        shortLabel: 'GCD',
                         fullName: 'GCD for spells',
                         description: 'Global cooldown (recast) time for spells',
                         tieringFunc: makeTiering(value => {
@@ -349,6 +358,7 @@ export class StatTierDisplay extends HTMLDivElement {
                 }
                 return [...tierDisplays, {
                     label: abbrev + ' DoT',
+                    shortLabel: 'DoT',
                     fullName: 'DoT scalar for spells',
                     description: 'DoT damage multiplier for spells',
                     tieringFunc: makeTiering(value => spsTickMulti(levelStats, value)),
@@ -375,6 +385,7 @@ export class StatTierDisplay extends HTMLDivElement {
                 else {
                     tierDisplays.push({
                         label: abbrev + ' GCD',
+                        shortLabel: 'GCD',
                         fullName: 'GCD for weaponskills',
                         description: 'Global cooldown (recast) time for weaponskills',
                         tieringFunc: makeTiering(value => {
@@ -387,6 +398,7 @@ export class StatTierDisplay extends HTMLDivElement {
 
                 return [...tierDisplays, {
                     label: abbrev + ' DoT',
+                    shortLabel: 'DoT',
                     fullName: 'DoT scalar for weaponskills',
                     description: 'DoT damage multiplier for weaponskills',
                     tieringFunc: makeTiering(value => sksTickMulti(levelStats, value)),


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/223dbe45-a215-43a9-b1c4-2aaa49bcb70a)

Fixes the stat displays on very narrow screens.

This also introduces a new "shortLabel" optional property which allows tiering labels to be even shorter, e.g. "SpS DoT" -> just "DoT". 