### PR TITLE
Add job icons to saved sheet picker

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -19,7 +19,7 @@
     <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myValues">
         <value>
-          <list size="54">
+          <list size="55">
             <item index="0" class="java.lang.String" itemvalue="nobr" />
             <item index="1" class="java.lang.String" itemvalue="noembed" />
             <item index="2" class="java.lang.String" itemvalue="comment" />
@@ -74,6 +74,7 @@
             <item index="51" class="java.lang.String" itemvalue="sheet-info-modal" />
             <item index="52" class="java.lang.String" itemvalue="gauge-outer" />
             <item index="53" class="java.lang.String" itemvalue="gauge-bar" />
+            <item index="54" class="java.lang.String" itemvalue="job-picker" />
           </list>
         </value>
       </option>

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -977,13 +977,13 @@ job-picker {
       --role-color: var(--role-color-dps);
     }
 
-    padding-top: 20px;
-    display: flex;
+    padding-top: 10px;
+    display: grid;
+    grid-template-columns: repeat(6, 40px);
     flex-direction: row;
     flex-wrap: wrap;
     align-items: center;
-    gap: 50px;
-    max-width: 500px;
+    gap: 5px;
 
 
     .job-picker-job-icon {
@@ -998,8 +998,8 @@ job-picker {
       filter: saturate(50%);
 
       img {
-        width: 64px;
-        height: 64px;
+        width: 100%;
+        height: 100%;
         max-height: unset;
         //opacity: 50%;
       }
@@ -1012,7 +1012,17 @@ job-picker {
         }
       }
 
+      &:active {
+        border-color: #00000000;
+        filter: brightness(80%);
+      }
+
       &.selected {
+        &:active {
+          border-color: #00000000;
+          filter: drop-shadow(0 0 10px var(--role-color)) saturate(200%) brightness(80%);
+        }
+
         // This has a LOWER z-index so that the shadows do not appear over other buttons
         z-index: 2;
         //background-color: var(--role-color);

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -985,6 +985,24 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
       td {
         border: none;
         border-top: var(--standard-border);
+        height: 23px;
+
+        &[col-id="sheetjob"] {
+          // Why does this work
+          width: 0;
+          text-align: right;
+          img {
+            height: 100%;
+          }
+
+        }
+        &[col-id="sheetjobicon"] {
+          width: 30px;
+          img {
+            height: 100%;
+          }
+
+        }
       }
 
       th {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -989,8 +989,8 @@ job-picker {
     .job-picker-job-icon {
       //flex-basis: 25%;
       flex-grow: 0;
-      height: fit-content;
-      width: fit-content;
+      height: 40px;
+      width: 40px;
       background: none;
       padding: 0;
       position: relative;
@@ -3270,9 +3270,41 @@ rename-dialog {
 }
 
 .ffxiv-job-icon {
-  max-height: 100%;
   display: block;
   aspect-ratio: 1;
+  box-sizing: border-box;
+  // Alt text should be white for better contrast
+  color: white;
+
+  border-radius: 20%;
+  border: 4px ridge #927d59;
+
+  &.job-picker-section-tank {
+    --role-color: var(--role-color-tank);
+  }
+
+  &.job-picker-section-healer {
+    --role-color: var(--role-color-healer);
+  }
+
+  &.job-picker-section-melee,
+  &.job-picker-section-range,
+  &.job-picker-section-caster {
+    --role-color: var(--role-color-dps);
+  }
+
+  background: linear-gradient(var(--role-color), color-mix(in srgb, var(--role-color) 50%, #000));
+
+  &.loaded {
+    border-radius: unset;
+    background: unset;
+    border: none;
+  }
+
+  &:not(.loaded) {
+    filter: saturate(40%);
+  }
+
 }
 
 .svg-glyph {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1117,6 +1117,9 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
         &[col-id="type"] {
           font-size: 30px;
           text-align: center;
+          img {
+            width: 100%;
+          }
         }
 
         &[col-id="name"] {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -72,6 +72,9 @@ body {
   --issue-error-color: #9c0000;
   --toolbar-button-size: 40px;
   --toolbar-border-radius: 8px;
+  --role-color-tank: #4848ff;
+  --role-color-healer: #13a813;;
+  --role-color-dps: #ff0000;
 
 
   &.light-mode {
@@ -958,6 +961,71 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
   }
 }
 
+job-picker {
+  .job-picker-section {
+    &.job-picker-section-tank {
+      --role-color: var(--role-color-tank);
+    }
+
+    &.job-picker-section-healer {
+      --role-color: var(--role-color-healer);
+    }
+
+    &.job-picker-section-melee,
+    &.job-picker-section-range,
+    &.job-picker-section-caster {
+      --role-color: var(--role-color-dps);
+    }
+
+    padding-top: 20px;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 50px;
+    max-width: 500px;
+
+
+    .job-picker-job-icon {
+      //flex-basis: 25%;
+      flex-grow: 0;
+      height: fit-content;
+      width: fit-content;
+      background: none;
+      padding: 0;
+      position: relative;
+      z-index: 5;
+      filter: saturate(50%);
+
+      img {
+        width: 64px;
+        height: 64px;
+        max-height: unset;
+        //opacity: 50%;
+      }
+
+      &:hover {
+        filter: saturate(200%);
+
+        img {
+          opacity: 100%;
+        }
+      }
+
+      &.selected {
+        // This has a LOWER z-index so that the shadows do not appear over other buttons
+        z-index: 2;
+        //background-color: var(--role-color);
+        filter: drop-shadow(0 0 10px var(--role-color)) saturate(200%);
+
+        img {
+          opacity: 100%;
+        }
+      }
+    }
+  }
+}
+
 #content-area > .my-sheets-section {
   .named-section-content-area {
     width: 600px;
@@ -991,13 +1059,16 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
           // Why does this work
           width: 0;
           text-align: right;
+
           img {
             height: 100%;
           }
 
         }
+
         &[col-id="sheetjobicon"] {
           width: 30px;
+
           img {
             height: 100%;
           }
@@ -1117,6 +1188,7 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
         &[col-id="type"] {
           font-size: 30px;
           text-align: center;
+
           img {
             width: 100%;
           }
@@ -1729,6 +1801,15 @@ add-sim-dialog {
       margin-right: 0;
       max-width: 100%;
       width: 100%;
+
+      td[col-id="sim-job-icon"] {
+        width: 1px;
+        height: 23px;
+
+        img {
+          height: 100%;
+        }
+      }
     }
   }
 
@@ -1786,6 +1867,7 @@ add-sim-dialog {
     > .named-section {
       .named-section-standard;
       width: 100%;
+
       .named-section-content-area {
         overflow: visible;
         overflow-x: clip;
@@ -3787,6 +3869,7 @@ expandable-text {
       grid-column-end: span 2;
       max-width: 100%;
       overflow: auto;
+
       .scroll-table-holder {
         overflow-x: auto;
         min-height: 100%;
@@ -3797,6 +3880,7 @@ expandable-text {
 
     .cycle-sim-rotations-holder {
       min-height: 0;
+
       .scroll-table-holder {
         min-height: 100%;
         max-height: 150px;
@@ -3807,6 +3891,7 @@ expandable-text {
       &.cycle-sim-one-rotation {
         grid-column: 1/-1;
       }
+
       > table > * > tr > td {
         width: 150px;
       }

--- a/packages/frontend/src/scripts/components/bis_browser.ts
+++ b/packages/frontend/src/scripts/components/bis_browser.ts
@@ -10,9 +10,10 @@ import {
 } from "@xivgear/common-ui/table/tables";
 import {NamedSection} from "./section";
 import {BIS_BROWSER_HASH, BIS_HASH} from "@xivgear/core/nav/common_nav";
-import {JOB_DATA} from "@xivgear/xivmath/xivconstants";
+import {JOB_DATA, JOB_IDS, JobName} from "@xivgear/xivmath/xivconstants";
 import {makeActionButton, mySheetsIcon, quickElement} from "@xivgear/common-ui/components/util";
 import {capitalizeFirstLetter} from "@xivgear/util/strutils";
+import {JobIcon} from "./job_icon";
 
 type NodeInfo = {
     name: string,
@@ -40,12 +41,19 @@ export class BisBrowser {
                 getter(item: AnyNode): string {
                     return item.type;
                 },
-                renderer(itemType: AnyNode['type']) {
+                renderer(itemType: AnyNode['type'], node: AnyNode) {
                     if (itemType === 'file') {
                         return quickElement('b', [], ['🗋']);
                     }
                     else {
-                        return mySheetsIcon();
+                        const jobNameMaybe = node.fileName.toUpperCase() as JobName;
+                        const jobId = JOB_IDS[jobNameMaybe];
+                        if (jobId) {
+                            return new JobIcon(jobNameMaybe);
+                        }
+                        else {
+                            return mySheetsIcon();
+                        }
                     }
                 },
                 fixedWidth: 30,

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1003,6 +1003,7 @@ export function itemIconRenderer<RowType>(): CellRenderer<RowType, XivItem> {
         image.setAttribute('intrinsicsize', '80x80');
         image.src = img.toString();
         image.classList.add('item-icon');
+        // TODO: should this behavior be part of ItemIcon + use that?
         if ('rarity' in item) {
             const rarity = item.rarity as number;
             switch (rarity) {

--- a/packages/frontend/src/scripts/components/job_icon.ts
+++ b/packages/frontend/src/scripts/components/job_icon.ts
@@ -30,6 +30,9 @@ export class JobIcon extends HTMLImageElement {
         // Rather, it seems that it's just 062100 + id (or 062000 if you don't want the border)
         const iconId = 62100 + id;
         this.src = xivApiIconUrl(iconId, true);
+        this.addEventListener('load', () => {
+            this.classList.add('loaded');
+        });
     }
 }
 

--- a/packages/frontend/src/scripts/components/job_icon.ts
+++ b/packages/frontend/src/scripts/components/job_icon.ts
@@ -1,0 +1,36 @@
+import {JOB_DATA, JOB_IDS, JobName} from "@xivgear/xivmath/xivconstants";
+import {xivApiIconUrl} from "@xivgear/core/external/xivapi";
+
+export class JobIcon extends HTMLImageElement {
+    constructor(job: JobName) {
+        super();
+        this.alt = job;
+        this.title = job;
+        this.classList.add('ffxiv-job-icon');
+        this.setAttribute('intrinsicsize', '64x64');
+        const jobDataConst = JOB_DATA[job];
+        switch (jobDataConst.role) {
+            case "Healer":
+                this.classList.add('ffxiv-role-healer');
+                break;
+            case "Tank":
+                this.classList.add('ffxiv-role-tank');
+                break;
+            case "Melee":
+            case "Ranged":
+            case "Caster":
+                this.classList.add('ffxiv-role-dps');
+        }
+        const id = JOB_IDS[job];
+        if (!id) {
+            this.classList.add('ffxiv-job-missing');
+            return;
+        }
+        // No real sheet to map these.
+        // Rather, it seems that it's just 062100 + id (or 062000 if you don't want the border)
+        const iconId = 62100 + id;
+        this.src = xivApiIconUrl(iconId, true);
+    }
+}
+
+customElements.define('job-icon', JobIcon, {extends: "img"});

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -144,7 +144,7 @@ export class NewSheetForm extends HTMLFormElement {
         this.appendChild(this.submitButton);
 
         onsubmit = (ev) => {
-            this.doSubmit();
+            this.doSubmit(ev);
         };
     }
 
@@ -156,9 +156,15 @@ export class NewSheetForm extends HTMLFormElement {
         this.fieldSet.recheck();
     }
 
-    private doSubmit() {
+    private doSubmit(ev: SubmitEvent) {
         const result = this.fieldSet.validateIsync();
         if (!result) {
+            ev.preventDefault();
+            return;
+        }
+        if (this.fieldSet.jobPicker.selectedJob === null) {
+            alert("Please select a job");
+            ev.preventDefault();
             return;
         }
         const nextSheetSaveStub = getNextSheetInternalName();
@@ -232,11 +238,17 @@ function spacer() {
     return quickElement('div', ['vertical-spacer'], []);
 }
 
+/**
+ * JobPicker provides a graphical job selection UI
+ */
 class JobPicker extends HTMLElement {
 
     private _selectedJob: JobName | null = null;
     private _selectedSelector: HTMLButtonElement | null = null;
 
+    /**
+     * @param defaultJob The job to default to, or null if nothing should be selected by default.
+     */
     constructor(defaultJob: JobName | null) {
         super();
         const tankDiv = quickElement('div', ['job-picker-section', 'job-picker-section-tank'], []);

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -14,6 +14,7 @@ import {levelSelect} from "@xivgear/common-ui/components/level_picker";
 import {BaseModal} from "@xivgear/common-ui/components/modal";
 import {SHARED_SET_NAME} from "@xivgear/core/imports/imports";
 import {recordSheetEvent} from "@xivgear/gearplan-frontend/analytics/analytics";
+import {JobIcon} from "./job_icon";
 
 export type NewSheetTempSettings = {
     ilvlSyncEnabled: boolean,
@@ -22,7 +23,8 @@ export type NewSheetTempSettings = {
 
 export class NewSheetFormFieldSet extends HTMLFieldSetElement {
     readonly nameInput: HTMLInputElement;
-    readonly jobDropdown: DataSelect<JobName>;
+    // readonly jobDropdown: DataSelect<JobName>;
+    readonly jobPicker: JobPicker;
     readonly levelDropdown: DataSelect<SupportedLevel>;
     readonly ilvlSyncCheckbox: FieldBoundCheckBox<typeof this.tempSettings>;
     readonly ilvlSyncValue: FieldBoundIntField<typeof this.tempSettings>;
@@ -45,16 +47,15 @@ export class NewSheetFormFieldSet extends HTMLFieldSetElement {
         if (defaults?.name) {
             this.nameInput.value = defaults.name;
         }
-        this.appendChild(labelFor("Sheet Name: ", this.nameInput));
-        this.appendChild(this.nameInput);
-        this.appendChild(spacer());
 
         // Job selection
-        this.jobDropdown = new DataSelect<JobName>(Object.keys(JOB_DATA) as JobName[], item => item, () => this.recheck(), defaults?.job);
-        this.jobDropdown.id = "new-sheet-job-dropdown";
-        this.jobDropdown.required = true;
-        this.appendChild(labelFor('Job: ', this.jobDropdown));
-        this.appendChild(this.jobDropdown);
+        this.jobPicker = new JobPicker(defaults.job ?? null);
+        this.appendChild(this.jobPicker);
+        this.appendChild(spacer());
+
+        // Sheet Name
+        this.appendChild(labelFor("Sheet Name: ", this.nameInput));
+        this.appendChild(this.nameInput);
         this.appendChild(spacer());
 
         // Level selection
@@ -161,7 +162,7 @@ export class NewSheetForm extends HTMLFormElement {
             return;
         }
         const nextSheetSaveStub = getNextSheetInternalName();
-        const gearPlanSheet = GRAPHICAL_SHEET_PROVIDER.fromScratch(nextSheetSaveStub, this.fieldSet.nameInput.value, this.fieldSet.jobDropdown.selectedItem, this.fieldSet.levelDropdown.selectedItem, this.fieldSet.tempSettings.ilvlSyncEnabled ? this.fieldSet.tempSettings.ilvlSync : undefined);
+        const gearPlanSheet = GRAPHICAL_SHEET_PROVIDER.fromScratch(nextSheetSaveStub, this.fieldSet.nameInput.value, this.fieldSet.jobPicker.selectedJob, this.fieldSet.levelDropdown.selectedItem, this.fieldSet.tempSettings.ilvlSyncEnabled ? this.fieldSet.tempSettings.ilvlSync : undefined);
         recordSheetEvent("newSheet", gearPlanSheet);
         this.sheetOpenCallback(gearPlanSheet).then(() => gearPlanSheet.requestSave());
     }
@@ -204,7 +205,7 @@ export class SaveAsModal extends BaseModal {
             const ilvlSyncEnabled = this.fieldSet.tempSettings.ilvlSyncEnabled;
             const ilvlSync = this.fieldSet.tempSettings.ilvlSync;
             const level: SupportedLevel = this.fieldSet.levelDropdown.selectedItem;
-            const newJob = this.fieldSet.jobDropdown.selectedItem;
+            const newJob = this.fieldSet.jobPicker.selectedJob;
             if (newJob !== undefined && newJob !== existingSheet.classJobName) {
                 const result = confirm(`You are attempting to change a sheet from ${existingSheet.classJobName} to ${newJob}. Items may need to be re-selected.`);
                 if (!result) {
@@ -231,6 +232,65 @@ function spacer() {
     return quickElement('div', ['vertical-spacer'], []);
 }
 
+class JobPicker extends HTMLElement {
+
+    private _selectedJob: JobName | null = null;
+    private _selectedSelector: HTMLButtonElement | null = null;
+
+    constructor(defaultJob: JobName | null) {
+        super();
+        const tankDiv = quickElement('div', ['job-picker-section', 'job-picker-section-tank'], []);
+        const healerDiv = quickElement('div', ['job-picker-section', 'job-picker-section-healer'], []);
+        const meleeDiv = quickElement('div', ['job-picker-section', 'job-picker-section-melee'], []);
+        const rangeDiv = quickElement('div', ['job-picker-section', 'job-picker-section-range'], []);
+        const casterDiv = quickElement('div', ['job-picker-section', 'job-picker-section-caster'], []);
+
+        const jobs = Object.keys(JOB_DATA) as JobName[];
+
+        jobs.forEach((jobName) => {
+            const job = JOB_DATA[jobName];
+            const jobSelector = quickElement('button', ['job-picker-job-icon'], [new JobIcon(jobName)]);
+            jobSelector.value = jobName;
+            jobSelector.type = 'button';
+            if (defaultJob === jobName) {
+                jobSelector.classList.add('selected');
+                this._selectedJob = jobName;
+            }
+            let parent: HTMLDivElement;
+            switch (job.role) {
+                case "Healer":
+                    parent = healerDiv;
+                    break;
+                case "Melee":
+                    parent = meleeDiv;
+                    break;
+                case "Ranged":
+                    parent = rangeDiv;
+                    break;
+                case "Caster":
+                    parent = casterDiv;
+                    break;
+                case "Tank":
+                    parent = tankDiv;
+                    break;
+            }
+            parent.appendChild(jobSelector);
+            jobSelector.addEventListener('click', (ev) => {
+                this._selectedJob = jobName;
+                this._selectedSelector?.classList.remove('selected');
+                jobSelector.classList.add('selected');
+                this._selectedSelector = jobSelector;
+            });
+        });
+        this.replaceChildren(healerDiv, tankDiv, meleeDiv, rangeDiv, casterDiv);
+    }
+
+    get selectedJob(): JobName | null {
+        return this._selectedJob;
+    }
+}
+
 customElements.define("save-as-modal", SaveAsModal);
 customElements.define("new-sheet-form-fieldset", NewSheetFormFieldSet, {extends: "fieldset"});
 customElements.define("new-sheet-form", NewSheetForm, {extends: "form"});
+customElements.define('job-picker', JobPicker);

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -294,7 +294,7 @@ class JobPicker extends HTMLElement {
                 this._selectedSelector = jobSelector;
             });
         });
-        this.replaceChildren(healerDiv, tankDiv, meleeDiv, rangeDiv, casterDiv);
+        this.replaceChildren(tankDiv, healerDiv, meleeDiv, rangeDiv, casterDiv);
     }
 
     get selectedJob(): JobName | null {

--- a/packages/frontend/src/scripts/components/saved_sheet_picker.ts
+++ b/packages/frontend/src/scripts/components/saved_sheet_picker.ts
@@ -1,4 +1,5 @@
 import {
+    col,
     CustomCell,
     CustomColumn,
     CustomRow,
@@ -7,10 +8,11 @@ import {
     TitleRow
 } from "@xivgear/common-ui/table/tables";
 import {SheetExport} from "@xivgear/xivmath/geartypes";
-import {faIcon, makeActionButton} from "@xivgear/common-ui/components/util";
+import {faIcon, makeActionButton, quickElement} from "@xivgear/common-ui/components/util";
 import {deleteSheetByKey} from "@xivgear/core/persistence/saved_sheets";
 import {getHashForSaveKey, openSheetByKey, showNewSheetForm} from "../base_ui";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";
+import {JobIcon} from "./job_icon";
 
 export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionModel<SheetExport, never, never, SheetExport | null>> {
     constructor() {
@@ -45,22 +47,27 @@ export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionMod
                     return div;
                 },
             },
+            col({
+                shortName: "sheetjob",
+                displayName: "Job",
+                getter: sheet => sheet.job,
+                renderer: job => {
+                    return document.createTextNode(job);
+                },
+            }),
+            col({
+                shortName: "sheetjobicon",
+                displayName: "Job Icon",
+                getter: sheet => sheet.job,
+                renderer: job => {
+                    return new JobIcon(job);
+                },
+            }),
             {
                 shortName: "sheetlevel",
                 displayName: "Lvl",
                 getter: sheet => sheet.level,
                 fixedWidth: 40,
-            },
-            {
-                shortName: "sheetjob",
-                displayName: "Job",
-                getter: sheet => sheet.job,
-                // renderer: job => {
-                //     const out = document.createElement('div');
-                //     out.replaceChildren(new JobIcon(job), job);
-                //     return out;
-                // },
-                fixedWidth: 60,
             },
             {
                 shortName: "sheetname",

--- a/packages/frontend/src/scripts/components/saved_sheet_picker.ts
+++ b/packages/frontend/src/scripts/components/saved_sheet_picker.ts
@@ -4,11 +4,12 @@ import {
     CustomColumn,
     CustomRow,
     CustomTable,
-    SpecialRow, TableSelectionModel,
+    SpecialRow,
+    TableSelectionModel,
     TitleRow
 } from "@xivgear/common-ui/table/tables";
 import {SheetExport} from "@xivgear/xivmath/geartypes";
-import {faIcon, makeActionButton, quickElement} from "@xivgear/common-ui/components/util";
+import {faIcon, makeActionButton} from "@xivgear/common-ui/components/util";
 import {deleteSheetByKey} from "@xivgear/core/persistence/saved_sheets";
 import {getHashForSaveKey, openSheetByKey, showNewSheetForm} from "../base_ui";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -91,6 +91,7 @@ import {recordError, recordEvent} from "@xivgear/common-ui/analytics/analytics";
 import {ExpandableText} from "@xivgear/common-ui/components/expandy_text";
 import {setDataManagerErrorReporter} from "@xivgear/core/datamanager_new";
 import {SheetInfoModal} from "./sheet_info_modal";
+import {JobIcon} from "./job_icon";
 
 const noSeparators = (set: CharacterGearSet) => !set.isSeparator;
 
@@ -2282,12 +2283,29 @@ export class AddSimDialog extends BaseModal {
         this.table.selectionModel = selModel;
         this.table.classList.add('hoverable');
         this.table.columns = [
-            {
-                shortName: 'sim-space-name',
+            col({
+                shortName: 'sim-job-icon',
+                displayName: 'Icon',
+                // fixedWidth: 500,
+                getter: item => item.supportedJobs,
+                renderer: (value) => {
+                    if (!value) {
+                        return document.createTextNode('');
+                    }
+                    if (value.length === 1) {
+                        return new JobIcon(value[0]);
+                    }
+                    // TODO: use role icon for sims that support entire roles
+                    // Role icons start at 062581
+                    return document.createTextNode('');
+                },
+            }),
+            col({
+                shortName: 'sim-name',
                 displayName: 'Name',
                 // fixedWidth: 500,
                 getter: item => item.displayName,
-            },
+            }),
         ];
         this.table.data = this.sheet.relevantSims;
         const showAllCb = labeledCheckbox('Show sims for other jobs', new FieldBoundCheckBox<AddSimDialog>(this, 'showAllSims'));

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -333,6 +333,30 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
     PCT: STANDARD_CASTER,
 };
 
+export const JOB_IDS: Record<JobName, number> = {
+    PLD: 19,
+    MNK: 20,
+    WAR: 21,
+    DRG: 22,
+    BRD: 23,
+    WHM: 24,
+    BLM: 25,
+    SMN: 27,
+    SCH: 28,
+    NIN: 30,
+    MCH: 31,
+    DRK: 32,
+    AST: 33,
+    SAM: 34,
+    RDM: 35,
+    BLU: 36,
+    GNB: 37,
+    DNC: 38,
+    RPR: 39,
+    SGE: 40,
+    VPR: 41,
+    PCT: 42,
+};
 
 /**
  * Clan/race-specific stats


### PR DESCRIPTION
Closes #557 

- [X] Implement JobIcon element
- [x] Add job icons to New Sheet form (including "Save As")
- [X] Add job icons to saved sheet picker
- [x] Add job icons to BiS browser
- [x] Add job icons to sim chooser
- [x] Add placeholder background for when image has not loaded yet, similar to the gradient backgrounds on items