### PR TITLE
Fixes some regressions with custom-stat relics

### DIFF
--- a/packages/common-ui/src/table/tables.ts
+++ b/packages/common-ui/src/table/tables.ts
@@ -586,6 +586,8 @@ export interface CustomColumnSpec<RowDataType, CellDataType, ColumnDataType = an
     dataValue?: ColumnDataType;
     headerStyler?: (value: ColumnDataType, colHeader: CustomTableHeaderCell<RowDataType, CellDataType, ColumnDataType>) => void;
     extraClasses?: string[];
+    titleSetter?: (value: CellDataType, rowValue: RowDataType, cell: CustomCell<RowDataType, CellDataType>) => string | null;
+    finisher?: (value: CellDataType, rowValue: RowDataType, cell: CustomCell<RowDataType, CellDataType>) => void;
 }
 
 export function col<RowDataType, CellDataType = string, ColumnDataType = any>(cdef: CustomColumnSpec<RowDataType, CellDataType, ColumnDataType>): CustomColumn<RowDataType, CellDataType, ColumnDataType> {
@@ -630,6 +632,8 @@ export class CustomColumn<RowDataType, CellDataType = string, ColumnDataType = a
     fixedWidth: number | undefined = undefined;
     dataValue?: ColumnDataType;
     headerStyler?: (value: typeof this.dataValue, colHeader: CustomTableHeaderCell<RowDataType, CellDataType, ColumnDataType>) => void;
+    titleSetter?: (value: CellDataType, rowValue: RowDataType, cell: CustomCell<RowDataType, CellDataType>) => string | null;
+    finisher?: (value: CellDataType, rowValue: RowDataType, cell: CustomCell<RowDataType, CellDataType>) => void;
 }
 
 export type RefreshableOpts = {
@@ -738,9 +742,10 @@ export class CustomCell<RowDataType, CellDataType> extends HTMLTableCellElement 
     }
 
     refreshFull() {
+        const rowValue = this.dataItem;
         let node: Node | null;
         try {
-            this._cellValue = this.colDef.getter(this.dataItem);
+            this._cellValue = this.colDef.getter(rowValue);
             node = this.colDef.renderer(this._cellValue, this.row.dataItem);
             if (node) {
                 this.colDef.colStyler(this._cellValue, this, node, this.row.dataItem);
@@ -768,6 +773,8 @@ export class CustomCell<RowDataType, CellDataType> extends HTMLTableCellElement 
             }
         }
         this.refreshSelection();
+        this.refreshTitle();
+        this.colDef.finisher?.(this._cellValue, this.row.dataItem, this);
     }
 
     refreshSelection() {
@@ -794,6 +801,17 @@ export class CustomCell<RowDataType, CellDataType> extends HTMLTableCellElement 
         return this.colDef.rowCondition(this.row.dataItem);
     }
 
