### PR TITLE
Multi-job sheets

### DIFF
--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -11,7 +11,7 @@ import {
     RawStats
 } from "@xivgear/xivmath/geartypes";
 import {xivApiIconUrl} from "../external/xivapi";
-import {CURRENT_MAX_LEVEL, LEVEL_ITEMS, MATERIA_LEVEL_MAX_NORMAL} from "@xivgear/xivmath/xivconstants";
+import {CURRENT_MAX_LEVEL, JobName, LEVEL_ITEMS, MATERIA_LEVEL_MAX_NORMAL} from "@xivgear/xivmath/xivconstants";
 import {IlvlSyncInfo} from "../datamanager_xivapi";
 import {applyStatCaps} from "../gear";
 import {GearPlanSheet} from "../sheet";
@@ -251,6 +251,11 @@ export class CustomItem implements GearItem {
             this.primarySubstat = sortedStats[0][0] as keyof RawStats;
             this.secondarySubstat = sortedStats[1][0] as keyof RawStats;
         }
+    }
+
+    // Don't restrict jobs on custom items, assume the user knows what they're doing
+    usableByJob(job: JobName): boolean {
+        return true;
     }
 
 }

--- a/packages/core/src/datamanager.ts
+++ b/packages/core/src/datamanager.ts
@@ -1,6 +1,5 @@
 import {JobName, SupportedLevel} from "@xivgear/xivmath/xivconstants";
 import {FoodItem, GearItem, JobMultipliers, Materia, OccGearSlotKey, RawStatKey} from "@xivgear/xivmath/geartypes";
-// import {XivApiDataManager} from "./datamanager_xivapi";
 import {NewApiDataManager} from "./datamanager_new";
 import {IlvlSyncInfo} from "./datamanager_xivapi";
 
