### PR TITLE
Add real links to bis browser

### DIFF
--- a/packages/common-ui/src/table/tables.ts
+++ b/packages/common-ui/src/table/tables.ts
@@ -641,6 +641,8 @@ export class CustomRow<RowDataType> extends HTMLTableRowElement implements Refre
     table: CustomTable<RowDataType, any>;
     dataColMap: Map<CustomColumn<RowDataType, unknown, unknown>, CustomCell<RowDataType, unknown>> = new Map<CustomColumn<RowDataType, unknown, unknown>, CustomCell<RowDataType, unknown>>();
     private _selected: boolean = false;
+    beforeElements: Node[] = [];
+    afterElements: Node[] = [];
 
     constructor(dataItem: RowDataType, table: CustomTable<RowDataType, any>, opts?: RefreshableOpts) {
         super();
@@ -683,7 +685,7 @@ export class CustomRow<RowDataType> extends HTMLTableRowElement implements Refre
                 }
             }
         }
-        this.replaceChildren(...newColElements);
+        this.replaceChildren(...this.beforeElements, ...newColElements, ...this.afterElements);
         for (const value of this.dataColMap.values()) {
             value.refreshFull();
         }

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1187,7 +1187,6 @@ job-picker {
       padding: 0;
       width: 100%;
 
-
       tr {
         height: 23px;
         max-height: 23px;
@@ -3991,3 +3990,12 @@ expandable-text {
   }
 }
 
+
+.row-overlay-link {
+  display: block;
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}


### PR DESCRIPTION
Overlays a real `<a>` element over the bis browser links so that you can middle click/open in new tab.

Fixes #588