+    refreshTitle() {
+        if (this.colDef.titleSetter) {
+            const newTitle = this.colDef.titleSetter(this._cellValue, this.row.dataItem, this);
+            if (newTitle) {
+                this.title = newTitle;
+            }
+            else {
+                this.removeAttribute('title');
+            }
+        }
+    }
 }
 
 export type ColDefs<RowDataType> = (CustomColumn<RowDataType> | CustomColumnSpec<RowDataType, any>)[];

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2509,7 +2509,7 @@ input.gear-items-table-relic-stat-input, select.gear-items-table-relic-stat-inpu
   text-align: center;
 
   &.relic-validation-failed {
-    border: 2px solid red;
+    box-shadow: 1px 1px 2px red inset, -1px -1px 2px #ff6000 inset;
   }
 
   &:hover, &:active, &:focus {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2500,13 +2500,15 @@ div.labeled-checkbox {
 
 input.gear-items-table-relic-stat-input, select.gear-items-table-relic-stat-input {
   //border: var(--soft-border);
-  border: 2px solid transparent;
+  border: none;
   padding: 0 0 0 0;
   background: var(--relic-stat-input-background-color);
   box-sizing: border-box;
   //margin: 1px;
   width: 100%;
   text-align: center;
+  font-size: 13px;
+  height: calc(100% - 4px);
 
   &.relic-validation-failed {
     box-shadow: 1px 1px 2px red inset, -1px -1px 2px #ff6000 inset;

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -714,7 +714,7 @@ export class CharacterGearSet {
      * @param stat
      * @param materiaOverride
      */
-    getStatDetail(slotId: keyof EquipmentSet, stat: RawStatKey, materiaOverride?: Materia[]): ReturnType<typeof this.getEquipStatDetail> {
+    getStatDetail(slotId: keyof EquipmentSet, stat: RawStatKey, materiaOverride?: Materia[]): ReturnType<CharacterGearSet['getEquipStatDetail']> {
         const equip = this.equipment[slotId];
         return this.getEquipStatDetail(equip, stat, materiaOverride);
     }
@@ -806,7 +806,7 @@ export class CharacterGearSet {
                 overcapAmount: 0,
                 effectiveAmount: meldedStatValue,
                 fullAmount: meldedStatValue,
-                cap: meldedStatValue,
+                cap: cap,
             };
         }
         // Overcapped

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -186,8 +186,8 @@ function loadSaved(sheetKey: string): SheetExport | null {
  */
 export class GearPlanSheet {
     // General sheet properties
-    _sheetName: string;
-    _description: string;
+    private _sheetName: string;
+    private _description: string;
     readonly classJobName: JobName;
     readonly altJobs: JobName[];
     readonly isMultiJob: boolean;
@@ -224,7 +224,7 @@ export class GearPlanSheet {
     private _setupDone: boolean = false;
 
     // Display state
-    _isViewOnly: boolean = false;
+    private _isViewOnly: boolean = false;
     isEmbed: boolean;
 
     // Temporal state

--- a/packages/frontend/src/scripts/components/relic_stats.ts
+++ b/packages/frontend/src/scripts/components/relic_stats.ts
@@ -1,6 +1,7 @@
 import {EquippedItem, RelicStats, Substat} from "@xivgear/xivmath/geartypes";
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {FieldBoundDataSelect, FieldBoundIntField} from "@xivgear/common-ui/components/util";
+import {CustomCell} from "@xivgear/common-ui/table/tables";
 
 type HasValidation = {
     revalidate: () => void;
@@ -10,15 +11,15 @@ function refreshEditorContainers(input: HTMLElement) {
     const row = input.closest('tr');
     const inputs = row.querySelectorAll('select, input');
     inputs.forEach(inp => {
-        const reval = (input as unknown as HasValidation).revalidate;
+        const reval = (inp as unknown as HasValidation).revalidate;
         if (reval) {
             reval();
         }
     });
     const cells = row.querySelectorAll('td');
     cells.forEach(cell => {
-        if ('refreshTitle' in cell) {
-            (cell.refreshTitle as () => void)();
+        if (cell instanceof CustomCell) {
+            cell.refreshTitle();
         }
     });
 }
@@ -28,10 +29,11 @@ export function makeRelicStatEditor(equipment: EquippedItem, stat: Substat, set:
     // If the stat is excluded, disable editing ONLY if the user had not already entered a value. Otherwise, they'd be
     // stuck with a value that they can't clear.
     if (gearItem.relicStatModel.type && gearItem.relicStatModel.excludedStats.includes(stat) && !equipment.relicStats[stat]) {
-        const div = document.createElement('div');
-        div.classList.add('relic-stat-excluded');
-        div.title = 'You cannot use this relic stat on this class';
-        return div;
+        const out = document.createElement('span');
+        out.classList.add('relic-stat-excluded');
+        out.title = 'You cannot use this relic stat on this class';
+        out.textContent = '-';
+        return out;
     }
     else if (gearItem.relicStatModel.type === 'unknown' || gearItem.relicStatModel.type === 'customrelic') {
         const inputSubstatCap = gearItem.unsyncedVersion.statCaps[stat] ?? 1000;

--- a/packages/frontend/src/scripts/components/relic_stats.ts
+++ b/packages/frontend/src/scripts/components/relic_stats.ts
@@ -49,7 +49,7 @@ export function makeRelicStatEditor(equipment: EquippedItem, stat: Substat, set:
             }
             else {
                 input.classList.add('relic-validation-failed');
-                input.title = validationFailures.join('\n');
+                input.title = validationFailures.map(vf => vf.description).join('\n');
             }
         };
         reval();
@@ -93,7 +93,7 @@ export function makeRelicStatEditor(equipment: EquippedItem, stat: Substat, set:
             }
             else {
                 input.classList.add('relic-validation-failed');
-                input.title = validationFailures.join('\n');
+                input.title = validationFailures.map(vf => vf.description).join('\n');
             }
         };
         reval();

--- a/packages/frontend/src/scripts/components/relic_stats.ts
+++ b/packages/frontend/src/scripts/components/relic_stats.ts
@@ -6,6 +6,23 @@ type HasValidation = {
     revalidate: () => void;
 }
 
+function refreshEditorContainers(input: HTMLElement) {
+    const row = input.closest('tr');
+    const inputs = row.querySelectorAll('select, input');
+    inputs.forEach(inp => {
+        const reval = (input as unknown as HasValidation).revalidate;
+        if (reval) {
+            reval();
+        }
+    });
+    const cells = row.querySelectorAll('td');
+    cells.forEach(cell => {
+        if ('refreshTitle' in cell) {
+            (cell.refreshTitle as () => void)();
+        }
+    });
+}
+
 export function makeRelicStatEditor(equipment: EquippedItem, stat: Substat, set: CharacterGearSet): HTMLElement {
     const gearItem = equipment.gearItem;
     // If the stat is excluded, disable editing ONLY if the user had not already entered a value. Otherwise, they'd be
@@ -58,14 +75,7 @@ export function makeRelicStatEditor(equipment: EquippedItem, stat: Substat, set:
         input.addListener(() => {
             setTimeout(() => {
                 set.forceRecalc();
-                const row = input.closest('tr');
-                const inputs = row.querySelectorAll('select, input');
-                inputs.forEach(inp => {
-                    const reval = (inp as unknown as HasValidation).revalidate;
-                    if (reval) {
-                        reval();
-                    }
-                });
+                refreshEditorContainers(input);
             }, 10);
 
         });
@@ -102,15 +112,7 @@ export function makeRelicStatEditor(equipment: EquippedItem, stat: Substat, set:
         input.addListener(() => {
             setTimeout(() => {
                 set.forceRecalc();
-                const row = input.closest('tr');
-                const inputs = row.querySelectorAll('select, input');
-                console.log('inputs', []);
-                inputs.forEach(inp => {
-                    const reval = (input as unknown as HasValidation).revalidate;
-                    if (reval) {
-                        reval();
-                    }
-                });
+                refreshEditorContainers(input);
             }, 10);
 
         });

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -288,7 +288,7 @@ export class GearPlanTable extends CustomTable<CharacterGearSet, SingleCellRowOr
     // }
 
     private setupColumns() {
-        const viewOnly = this.sheet._isViewOnly;
+        const viewOnly = this.sheet.isViewOnly;
         if (viewOnly) {
             // TODO: this leaves 1px extra to the left of the name columns
             // Also messes with the selection outline
@@ -1247,7 +1247,7 @@ function formatSimulationConfigArea<SettingsType extends SimSettings>(
     // const header = document.createElement("h1");
     // header.textContent = "Configuring " + sim.displayName;
     // outerDiv.appendChild(header);
-    if (sheet._isViewOnly) {
+    if (sheet.isViewOnly) {
         const title = document.createElement('h1');
         title.textContent = simGui.sim.displayName;
     }
@@ -1411,7 +1411,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
     private set editorItem(item: typeof this._editorItem) {
         this._editorItem = item;
-        if (this._isViewOnly) {
+        if (this.isViewOnly) {
             this.headerArea.style.display = 'none';
         }
         this.resetEditorArea();
@@ -1442,7 +1442,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
                 // TODO: centralize these debugging shortcuts
                 window.currentGearSet = item;
                 if (item.isSeparator) {
-                    if (this._isViewOnly) {
+                    if (this.isViewOnly) {
                         this.setupEditorArea(new SeparatorViewer(item));
                     }
                     else {
@@ -1450,7 +1450,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
                     }
                 }
                 else {
-                    if (this._isViewOnly) {
+                    if (this.isViewOnly) {
                         this.setupEditorArea(new GearSetViewer(this, item));
                     }
                     else {
@@ -1492,7 +1492,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
         const sheetOptions = new DropdownActionMenu('More Actions...');
 
-        if (!this._isViewOnly) {
+        if (!this.isViewOnly) {
             const addRowButton = makeActionButton("New Gear Set", () => {
                 const newSet = new CharacterGearSet(this);
                 newSet.name = "New Set";
@@ -1543,7 +1543,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
             buttonsArea.appendChild(ilvlSyncLabel);
         }
 
-        if (this._isViewOnly) {
+        if (this.isViewOnly) {
             const saveAsButton = makeActionButton("Save As", () => {
                 const modal = new SaveAsModal(this, newSheet => openSheetByKey(newSheet.saveKey));
                 modal.attachAndShow();
@@ -1561,7 +1561,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
             });
         }
 
-        if (!this._isViewOnly) {
+        if (!this.isViewOnly) {
 
             const newSimButton = makeActionButton("Add Simulation", () => {
                 this.showAddSimDialog();
@@ -1645,7 +1645,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
             this.headerArea.style.display = 'none';
         }
         else {
-            if (this._isViewOnly) {
+            if (this.isViewOnly) {
                 const heading = document.createElement('h1');
                 heading.textContent = this.sheetName;
                 this.headerArea.appendChild(heading);
@@ -2085,7 +2085,7 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
     set sheetName(name: string) {
         super.sheetName = name;
-        setTitle(this._sheetName);
+        setTitle(this.sheetName);
     }
 
     configureBacklinkArea(sheetName: string, sheetUrl: URL): void {

--- a/packages/frontend/src/style.less
+++ b/packages/frontend/src/style.less
@@ -19,10 +19,6 @@ custom-item-popup, custom-food-popup {
         //margin: 1px;
         text-align: center;
 
-        &.relic-validation-failed {
-          border: 2px solid red;
-        }
-
         &:hover, &:active, &:focus {
           background: var(--relic-stat-input-background-hover-color);
         }


### PR DESCRIPTION
- [X] Fixes #607 
- [X] Fixes lack of styling for invalid relic cells
- [X] Fixes tooltip not updating until you deselect and reselect the relic
- [X] Fixes relic tooltip not actually showing the stat cap
- [X] Fixes a bug where relics with memorized stats would not display those stats if no weapon was selected when opening the set
- [X] Fix incorrect appearance of downsynced relic cells in view mode
- [X] Closes #610 

While in the code, I also made a small change to make relics which are unequipped display a '-' instead of a '0' in stats that the relic in question does not support.