@@ -17,7 +16,7 @@ export type BaseParamMap = { [rawStat in RawStatKey]?: BaseParamInfo }
 export type BaseParamInfo = Record<OccGearSlotKey, number>
 
 export interface DataManager {
-    readonly classJob: JobName;
+    readonly primaryClassJob: JobName;
     readonly allItems: GearItem[];
     readonly allFoodItems: FoodItem[];
     readonly allMateria: Materia[];
@@ -29,21 +28,61 @@ export interface DataManager {
     readonly ilvlSync: number;
     readonly level: number;
 
+    /**
+     * Retrieve a gear item by item ID. Returns undefined if the item cannot be found.
+     * If forceNq is true, will only look for an NQ version.
+     *
+     * @param id
+     * @param forceNq
+     */
     itemById(id: number, forceNq?: boolean): GearItem | undefined;
 
+    /**
+     * Retrieve a materia by item ID. Returns undefined if the item cannot be found.
+     *
+     * @param id
+     */
     materiaById(id: number): Materia | undefined;
 
+    /**
+     * Retrieve a food item by item ID. Returns undefined if the item cannot be found.
+     *
+     * @param id
+     */
     foodById(id: number): FoodItem | undefined;
 
+    /**
+     * Asynchronously load the data.
+     */
     loadData(): Promise<void>;
 
+    /**
+     * Get the multipliers for a particular job.
+     *
+     * @param job
+     */
     multipliersForJob(job: JobName): JobMultipliers;
 
+    /**
+     * For a given ilvl, return the sync information. May return undefined if we do not have information for the given
+     * ilvl.
+     * @param ilvl
+     */
     getIlvlSyncInfo(ilvl: number): IlvlSyncInfo | undefined;
 
+    /**
+     * Get the implicit max ilvl for a particular level of character. Can be different for weapons vs non-weapons.
+     * For example, if the highest ilvl at level 80 is 535 for weapons, then getImplicitIlvlSync(80, true) will return
+     * 535. Returns undefined if the max cannot be determined.
+     *
+     * @param level
+     * @param isWeapon
+     */
     getImplicitIlvlSync(level: number, isWeapon: boolean): number | undefined;
 }
 
-export function makeDataManager(classJob: JobName, level: SupportedLevel, ilvlSync?: number | undefined): DataManager {
+export type DmJobs = [primary: JobName, ...alts: JobName[]]
+
+export function makeDataManager(classJob: DmJobs, level: SupportedLevel, ilvlSync?: number | undefined): DataManager {
     return new NewApiDataManager(classJob, level, ilvlSync);
 }

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -274,6 +274,11 @@ export class CharacterGearSet {
         this._sheet = sheet;
         this.name = "";
         this.equipment = new EquipmentSet();
+        if (sheet.isMultiJob) {
+            // This acts as a default. For a variety of reasons, such as changing the main class of a sheet, we want
+            // this to be set to the current job upon sheet creation/import.
+            this.earlySetJobOverride(sheet.classJobName);
+        }
     }
 
 

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -1,12 +1,14 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 // TODO: get back to fixing this at some point
 import {
+    ALL_COMBAT_JOBS,
     CURRENT_MAX_LEVEL,
     defaultItemDisplaySettings,
     DefaultMateriaFillPrio,
     getClassJobStats,
     getDefaultDisplaySettings,
     getRaceStats,
+    JOB_DATA,
     JobName,
     LEVEL_ITEMS,
     MAIN_STATS,
@@ -40,7 +42,7 @@ import {
     Substat
 } from "@xivgear/xivmath/geartypes";
 import {CharacterGearSet, isSameOrBetterItem, SyncInfo} from "./gear";
-import {DataManager, makeDataManager} from "./datamanager";
+import {DataManager, DmJobs, makeDataManager} from "./datamanager";
 import {Inactivitytimer} from "@xivgear/util/inactivitytimer";
 import {writeProxy} from "@xivgear/util/proxies";
 import {SHARED_SET_NAME} from "@xivgear/core/imports/imports";
@@ -110,6 +112,7 @@ export class SheetProvider<SheetType extends GearPlanSheet> {
             customItems: importedData.flatMap(imp => imp.customItems ?? []),
             customFoods: importedData.flatMap(imp => imp.customFoods ?? []),
             timestamp: importedData[0].timestamp,
+            isMultiJob: false,
         });
         if (importedData[0].sims === undefined) {
             gearPlanSheet.addDefaultSims();
@@ -127,8 +130,9 @@ export class SheetProvider<SheetType extends GearPlanSheet> {
      * @param classJob The class/job of the sheet
      * @param level The level of the sheet
      * @param ilvlSync The ilvl sync of the sheet, or undefined if the sheet should not have an ilvl sync.
+     * @param multiJob Whether to create a multi-job sheet.
      */
-    fromScratch(sheetKey: string, sheetName: string, classJob: JobName, level: SupportedLevel, ilvlSync: number | undefined): SheetType {
+    fromScratch(sheetKey: string, sheetName: string, classJob: JobName, level: SupportedLevel, ilvlSync: number | undefined, multiJob: boolean): SheetType {
         const fakeExport: SheetExport = {
             job: classJob,
             level: level,
@@ -142,6 +146,7 @@ export class SheetProvider<SheetType extends GearPlanSheet> {
             }],
             sims: [],
             ilvlSync: ilvlSync,
+            isMultiJob: multiJob,
             // ctor will auto-fill the rest
         };
         const gearPlanSheet = this.construct(sheetKey, fakeExport);
@@ -184,6 +189,8 @@ export class GearPlanSheet {
     _sheetName: string;
     _description: string;
     readonly classJobName: JobName;
+    readonly altJobs: JobName[];
+    readonly isMultiJob: boolean;
     readonly level: SupportedLevel;
     readonly ilvlSync: number | undefined;
     private _race: RaceName | undefined;
@@ -234,7 +241,14 @@ export class GearPlanSheet {
         this.level = importedData.level ?? CURRENT_MAX_LEVEL;
         this._race = importedData.race;
         this._partyBonus = importedData.partyBonus ?? 0;
+        // TODO: why does this default to WHM? Shouldn't it just throw?
         this.classJobName = importedData.job ?? 'WHM';
+        this.isMultiJob = importedData.isMultiJob;
+        this.altJobs = this.isMultiJob ? [
+            ...ALL_COMBAT_JOBS.filter(job => JOB_DATA[job].role === JOB_DATA[this.classJobName].role
+                // Don't include the primary job in the list of alt jobs
+                && job !== this.classJobName),
+        ] : [];
         this.ilvlSync = importedData.ilvlSync;
         this._description = importedData.description;
         if (importedData.itemDisplaySettings) {
@@ -362,11 +376,15 @@ export class GearPlanSheet {
         this._isViewOnly = true;
     }
 
+    get allJobs(): DmJobs {
+        return [this.classJobName, ...this.altJobs];
+    }
+
     /**
      * Load the sheet data fully. Create a DataManager internally.
      */
     async load() {
-        const dataManager = makeDataManager(this.classJobName, this.level, this.ilvlSync);
+        const dataManager = makeDataManager(this.allJobs, this.level, this.ilvlSync);
         await dataManager.loadData();
         await this.loadFromDataManager(dataManager);
     }
@@ -550,6 +568,7 @@ export class GearPlanSheet {
             customItems: this._customItems.map(ci => ci.export()),
             customFoods: this._customFoods.map(cf => cf.export()),
             timestamp: this.timestamp.getTime(),
+            isMultiJob: this.isMultiJob,
         };
         if (!external) {
             out.saveKey = this._saveKey;
@@ -696,6 +715,7 @@ export class GearPlanSheet {
             ext.customFoods = this._customFoods.map(cf => cf.export());
             ext.partyBonus = this._partyBonus;
             ext.race = this._race;
+            ext.job = set.job;
         }
         else {
             if (set.relicStatMemory) {
@@ -703,6 +723,9 @@ export class GearPlanSheet {
             }
             if (set.materiaMemory) {
                 out.materiaMemory = set.materiaMemory.export();
+            }
+            if (set.jobOverride) {
+                out.jobOverride = set.jobOverride;
             }
         }
         return out;
@@ -922,6 +945,13 @@ export class GearPlanSheet {
             if (importedSet.materiaMemory) {
                 set.materiaMemory.import(importedSet.materiaMemory);
             }
+            if (importedSet.jobOverride) {
+                set.earlySetJobOverride(importedSet.jobOverride);
+            }
+            // When importing a single set into a multi-job sheet, set the job override
+            else if ('job' in importedSet && importedSet.job && this.isMultiJob) {
+                set.earlySetJobOverride((importedSet as SetExportExternalSingle).job);
+            }
         }
         return set;
     }
@@ -1012,7 +1042,7 @@ export class GearPlanSheet {
      * Get sims which might be relevant to this sheet.
      */
     get relevantSims() {
-        return getRegisteredSimSpecs().filter(simSpec => simSpec.supportedJobs === undefined ? true : simSpec.supportedJobs.includes(this.dataManager.classJob));
+        return getRegisteredSimSpecs().filter(simSpec => simSpec.supportedJobs === undefined ? true : simSpec.supportedJobs.includes(this.dataManager.primaryClassJob));
     }
 
     /**

--- a/packages/core/src/test/custom_items_test.ts
+++ b/packages/core/src/test/custom_items_test.ts
@@ -6,7 +6,7 @@ import 'global-jsdom/register';
 describe('Custom items support', () => {
     it('Supports a custom item with ignored caps', async () => {
         // Setup
-        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined);
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined, false);
         await sheet.load();
 
         // Make one set before adding the custom item to make sure we can still use it.
@@ -53,7 +53,7 @@ describe('Custom items support', () => {
     }).timeout(30_000);
     it('Supports a custom item with respected caps', async () => {
         // Setup
-        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined);
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined, false);
         await sheet.load();
 
         // Make one set before adding the custom item to make sure we can still use it.
@@ -98,7 +98,7 @@ describe('Custom items support', () => {
 
     it('Supports a custom item with ignored caps + isync', async () => {
         // Setup
-        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, 635);
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, 635, false);
         await sheet.load();
 
         // Make one set before adding the custom item to make sure we can still use it.
@@ -144,7 +144,7 @@ describe('Custom items support', () => {
     }).timeout(30_000);
     it('Supports a custom item with respected caps + isync', async () => {
         // Setup
-        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, 635);
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, 635, false);
         await sheet.load();
 
         // Make one set before adding the custom item to make sure we can still use it.
@@ -189,7 +189,7 @@ describe('Custom items support', () => {
 
 
     it('Supports a custom food', async () => {
-        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined);
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch("foo", "foo", 'SGE', 100, undefined, false);
         await sheet.load();
 
         // Make one set before adding the custom item to make sure we can still use it.

--- a/packages/core/src/test/datamanager_tests.ts
+++ b/packages/core/src/test/datamanager_tests.ts
@@ -15,7 +15,7 @@ function deq<T>(actual: T, expected: T) {
 
 describe('New Datamanager', () => {
     it('can load some SCH items', async () => {
-        const dm = new NewApiDataManager('SCH', 90);
+        const dm = new NewApiDataManager(['SCH'], 90);
         await dm.loadData();
         const codexOfAscension = dm.itemById(40176);
         // Basic item props
@@ -84,7 +84,7 @@ describe('New Datamanager', () => {
 
     }).timeout(20_000);
     it('can get stats of food items', async () => {
-        const dm = new NewApiDataManager('SCH', 90);
+        const dm = new NewApiDataManager(['SCH'], 90);
         await dm.loadData();
         const food = dm.foodById(44096);
         eq(food.id, 44096);
@@ -102,7 +102,7 @@ describe('New Datamanager', () => {
 
         // Test cases from https://github.com/xiv-gear-planner/gear-planner/issues/317
         describe('syncs correctly in a lvl 90 i665 instance', () => {
-            const dm = new NewApiDataManager('SGE', 90, 665);
+            const dm = new NewApiDataManager(['SGE'], 90, 665);
             before(async () => {
                 await dm.loadData();
             });
@@ -168,7 +168,7 @@ describe('New Datamanager', () => {
         });
         // See also https://docs.google.com/spreadsheets/d/1C9OgUzFBTlomSpGV7rnv-M20DEGEJ8gtQN6JLNQ336o/edit?gid=791671595#gid=791671595
         describe('syncs correctly in a lvl 90 no-isync instance', () => {
-            const dm = new NewApiDataManager('SGE', 90);
+            const dm = new NewApiDataManager(['SGE'], 90);
             before(async () => {
                 await dm.loadData();
             });

--- a/packages/core/src/test/export_import_tests.ts
+++ b/packages/core/src/test/export_import_tests.ts
@@ -17,7 +17,7 @@ describe('importing and exporting', () => {
         let set: CharacterGearSet;
 
         before(async () => {
-            sheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "Foo", "WHM", 100, 735);
+            sheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "Foo", "WHM", 100, 735, false);
             await sheet.load();
             sheet.race = 'Wildwood';
             sheet.partyBonus = 3;
@@ -34,7 +34,7 @@ describe('importing and exporting', () => {
             set.forceRecalc();
             sheet.addGearSet(set);
         });
-        it('can export sheet correctly', async () => {
+        it('can export set correctly', async () => {
             const setExport = sheet.exportGearSet(set, true);
             expect(setExport.race).to.eq('Wildwood');
             expect(setExport.partyBonus).to.eq(3);
@@ -44,6 +44,9 @@ describe('importing and exporting', () => {
             expect(setExport.items.Weapon.materia[0].id).to.eq(MATERIA_ID);
             expect(setExport.items.Head.id).to.eq(HAT_ID);
             expect(setExport.items.Head.materia[0].id).to.eq(MATERIA_ID);
+
+            expect(setExport.jobOverride).to.be.oneOf([undefined, null]);
+            expect(setExport.job).to.equal('WHM');
         });
         it('can export set and import as a fresh sheet', async () => {
             const setExport = sheet.exportGearSet(set, true);
@@ -61,6 +64,10 @@ describe('importing and exporting', () => {
             const weapon = newSet.equipment.Weapon;
             expect(weapon.gearItem.id).to.equal(WEAPON_ID);
             expect(weapon.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+            expect(newSheet.isMultiJob).to.be.false;
+            expect(newSet.jobOverride).to.be.null;
+            expect(newSet.job).to.equal('WHM');
         });
         it('can export sheet and import as a fresh sheet', async () => {
             const sheetExport = sheet.exportSheet(true);
@@ -78,11 +85,15 @@ describe('importing and exporting', () => {
             const weapon = newSet.equipment.Weapon;
             expect(weapon.gearItem.id).to.equal(WEAPON_ID);
             expect(weapon.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+            expect(newSheet.isMultiJob).to.be.false;
+            expect(newSet.jobOverride).to.be.null;
+            expect(newSet.job).to.equal('WHM');
         });
         it('can export set and import onto a sheet', async () => {
             const setExport = sheet.exportGearSet(set, true);
             // Note that we are doing a cross-job import
-            const newSheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "Foo2", 'SGE', 90, 665);
+            const newSheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "Foo2", 'SGE', 90, 665, false);
             await newSheet.load();
             // If default set added, delete it
             if (newSheet.sets.length > 0) {
@@ -107,6 +118,206 @@ describe('importing and exporting', () => {
             const hat = newSet.equipment.Head;
             expect(hat.gearItem.id).to.equal(HAT_ID);
             expect(hat.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+            expect(newSheet.isMultiJob).to.be.false;
+            expect(newSet.jobOverride).to.be.null;
+            expect(newSet.job).to.equal('SGE');
+        });
+    });
+    describe('can export and import multi-job sheets', async () => {
+
+        // Cane of Ascension (i665 WHM cane)
+        const WEAPON_ID = 40173;
+        const WEAPON_ID_SGE = 44739;
+        // Credendum Circlet of Healing (i650)
+        const HAT_ID = 40060;
+        // Crit X materia
+        const MATERIA_ID = 33932;
+
+        let sheet: GearPlanSheet;
+        let set: CharacterGearSet;
+        // set with Job Override
+        let setJO: CharacterGearSet;
+
+        before(async () => {
+            sheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "Foo", "WHM", 100, 735, true);
+            await sheet.load();
+            sheet.race = 'Wildwood';
+            sheet.partyBonus = 3;
+            // If default set added, delete it
+            if (sheet.sets.length > 0) {
+                sheet.delGearSet(sheet.sets[0]);
+            }
+            set = new CharacterGearSet(sheet);
+            set.name = 'Bar';
+            set.setEquip("Weapon", sheet.itemById(WEAPON_ID));
+            set.equipment.Weapon.melds[0].equippedMateria = sheet.getMateriaById(MATERIA_ID);
+            set.setEquip("Head", sheet.itemById(HAT_ID));
+            set.equipment.Head.melds[0].equippedMateria = sheet.getMateriaById(MATERIA_ID);
+            set.forceRecalc();
+            sheet.addGearSet(set);
+
+            setJO = new CharacterGearSet(sheet);
+            setJO.earlySetJobOverride('SGE');
+            setJO.name = 'Bar';
+            setJO.setEquip("Weapon", sheet.itemById(WEAPON_ID_SGE));
+            setJO.equipment.Weapon.melds[0].equippedMateria = sheet.getMateriaById(MATERIA_ID);
+            setJO.setEquip("Head", sheet.itemById(HAT_ID));
+            setJO.equipment.Head.melds[0].equippedMateria = sheet.getMateriaById(MATERIA_ID);
+            setJO.forceRecalc();
+            sheet.addGearSet(setJO);
+        });
+        it('can export non-override set correctly', async () => {
+            const setExport = sheet.exportGearSet(set, true);
+            expect(setExport.race).to.eq('Wildwood');
+            expect(setExport.partyBonus).to.eq(3);
+            expect(setExport.ilvlSync).to.eq(735);
+            expect(setExport.name).to.eq("Bar");
+            expect(setExport.items.Weapon.id).to.eq(WEAPON_ID);
+            expect(setExport.items.Weapon.materia[0].id).to.eq(MATERIA_ID);
+            expect(setExport.items.Head.id).to.eq(HAT_ID);
+            expect(setExport.items.Head.materia[0].id).to.eq(MATERIA_ID);
+
+            expect(setExport.jobOverride).to.be.oneOf([undefined, null]);
+            expect(setExport.job).to.eq('WHM');
+        });
+        it('can export job override set correctly', async () => {
+            const setExport = sheet.exportGearSet(setJO, true);
+            expect(setExport.race).to.eq('Wildwood');
+            expect(setExport.partyBonus).to.eq(3);
+            expect(setExport.ilvlSync).to.eq(735);
+            expect(setExport.name).to.eq("Bar");
+            expect(setExport.items.Weapon.id).to.eq(WEAPON_ID_SGE);
+            expect(setExport.items.Weapon.materia[0].id).to.eq(MATERIA_ID);
+            expect(setExport.items.Head.id).to.eq(HAT_ID);
+            expect(setExport.items.Head.materia[0].id).to.eq(MATERIA_ID);
+
+            expect(setExport.jobOverride).to.be.oneOf([undefined, null]);
+            expect(setExport.job).to.eq('SGE');
+        });
+        it('can export set and import as a fresh sheet', async () => {
+            const setExport = sheet.exportGearSet(set, true);
+            const newSheet = HEADLESS_SHEET_PROVIDER.fromSetExport(setExport);
+            await newSheet.load();
+            expect(newSheet.race).to.equal('Wildwood');
+            expect(newSheet.partyBonus).to.equal(3);
+            // Should come from set name
+            expect(newSheet.sheetName).to.equal('Bar');
+
+            expect(newSheet.sets).to.have.length(1);
+            const newSet = newSheet.sets[0];
+
+            expect(newSet.name).to.equal('Bar');
+            const weapon = newSet.equipment.Weapon;
+            expect(weapon.gearItem.id).to.equal(WEAPON_ID);
+            expect(weapon.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+            expect(newSheet.isMultiJob).to.be.false;
+            expect(newSet.jobOverride).to.be.null;
+            expect(newSet.job).to.equal('WHM');
+        });
+        it('can export sheet and import as a fresh sheet', async () => {
+            const sheetExport = sheet.exportSheet(true);
+            const newSheet = HEADLESS_SHEET_PROVIDER.fromExport(sheetExport);
+            await newSheet.load();
+            expect(newSheet.race).to.equal('Wildwood');
+            expect(newSheet.partyBonus).to.equal(3);
+            // Should come from set name
+            expect(newSheet.sheetName).to.equal('Foo');
+
+            expect(newSheet.sets).to.have.length(2);
+            {
+                const newSet = newSheet.sets[0];
+
+                expect(newSet.name).to.equal('Bar');
+                const weapon = newSet.equipment.Weapon;
+                expect(weapon.gearItem.id).to.equal(WEAPON_ID);
+                expect(weapon.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+                expect(newSheet.isMultiJob).to.be.true;
+                expect(newSet.jobOverride).to.be.null;
+                expect(newSet.job).to.equal('WHM');
+            }
+
+            {
+                const newSet = newSheet.sets[1];
+
+                expect(newSet.name).to.equal('Bar');
+                const weapon = newSet.equipment.Weapon;
+                expect(weapon.gearItem.id).to.equal(WEAPON_ID_SGE);
+                expect(weapon.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+                expect(newSheet.isMultiJob).to.be.true;
+                expect(newSet.jobOverride).to.eq('SGE');
+                expect(newSet.job).to.equal('SGE');
+            }
+        });
+        it('can export set and import onto a non-multijob sheet', async () => {
+            const setExport = sheet.exportGearSet(set, true);
+            // Note that we are doing a cross-job import
+            const newSheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "Foo2", 'SGE', 90, 665, false);
+            await newSheet.load();
+            // If default set added, delete it
+            if (newSheet.sets.length > 0) {
+                newSheet.delGearSet(newSheet.sets[0]);
+            }
+            expect(newSheet.sets).to.have.length(0);
+            newSheet.addGearSet(newSheet.importGearSet(setExport));
+            expect(newSheet.sets).to.have.length(1);
+
+            // Does not keep these
+            expect(newSheet.race).to.equal(undefined);
+            expect(newSheet.partyBonus).to.equal(5);
+            // Should come from set name
+            expect(newSheet.sheetName).to.equal('Foo2');
+
+            const newSet = newSheet.sets[0];
+
+            expect(newSet.name).to.equal('Bar');
+
+            // Weapon is forcibly deleted because we can't use a WHM weapon on a SGE sheet
+            expect(newSet.equipment.Weapon).to.be.null;
+            const hat = newSet.equipment.Head;
+            expect(hat.gearItem.id).to.equal(HAT_ID);
+            expect(hat.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+            expect(newSheet.isMultiJob).to.be.false;
+            expect(newSet.jobOverride).to.be.null;
+            expect(newSet.job).to.equal('SGE');
+        });
+        it('can export set and import onto a multijob sheet', async () => {
+            const setExport = sheet.exportGearSet(set, true);
+            expect(setExport.job).to.equal('WHM');
+            // Note that we are doing a cross-job import
+            const newSheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "Foo2", 'SGE', 90, 665, true);
+            await newSheet.load();
+            // If default set added, delete it
+            if (newSheet.sets.length > 0) {
+                newSheet.delGearSet(newSheet.sets[0]);
+            }
+            expect(newSheet.sets).to.have.length(0);
+            newSheet.addGearSet(newSheet.importGearSet(setExport));
+            expect(newSheet.sets).to.have.length(1);
+
+            // Does not keep these
+            expect(newSheet.race).to.equal(undefined);
+            expect(newSheet.partyBonus).to.equal(5);
+            // Should come from set name
+            expect(newSheet.sheetName).to.equal('Foo2');
+
+            const newSet = newSheet.sets[0];
+
+            expect(newSet.name).to.equal('Bar');
+
+            // Weapon is retained because this is a multi-job sheet
+            expect(newSet.equipment.Weapon.gearItem.id).to.eq(WEAPON_ID);
+            const hat = newSet.equipment.Head;
+            expect(hat.gearItem.id).to.equal(HAT_ID);
+            expect(hat.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
+
+            expect(newSheet.isMultiJob).to.be.true;
+            expect(newSet.jobOverride).to.eq('WHM');
+            expect(newSet.job).to.equal('WHM');
         });
     });
 }).timeout(30_000);

--- a/packages/core/src/test/export_import_tests.ts
+++ b/packages/core/src/test/export_import_tests.ts
@@ -167,6 +167,10 @@ describe('importing and exporting', () => {
             setJO.forceRecalc();
             sheet.addGearSet(setJO);
         });
+        it('always sets jobOverride even for default job', async () => {
+            expect(set.job).to.eq('WHM');
+            expect(set.jobOverride).to.eq('WHM');
+        });
         it('can export non-override set correctly', async () => {
             const setExport = sheet.exportGearSet(set, true);
             expect(setExport.race).to.eq('Wildwood');
@@ -235,7 +239,7 @@ describe('importing and exporting', () => {
                 expect(weapon.melds[0].equippedMateria.id).to.equal(MATERIA_ID);
 
                 expect(newSheet.isMultiJob).to.be.true;
-                expect(newSet.jobOverride).to.be.null;
+                expect(newSet.jobOverride).to.eq('WHM');
                 expect(newSet.job).to.equal('WHM');
             }
 

--- a/packages/core/src/test/sims/sim_tests.ts
+++ b/packages/core/src/test/sims/sim_tests.ts
@@ -202,7 +202,7 @@ describe('Default sims', () => {
                 return existing;
             }
             else {
-                const newSheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "", job, level, undefined);
+                const newSheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, "", job, level, undefined, false);
                 const promise = newSheet.load();
                 sampleSheetLoad.set(newSheet, promise);
                 sampleSheets.push(newSheet);

--- a/packages/core/src/test/stats/auto_crit_dh_tests.ts
+++ b/packages/core/src/test/stats/auto_crit_dh_tests.ts
@@ -7,7 +7,7 @@ import {Buff, DamagingAbility, GcdAbility} from "../../sims/sim_types";
 import {abilityToDamageNew, combineBuffEffects} from "../../sims/sim_utils";
 
 const level = 100;
-const fakeSheetGNB = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'GNB', level, undefined);
+const fakeSheetGNB = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'GNB', level, undefined, false);
 const loadPromiseGNB = fakeSheetGNB.load();
 const rawStats = new RawStats({
     hp: 0,

--- a/packages/core/src/test/stats/general_stats_tests.ts
+++ b/packages/core/src/test/stats/general_stats_tests.ts
@@ -11,7 +11,7 @@ import {getScalingOverrides} from "../../sims/sim_utils";
 
 const level = 100;
 const job = 'SCH';
-const fakeSheet = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", job, level, undefined);
+const fakeSheet = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", job, level, undefined, false);
 
 const loadPromise = fakeSheet.load();
 
@@ -220,13 +220,13 @@ describe("ComputedSetStats", () => {
 
 describe("Dmg/100p for known values", () => {
     // https://docs.google.com/spreadsheets/d/1yy11-m_iWaKs8zccrjunLELEGHCDSE3YNQkhx-E_tkk/edit?gid=1658055958#gid=1658055958
-    const fakeSheetSMN = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'SMN', level, undefined);
+    const fakeSheetSMN = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'SMN', level, undefined, false);
     const loadPromiseSMN = fakeSheetSMN.load();
-    const fakeSheetSCH = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'SCH', level, undefined);
+    const fakeSheetSCH = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'SCH', level, undefined, false);
     const loadPromiseSCH = fakeSheetSCH.load();
-    const fakeSheetWAR = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'WAR', level, undefined);
+    const fakeSheetWAR = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'WAR', level, undefined, false);
     const loadPromiseWAR = fakeSheetWAR.load();
-    const fakeSheetGNB = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'GNB', level, undefined);
+    const fakeSheetGNB = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'GNB', level, undefined, false);
     const loadPromiseGNB = fakeSheetGNB.load();
     it('SMN test 1', async () => {
         await loadPromiseSMN;
@@ -732,9 +732,9 @@ describe("Dmg/100p for known values", () => {
 });
 
 describe("Final damage values for known values", () => {
-    const fakeSheetDRK = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'DRK', level, undefined);
+    const fakeSheetDRK = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'DRK', level, undefined, false);
     const loadPromiseDRK = fakeSheetDRK.load();
-    const fakeSheetWAR = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'WAR', level, undefined);
+    const fakeSheetWAR = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'WAR', level, undefined, false);
     const loadPromiseWAR = fakeSheetWAR.load();
     it('WAR test autocrit/dh', async () => {
         await loadPromiseWAR;

--- a/packages/data-api-client/src/dataapi.ts
+++ b/packages/data-api-client/src/dataapi.ts
@@ -108,7 +108,7 @@ export type FoodItemAction = XivApiObject &
 export type FoodItemBase = XivApiObject &
   XivApiBase & {
     name?: string;
-    nameTranslations?: XivApiLangString;
+    nameTranslations?: XivApiLangValueString;
     icon?: Icon;
     /** @format int32 */
     levelItem?: number;
@@ -171,7 +171,7 @@ export type ItemBase = XivApiObject &
     /** @format int32 */
     ilvl?: number;
     name?: string;
-    nameTranslations?: XivApiLangString;
+    nameTranslations?: XivApiLangValueString;
     icon?: Icon;
     equipSlotCategory?: EquipSlotCategory;
     /** @format int32 */
@@ -258,7 +258,7 @@ export interface MateriaEndpointResponse {
 export type MateriaItem = XivApiObject &
   XivApiBase & {
     name?: string;
-    nameTranslations?: XivApiLangString;
+    nameTranslations?: XivApiLangValueString;
     icon?: Icon;
     /** @format int32 */
     ilvl?: number;
@@ -268,7 +268,7 @@ export interface XivApiBase {
   schemaVersion?: XivApiSchemaVersion;
 }
 
-export interface XivApiLangString {
+export interface XivApiLangValueString {
   en?: string;
   de?: string;
   fr?: string;
@@ -563,7 +563,7 @@ export class DataApiClient<SecurityDataType extends unknown> extends HttpClient<
      */
     items: (
       query: {
-        job: string;
+        job: string[];
       },
       params: RequestParams = {},
     ) =>

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -282,6 +282,7 @@ class JobPicker extends HTMLElement {
             if (defaultJob === jobName) {
                 jobSelector.classList.add('selected');
                 this._selectedJob = jobName;
+                this._selectedSelector = jobSelector;
             }
             let parent: HTMLDivElement;
             switch (job.role) {

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -16,7 +16,7 @@ import {BaseModal} from "@xivgear/common-ui/components/modal";
 import {SHARED_SET_NAME} from "@xivgear/core/imports/imports";
 import {recordSheetEvent} from "@xivgear/gearplan-frontend/analytics/analytics";
 import {JobIcon} from "./job_icon";
-import {JobDataConst, RoleKey} from "@xivgear/xivmath/geartypes";
+import {RoleKey} from "@xivgear/xivmath/geartypes";
 
 export type NewSheetTempSettings = {
     ilvlSyncEnabled: boolean,

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -222,8 +222,10 @@ async function doNav(navState: NavState) {
         }
     }
     catch (e) {
+        console.error(e);
         recordError('doNav', e);
         showFatalError("navigation error");
+        return;
     }
     console.error("I don't know what to do with this path", navState);
     showFatalError("This does not seem to be a valid page");

--- a/packages/frontend/src/scripts/workers/worker_main.ts
+++ b/packages/frontend/src/scripts/workers/worker_main.ts
@@ -47,7 +47,7 @@ onmessage = async function (event) {
             // This "sheet" is only used to get everything into the cache - it is never actually used.
             // We re-use the DataManager only.
             const sheet = HEADLESS_SHEET_PROVIDER.fromExport(request.sheet);
-            dataManager = makeDataManager(sheet.classJobName, sheet.level, sheet.ilvlSync);
+            dataManager = makeDataManager(sheet.allJobs, sheet.level, sheet.ilvlSync);
             await dataManager.loadData();
 
             const response: WorkResponseDone<AnyJobContext> = {

--- a/packages/math-frontend/src/scripts/mathpage/formulae.ts
+++ b/packages/math-frontend/src/scripts/mathpage/formulae.ts
@@ -57,7 +57,7 @@ let jobDataManager: Promise<DataManager>;
 
 async function getClassJobStatsFull(job: JobName) {
     if (jobDataManager === undefined) {
-        const dm = makeDataManager(job, 100);
+        const dm = makeDataManager([job], 100);
         jobDataManager = dm.loadData().then(() => dm);
     }
     const multipliers = (await jobDataManager).multipliersForJob(job);

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -198,6 +198,8 @@ export interface GearItem extends XivCombatItem {
     relicStatModel: RelicStatModel | undefined;
     isNqVersion: boolean;
     rarity: number;
+
+    usableByJob(job: JobName): boolean;
 }
 
 export interface FoodStatBonus {
@@ -721,6 +723,11 @@ export interface SheetExport {
      * Unix timestamp
      */
     timestamp?: number,
+
+    /**
+     * True if this is a multi-job sheet (within a single role)
+     */
+    isMultiJob?: boolean,
 }
 
 export type CustomItemExport = {
@@ -804,6 +811,10 @@ export interface SetExport {
      * Indicates that this set is a separator rather than an actual set
      */
     isSeparator?: boolean,
+    /**
+     * For multi-class sheets, each set can have a different job.
+     */
+    jobOverride?: JobName | null,
 }
 
 export type ItemsSlotsExport = {

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -56,15 +56,17 @@ export const STANDARD_APPLICATION_DELAY = 0.6;
 // TODO: find actual value
 export const AUTOATTACK_APPLICATION_DELAY = 0.6;
 
+export const ALL_COMBAT_JOBS = [
+    'WHM', 'SGE', 'SCH', 'AST',
+    'PLD', 'WAR', 'DRK', 'GNB',
+    'DRG', 'MNK', 'NIN', 'SAM', 'RPR', 'VPR',
+    'BRD', 'MCH', 'DNC',
+    'BLM', 'SMN', 'RDM', 'BLU', 'PCT',
+] as const;
 /**
  * Supported Jobs.
  */
-export type JobName
-    = 'WHM' | 'SGE' | 'SCH' | 'AST'
-    | 'PLD' | 'WAR' | 'DRK' | 'GNB'
-    | 'DRG' | 'MNK' | 'NIN' | 'SAM' | 'RPR' | 'VPR'
-    | 'BRD' | 'MCH' | 'DNC'
-    | 'BLM' | 'SMN' | 'RDM' | 'BLU' | 'PCT';
+export type JobName = typeof ALL_COMBAT_JOBS[number];
 
 /**
  * All clans/races.
@@ -246,8 +248,8 @@ export const JOB_DATA: Record<JobName, JobDataConst> = {
                 apply: (stats) => {
                     stats.bonusHaste.push(attackType =>
                         attackType === 'Weaponskill'
-                    || attackType === 'Spell'
-                    || attackType === 'Auto-attack'
+                        || attackType === 'Spell'
+                        || attackType === 'Auto-attack'
                             ? 20 : 0);
                 },
             }],


### PR DESCRIPTION
Closes #272 and #587

This allows you to have a role-based sheet, which includes jobs of all roles. The sheet still has a "primary" job as selected on the new sheet (or the "save as" screen), but you can change the job for an individual set within the sheet.

- [x] Make Datamanager server support querying multiple jobs' worth of items in one request.
- [x] Add multi-job logic to sheets and sets.
- [x] Make UI show appropriate items.
- [x] UI to pick job for an individual sheet.
- [x] Import/export logic.
- [x] Make sure it works correctly when you "Save As" the sheet for a different class.
- [x] Make the "Save As" dialog only show jobs of the same role.