### PR TITLE
[GNB] Fix logic error with gnb microclip setting, make it work in a more intuitive way

### DIFF
--- a/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
@@ -447,7 +447,7 @@ export class GnbSim extends BaseMultiCycleSim<GnbSimResult, GnbSettings, GnbCycl
                 // The 9 here counts:
                 // - The immediately following GCD (not in No Mercy)
                 // - The 8 GCDs we'll get in No Mercy
-                if (readyAt.relative + NoMercyBuff.duration <= cp.stats.gcdPhys(2.5) * 9) {
+                if (readyAt.relative + NoMercyBuff.duration <= cp.stats.gcdPhys(2.5) * 9 && cp.gauge.cartridges === 3) {
                     return Actions.BurstStrike;
                 }
             }

--- a/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
+++ b/packages/core/src/sims/tank/gnb/gnb_sheet_sim.ts
@@ -447,7 +447,10 @@ export class GnbSim extends BaseMultiCycleSim<GnbSimResult, GnbSettings, GnbCycl
                 // The 9 here counts:
                 // - The immediately following GCD (not in No Mercy)
                 // - The 8 GCDs we'll get in No Mercy
-                if (readyAt.relative + NoMercyBuff.duration <= cp.stats.gcdPhys(2.5) * 9 && cp.gauge.cartridges === 3) {
+                // We check Ready To Reign to make sure it's a 2m burst. Otherwise the Burst Strike
+                // we're about to use would go in the No Mercy fully.
+                const aboutToStart2mBurst = cp.gauge.cartridges === 3 && cp.isReadyToReignBuffActive();
+                if (readyAt.relative + NoMercyBuff.duration <= cp.stats.gcdPhys(2.5) * 9 && aboutToStart2mBurst) {
                     return Actions.BurstStrike;
                 }
             }


### PR DESCRIPTION
This makes the solution a lot more elegant. In essence, we will subtract from the cooldown the difference between the ideal cooldown and the actual cooldown. It also no longer cheats.

![image](https://github.com/user-attachments/assets/470aafd5-94cc-4cce-9054-7b67a9512a97)


Additionally this fixes a bug introduced by https://github.com/xiv-gear-planner/gear-planner/pull/544 that caused issues in the 1m for speeds other than 2.50