### PR TITLE
Custom item UI improvements

### DIFF
--- a/packages/common-ui/src/components/util.ts
+++ b/packages/common-ui/src/components/util.ts
@@ -54,11 +54,15 @@ export class DataSelect<X> extends HTMLSelectElement {
 
 let idCounter = 1;
 
+export function randomId(prefix: string = 'unique-id-') : string{
+    return prefix + (idCounter++);
+}
+
 export function labelFor(label: string, labelFor: HTMLElement) {
     const element = document.createElement("label");
     element.textContent = label;
     if (!labelFor.id) {
-        labelFor.id = 'lbl-id-' + idCounter++;
+        labelFor.id = randomId('lbl-id-');
     }
     element.htmlFor = labelFor.id;
     return element;

--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -72,7 +72,19 @@ export class CustomItem implements GearItem {
             respectCaps: true,
             slot: slot,
         };
-        data.ilvl = sheet.highestIlvlForSlot(slot);
+        // Copy relevant features of the highest ilvl available for that slot
+        const highest = sheet.highestIlvlItemForSlot(slot);
+        data.ilvl = highest.ilvl;
+        data.stats.vitality = highest.stats.vitality;
+        data.stats.strength = highest.stats.strength;
+        data.stats.dexterity = highest.stats.dexterity;
+        data.stats.intelligence = highest.stats.intelligence;
+        data.stats.mind = highest.stats.mind;
+        if (slot === 'Weapon2H' || slot === 'Weapon1H') {
+            data.stats.weaponDelay = highest.stats.weaponDelay;
+            data.stats.wdMag = highest.stats.wdMag;
+            data.stats.wdPhys = highest.stats.wdPhys;
+        }
         return new CustomItem(data, sheet);
     }
 

--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -30,7 +30,7 @@ export class CustomItem implements GearItem {
 
     primarySubstat: keyof RawStats = null;
     secondarySubstat: keyof RawStats = null;
-    statCaps = {};
+    statCaps: Partial<RawStats> = {};
     // TODO: pull this out into a constant somewhere
     iconUrl: URL = new URL(xivApiIconUrl(26270));
     syncedDownTo: number | null;
@@ -72,6 +72,7 @@ export class CustomItem implements GearItem {
             respectCaps: true,
             slot: slot,
         };
+        data.ilvl = sheet.highestIlvlForSlot(slot);
         return new CustomItem(data, sheet);
     }
 

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -15,7 +15,6 @@ import {
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
 import {
-    DisplayGearSlotKey,
     EquippedItem,
     EquipSlotKey,
     FoodItem,

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -759,6 +759,15 @@ export class GearPlanSheet {
     }
 
     /**
+     * Returns the highest
+     * @param slot
+     */
+    highestIlvlItemForSlot(slot: OccGearSlotKey): GearItem | undefined {
+        return this.dataManager.allItems.filter(item => item.occGearSlotName === slot)
+            .sort((a, b) => b.ilvl - a.ilvl)[0];
+    }
+
+    /**
      * Get the next free custom item ID.
      * @private
      */

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -15,6 +15,7 @@ import {
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
 import {
+    DisplayGearSlotKey,
     EquippedItem,
     EquipSlotKey,
     FoodItem,
@@ -746,6 +747,16 @@ export class GearPlanSheet {
      */
     ilvlSyncInfo(ilvl: number): IlvlSyncInfo | undefined {
         return this.dataManager?.getIlvlSyncInfo(ilvl);
+    }
+
+    /**
+     * Return the highest ilvl of non-custom items in a particular slot
+     *
+     * @param slot
+     */
+    highestIlvlForSlot(slot: OccGearSlotKey): number {
+        return Math.max(...this.dataManager.allItems.filter(item => item.occGearSlotName === slot)
+            .map(item => item.ilvl));
     }
 
     /**

--- a/packages/core/src/test/custom_items_test.ts
+++ b/packages/core/src/test/custom_items_test.ts
@@ -15,6 +15,7 @@ describe('Custom items support', () => {
 
         // Make custom item
         const custom = sheet.newCustomItem('Weapon2H');
+        custom.ilvl = 640;
         const customStats = custom.customData.stats;
         customStats.wdMag = 200;
         customStats.wdPhys = 200;
@@ -61,6 +62,7 @@ describe('Custom items support', () => {
 
         // Make custom item
         const custom = sheet.newCustomItem('Weapon2H');
+        custom.ilvl = 640;
         const customStats = custom.customData.stats;
         customStats.wdMag = 200;
         customStats.wdPhys = 200;

--- a/packages/frontend/src/scripts/components/custom_item_manager.ts
+++ b/packages/frontend/src/scripts/components/custom_item_manager.ts
@@ -11,7 +11,7 @@ import {
     FieldBoundTextField,
     makeActionButton,
     nonNegative,
-    quickElement
+    quickElement, randomId
 } from "@xivgear/common-ui/components/util";
 import {ALL_STATS, ALL_SUB_STATS, STAT_ABBREVIATIONS, STAT_FULL_NAMES} from "@xivgear/xivmath/xivconstants";
 import {BaseModal} from "@xivgear/common-ui/components/modal";
@@ -67,7 +67,7 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: (item: CustomItem) => {
                     const out = document.createElement('div');
                     out.appendChild(makeActionButton([faIcon('fa-trash-can')], (ev) => {
-                        if (confirmDelete(ev, `Delete custom item '${item.name}'?`)) {
+                        if (confirmDelete(ev, `Delete custom item '${item.name}'? Please make sure it is not equipped on any set.`)) {
                             this.sheet.deleteCustomItem(item);
                             this.refresh();
                         }
@@ -109,6 +109,7 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                     ilvlInput.addListener(recheck);
                     capBox.addListener(() => recheck(item.ilvl));
                     recheck(item.ilvl);
+                    ilvlInput.addEventListener('focusout', () => this.refreshRowData(item));
                     const holder = quickElement("div", [], [ilvlInput, capBox]);
                     holder.style.display = 'flex';
                     ilvlInput.style.minWidth = '40px';
@@ -156,7 +157,7 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                             opt.value = sugg.toString();
                             return opt;
                         }));
-                        datalist.id = `custom-item-datalist-${stat}`;
+                        datalist.id = randomId('custom-item-datalist-');
 
                         const statsProxy = customStatsProxy(item.customData.stats);
 
@@ -201,6 +202,20 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                         postValidators: [nonNegative],
                     });
                     out.title = 'Enter weapon delay in seconds (e.g. 3.125)';
+
+                    const exampleWeapon = this.sheet.highestIlvlItemForSlot(item.occGearSlotName);
+                    const suggestions = [exampleWeapon.stats.weaponDelay];
+
+                    const datalist = quickElement('datalist', [], suggestions.map(sugg => {
+                        const opt = document.createElement('option');
+                        opt.value = sugg.toString();
+                        return opt;
+                    }));
+                    datalist.id = randomId('custom-item-datalist-');
+
+                    out.setAttribute('list', datalist.id);
+                    out.appendChild(datalist);
+
                     return out;
                 }),
                 initialWidth: 80,
@@ -279,7 +294,7 @@ export class CustomFoodTable extends CustomTable<CustomFood> {
                 renderer: (item: CustomFood) => {
                     const out = document.createElement('div');
                     out.appendChild(makeActionButton([faIcon('fa-trash-can')], (ev) => {
-                        if (confirmDelete(ev, `Delete custom item '${item.name}'?`)) {
+                        if (confirmDelete(ev, `Delete custom item '${item.name}'? Please make sure it is not equipped on any set.`)) {
                             this.sheet.deleteCustomFood(item);
                             this.refresh();
                         }

--- a/packages/frontend/src/scripts/components/custom_item_manager.ts
+++ b/packages/frontend/src/scripts/components/custom_item_manager.ts
@@ -16,7 +16,7 @@ import {
 import {ALL_STATS, ALL_SUB_STATS, STAT_ABBREVIATIONS, STAT_FULL_NAMES} from "@xivgear/xivmath/xivconstants";
 import {BaseModal} from "@xivgear/common-ui/components/modal";
 import {DropdownActionMenu} from "./dropdown_actions_menu";
-import {OccGearSlots, RawStats} from "@xivgear/xivmath/geartypes";
+import {OccGearSlots, RawStats, Substat} from "@xivgear/xivmath/geartypes";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";
 import {CustomItem} from "@xivgear/core/customgear/custom_item";
 import {CustomFood} from "@xivgear/core/customgear/custom_food";
@@ -146,7 +146,11 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                         const ilvlSyncInfo = sheet.ilvlSyncInfo(item.ilvl);
                         const cap = ilvlSyncInfo.substatCap(item.occGearSlotName, stat);
                         // Small stat is ceil(big stat * 70%)
-                        const suggestions = [cap, Math.ceil(cap * 0.7), 0]; // TODO: small value
+                        const suggestions = [cap];
+                        if (ALL_SUB_STATS.includes(stat as Substat)) {
+                            suggestions.push(Math.ceil(cap * 0.7));
+                        }
+                        suggestions.push(0);
                         const datalist = quickElement('datalist', [], suggestions.map(sugg => {
                             const opt = document.createElement('option');
                             opt.value = sugg.toString();


### PR DESCRIPTION
Fixes #492 

Makes two improvements:
- Autocomplete will suggest values for stats
  - For main stats, it will suggest the cap
  - For substats, it will suggest the cap, 70% of the cap (the secondary substat), and zero
- Items will default to the highest ilvl item available for that stat, rather than the minimum ilvl for the level