### PR TITLE
Improve level modifiers to make them respect unique fields on different ability types

### DIFF
--- a/packages/core/src/sims/healer/ast_sheet_sim.ts
+++ b/packages/core/src/sims/healer/ast_sheet_sim.ts
@@ -1,14 +1,30 @@
 import {Divination} from "@xivgear/core/sims/buffs";
-import {Ability, BuffController, GcdAbility, OgcdAbility, PersonalBuff, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
-import {CycleProcessor, CycleSimResult, ExternalCycleSettings, MultiCycleSettings, Rotation, PreDmgAbilityUseRecordUnf, AbilityUseResult} from "@xivgear/core/sims/cycle_sim";
+import {
+    Ability,
+    BuffController,
+    GcdAbility, LevelModifiable,
+    OgcdAbility,
+    PersonalBuff,
+    SimSettings,
+    SimSpec
+} from "@xivgear/core/sims/sim_types";
+import {
+    AbilityUseResult,
+    CycleProcessor,
+    CycleSimResult,
+    ExternalCycleSettings,
+    MultiCycleSettings,
+    PreDmgAbilityUseRecordUnf,
+    Rotation
+} from "@xivgear/core/sims/cycle_sim";
 import {rangeInc} from "@xivgear/util/array_utils";
 import {BaseMultiCycleSim} from "@xivgear/core/sims/processors/sim_processors";
 //import {potionMaxMind} from "@xivgear/core/sims/common/potion";
 
-type AstAbility = Ability & Readonly<{
+type AstAbility = Ability & Readonly<LevelModifiable<{
     /** Run if an ability needs to update the aetherflow gauge */
     updateGauge?(gauge: AstGauge): void;
-}>
+}>>
 
 type AstGcdAbility = GcdAbility & AstAbility;
 
@@ -40,11 +56,19 @@ const combust: AstGcdAbility = {
     potency: 0,
     dot: {
         id: 2041,
-        tickPotency: 70,
+        tickPotency: 55,
         duration: 30,
     },
     attackType: "Spell",
     gcd: 2.5,
+    levelModifiers: [{
+        minLevel: 94,
+        dot: {
+            id: 2041,
+            tickPotency: 70,
+            duration: 30,
+        },
+    }],
 };
 
 const star: AstOgcdAbility = {
@@ -214,17 +238,20 @@ class AstGauge {
     get cards() {
         return this._cards;
     }
+
     set cards(newCards: Set<string>) {
         this._cards = newCards;
     }
 
-    addCard(newCard: string){
+    addCard(newCard: string) {
         this._cards.add(newCard);
     }
-    playCard(played: string){
+
+    playCard(played: string) {
         this._cards.delete(played);
     }
-    clearCards(){
+
+    clearCards() {
         this._cards.clear();
     }
 
@@ -359,9 +386,7 @@ class AstCycleProcessor extends CycleProcessor {
 export class AstSim extends BaseMultiCycleSim<AstSimResult, AstSettings, AstCycleProcessor> {
 
     makeDefaultSettings(): AstSettings {
-        return {
-
-        };
+        return {};
     };
 
     spec = astNewSheetSpec;
@@ -405,8 +430,7 @@ export class AstSim extends BaseMultiCycleSim<AstSimResult, AstSettings, AstCycl
                     }
                 });
             },
-        },
-        ...rangeInc(10, 28, 2).map(i => ({
+        }, ...rangeInc(10, 28, 2).map(i => ({
             name: `Redot at ${i}s`,
             cycleTime: 120,
             apply(cp: AstCycleProcessor) {
@@ -449,8 +473,7 @@ export class AstSim extends BaseMultiCycleSim<AstSimResult, AstSettings, AstCycl
                     }
                 });
             },
-        })),
-        ...rangeInc(2, 16, 2).map(i => ({
+        })), ...rangeInc(2, 16, 2).map(i => ({
             name: `Delay dot to ${i}s`,
             cycleTime: 120,
             apply(cp: AstCycleProcessor) {

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -265,11 +265,19 @@ export type DamagingAbility = Readonly<{
  * above a certain level. Can be used to express e.g. traits increasing
  * the potency of skills, or granting new buffs.
  */
-export type LevelModifier = ({
+export type LevelModifier<X> = ({
         minLevel: number,
     })
-    & Omit<Partial<BaseAbility>, 'levelModifiers'>;
+    & Omit<Partial<X>, 'levelModifiers'>;
 
+export type LevelModifiable<X> = X & {
+    /**
+     * A list of level modifiers, that can override properties of the ability
+     * at the specified level. An action will have its properties overriden for
+     * the highest `minLevel` specified.
+     */
+    levelModifiers?: LevelModifier<X>[],
+}
 /**
  * Combo mode:
  * start: starts a combo.
@@ -285,7 +293,7 @@ export type ComboBehavior = ComboData['comboBehavior'];
  */
 export type AlternativeScaling = "Living Shadow Strength Scaling" | "Pet Action Weapon Damage";
 
-export type BaseAbility = Readonly<{
+export type BaseAbility = Readonly<LevelModifiable<{
     /**
      * Name of the ability.
      */
@@ -342,17 +350,11 @@ export type BaseAbility = Readonly<{
      */
     appDelay?: number,
     /**
-     * A list of level modifiers, that can override properties of the ability
-     * at the specified level. An action will have its properties overriden for
-     * the highest `minLevel` specified.
-     */
-    levelModifiers?: LevelModifier[],
-    /**
      * If the ability uses alternate scalings, such as Living Shadow Strength
      * scaling or using the pet action Weapon Damage multiplier.
      */
     alternativeScalings?: AlternativeScaling[],
-} & (NonDamagingAbility | DamagingAbility)>;
+}> & (LevelModifiable<NonDamagingAbility> | LevelModifiable<DamagingAbility>)>;
 
 
 /**
@@ -403,25 +405,25 @@ export type CdAbility = OriginCdAbility | SharedCdAbility;
 /**
  * Represents a GCD action
  */
-export type GcdAbility = BaseAbility & Readonly<{
+export type GcdAbility = BaseAbility & Readonly<LevelModifiable<{
     type: 'gcd';
     /**
      * If the ability's GCD can be lowered by sps/sks, put it here.
      */
     gcd: number,
-}>
+}>>
 
 /**
  * Represents an oGCD action
  */
-export type OgcdAbility = BaseAbility & Readonly<{
+export type OgcdAbility = BaseAbility & Readonly<LevelModifiable<{
     type: 'ogcd',
-}>;
+}>>;
 
-export type AutoAttack = BaseAbility & DamagingAbility & Readonly<{
+export type AutoAttack = BaseAbility & DamagingAbility & Readonly<LevelModifiable<{
     type: 'autoattack',
     // TODO
-}>;
+}>>;
 
 export type Ability = GcdAbility | OgcdAbility | AutoAttack;
 


### PR DESCRIPTION
You can now wrap any `Ability`-ish type with `LevelModifiable<X>` to allow `levelModifiers` to contain your type's custom fields.