### PR TITLE
[DRK] Correct Living Shadow scaling, make the code better

### DIFF
--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -40,7 +40,7 @@ import {
     XivCombatItem
 } from "@xivgear/xivmath/geartypes";
 import {Inactivitytimer} from "@xivgear/util/inactivitytimer";
-import {addStats, finalizeStats, finalizeStatsInt} from "@xivgear/xivmath/xivstats";
+import {addStats, finalizeStats, finalizeStatsInt, getBaseMainStat} from "@xivgear/xivmath/xivstats";
 import {GearPlanSheet} from "./sheet";
 import {isMateriaAllowed} from "./materia/materia_utils";
 
@@ -597,7 +597,7 @@ export class CharacterGearSet {
 
         // Base stats based on job and level
         for (const statKey of MAIN_STATS) {
-            combinedStats[statKey] += Math.floor(levelStats.baseMainStat * classJobStats.jobStatMultipliers[statKey] / 100);
+            combinedStats[statKey] += getBaseMainStat(levelStats, classJobStats, statKey);
         }
         for (const statKey of FAKE_MAIN_STATS) {
             combinedStats[statKey] += Math.floor(levelStats.baseMainStat);
@@ -612,7 +612,7 @@ export class CharacterGearSet {
         this._dirtyComp = false;
         // Add BLU weapon damage modifier
         combinedStats.wdMag += classJob === "BLU" ? bluWdfromInt(gearIntStat) : 0;
-        const computedStats = finalizeStats(combinedStats, this._food?.bonuses ?? {}, level, levelStats, classJob, classJobStats, this._sheet.partyBonus, this._sheet.race);
+        const computedStats = finalizeStats(combinedStats, this._food?.bonuses ?? {}, level, levelStats, classJob, classJobStats, this._sheet.partyBonus, raceStats);
         const leftRing = this.getItemInSlot('RingLeft');
         const rightRing = this.getItemInSlot('RingRight');
         if (leftRing && leftRing.isUnique && rightRing && rightRing.isUnique) {

--- a/packages/core/src/sims/sim_utils.ts
+++ b/packages/core/src/sims/sim_utils.ts
@@ -109,7 +109,7 @@ export function getScalingOverrides(alternativeScalings: AlternativeScaling[], s
     // Process alternative scalings for the ability. There may be multiple.
     if (alternativeScalings) {
         if (alternativeScalings.includes("Living Shadow Strength Scaling")) {
-            const livingShadowStrength = getLivingShadowStrength(stats.gearStats.strength, stats.racialStats) + strengthBuff;
+            const livingShadowStrength = getLivingShadowStrength(stats.gearStats.strength, stats.levelStats.baseMainStat, stats.baseMainStatPlusRace) + strengthBuff;
             scalings.mainStatMulti = mainStatMultiLivingShadow(stats.levelStats, livingShadowStrength);
         }
         if (alternativeScalings.includes("Pet Action Weapon Damage")) {

--- a/packages/core/src/test/sims/common_values.ts
+++ b/packages/core/src/test/sims/common_values.ts
@@ -1,6 +1,6 @@
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {JobMultipliers} from "@xivgear/xivmath/geartypes";
-import {getClassJobStats, getLevelStats} from "@xivgear/xivmath/xivconstants";
+import {getClassJobStats, getLevelStats, getRaceStats} from "@xivgear/xivmath/xivconstants";
 import {finalizeStats} from "@xivgear/xivmath/xivstats";
 import {GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
 import {makeFakeSet} from "../test_utils";
@@ -122,13 +122,12 @@ const rawStats = {
     wdMag: 132,
     wdPhys: 132,
     weaponDelay: 3.44,
-    racialStrengthModifier: 3,
 };
 // Finalize the stats (add class modifiers, party bonus, etc)
 const stats = finalizeStats(rawStats, {}, 90, getLevelStats(90), 'WHM', {
     ...getClassJobStats('WHM'),
     jobStatMultipliers: jobStatMultipliers,
-}, 5, "The Lost");
+}, 5, getRaceStats("Wildwood"));
 
 // Turn the stats into a fake gear set. This object does not implement all of the methods that a CharacterGearSet
 // should, only the ones that would commonly be used in a simulation.

--- a/packages/core/src/test/sims/cycle_processor_tests.ts
+++ b/packages/core/src/test/sims/cycle_processor_tests.ts
@@ -5,7 +5,7 @@ import * as assert from "assert";
 import {assertClose} from "@xivgear/util/test/test_utils";
 import {assertSimAbilityResults, setPartyBuffEnabled, UseResult} from "./sim_test_utils";
 import {JobMultipliers} from "@xivgear/xivmath/geartypes";
-import {getClassJobStats, getLevelStats, STANDARD_APPLICATION_DELAY} from "@xivgear/xivmath/xivconstants";
+import {getClassJobStats, getLevelStats, getRaceStats, STANDARD_APPLICATION_DELAY} from "@xivgear/xivmath/xivconstants";
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {Divination, Litany, Dokumori} from "@xivgear/core/sims/buffs";
 import {exampleGearSet} from "./common_values";
@@ -245,7 +245,7 @@ const rawStats = {
 const stats = finalizeStats(rawStats, {}, 90, getLevelStats(90), 'WHM', {
     ...getClassJobStats('WHM'),
     jobStatMultipliers: jobStatMultipliers,
-}, 5, "The Lost");
+}, 5, getRaceStats("Wildwood"));
 
 // Turn the stats into a fake gear set. This object does not implement all of the methods that a CharacterGearSet
 // should, only the ones that would commonly be used in a simulation.

--- a/packages/core/src/test/stats/auto_crit_dh_tests.ts
+++ b/packages/core/src/test/stats/auto_crit_dh_tests.ts
@@ -1,6 +1,6 @@
 import {finalizeStats} from "@xivgear/xivmath/xivstats";
 import {RawStats} from "@xivgear/xivmath/geartypes";
-import {getLevelStats} from "@xivgear/xivmath/xivconstants";
+import {getLevelStats, getRaceStats} from "@xivgear/xivmath/xivconstants";
 import {HEADLESS_SHEET_PROVIDER} from "../../sheet";
 import {expect} from "chai";
 import {Buff, DamagingAbility, GcdAbility} from "../../sims/sim_types";
@@ -27,7 +27,7 @@ const rawStats = new RawStats({
     wdMag: 79,
     weaponDelay: 3.12,
 });
-const makeStats = loadPromiseGNB.then(() => finalizeStats(rawStats, {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost"));
+const makeStats = loadPromiseGNB.then(() => finalizeStats(rawStats, {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost")));
 
 describe("Auto Crit and Dh Bonus Multi Calculation", () => {
     it('has no bonuses by default', async () => {

--- a/packages/core/src/test/stats/general_stats_tests.ts
+++ b/packages/core/src/test/stats/general_stats_tests.ts
@@ -1,6 +1,6 @@
 import {finalizeStats} from "@xivgear/xivmath/xivstats";
 import {RawStats} from "@xivgear/xivmath/geartypes";
-import {getLevelStats} from "@xivgear/xivmath/xivconstants";
+import {getLevelStats, getRaceStats} from "@xivgear/xivmath/xivconstants";
 import {expect} from "chai";
 import {applyDhCritFull, baseDamageFull, fl} from "@xivgear/xivmath/xivmath";
 import {multiplyFixed} from "@xivgear/xivmath/deviation";
@@ -37,7 +37,7 @@ describe("ComputedSetStats", () => {
             wdPhys: 141,
             wdMag: 141,
             weaponDelay: 3.12,
-        }), {}, level, getLevelStats(level), job, fakeSheet.classJobStats, 0, "The Lost");
+        }), {}, level, getLevelStats(level), job, fakeSheet.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.aaDelay).to.eq(3.12);
         expect(stats.aaMulti).to.eq(1.87);
         expect(stats.aaStatMulti).to.eq(0.77);
@@ -108,7 +108,7 @@ describe("ComputedSetStats", () => {
                 max: 79,
                 percentage: 10,
             },
-        }, level, getLevelStats(level), job, fakeSheet.classJobStats, 0, "The Lost");
+        }, level, getLevelStats(level), job, fakeSheet.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.aaDelay).to.eq(3.12);
         expect(stats.aaMulti).to.eq(1.87);
         expect(stats.aaStatMulti).to.eq(0.77);
@@ -179,7 +179,7 @@ describe("ComputedSetStats", () => {
                 max: 79,
                 percentage: 10,
             },
-        }, level, getLevelStats(level), job, fakeSheet.classJobStats, 5, "The Lost");
+        }, level, getLevelStats(level), job, fakeSheet.classJobStats, 5, getRaceStats("The Lost"));
         expect(stats.aaDelay).to.eq(3.12);
         expect(stats.aaMulti).to.eq(1.87);
         expect(stats.aaStatMulti).to.eq(0.87);
@@ -249,7 +249,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'SMN', fakeSheetSMN.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'SMN', fakeSheetSMN.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 100, 'Spell', false, false);
         expect(dmg100p.expected).to.eq(913);
         expect(stats.detMulti).to.eq(1.018);
@@ -281,7 +281,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'SMN', fakeSheetSMN.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'SMN', fakeSheetSMN.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 100, 'Spell', false, false);
         expect(dmg100p.expected).to.eq(1069);
         expect(stats.detMulti).to.eq(1.023);
@@ -313,7 +313,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'WAR', fakeSheetWAR.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'WAR', fakeSheetWAR.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 100, 'Weaponskill', false, false);
         expect(dmg100p.expected).to.eq(656);
         expect(stats.mainStatValue).to.eq(1012);
@@ -345,7 +345,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'WAR', fakeSheetWAR.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'WAR', fakeSheetWAR.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 100, 'Weaponskill', false, false);
         expect(dmg100p.expected).to.eq(703);
         expect(stats.mainStatValue).to.eq(1069);
@@ -378,7 +378,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 75, 'Spell', false, true);
         expect(dmg100p.expected).to.eq(467);
         expect(stats.determination).to.eq(440);
@@ -412,7 +412,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 75, 'Spell', false, true);
         expect(dmg100p.expected).to.eq(474);
         expect(stats.determination).to.eq(440);
@@ -446,7 +446,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 75, 'Spell', false, true);
         expect(dmg100p.expected).to.eq(475);
         expect(stats.determination).to.eq(440);
@@ -480,7 +480,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'SCH', fakeSheetSCH.classJobStats, 0, getRaceStats("The Lost"));
         const dmg100p = baseDamageFull(stats, 75, 'Spell', false, true);
         expect(dmg100p.expected).to.eq(476);
         expect(stats.determination).to.eq(440);
@@ -514,7 +514,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.determination).to.eq(987);
         expect(stats.detMulti).to.eq(1.027);
         expect(stats.skillspeed).to.eq(420);
@@ -548,7 +548,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.determination).to.eq(987);
         expect(stats.detMulti).to.eq(1.027);
         expect(stats.skillspeed).to.eq(456);
@@ -582,7 +582,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.determination).to.eq(987);
         expect(stats.detMulti).to.eq(1.027);
         expect(stats.skillspeed).to.eq(492);
@@ -616,7 +616,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.determination).to.eq(987);
         expect(stats.detMulti).to.eq(1.027);
         expect(stats.skillspeed).to.eq(564);
@@ -650,7 +650,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.determination).to.eq(1113);
         expect(stats.detMulti).to.eq(1.033);
         expect(stats.skillspeed).to.eq(456);
@@ -684,7 +684,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.determination).to.eq(1113);
         expect(stats.detMulti).to.eq(1.033);
         expect(stats.skillspeed).to.eq(600);
@@ -717,7 +717,7 @@ describe("Dmg/100p for known values", () => {
             weaponDelay: 3.12,
         }),
         // Pineapple Orange Jelly
-        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'GNB', fakeSheetGNB.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.determination).to.eq(1667);
         expect(stats.detMulti).to.eq(1.061);
         expect(stats.skillspeed).to.eq(492);
@@ -758,7 +758,7 @@ describe("Final damage values for known values", () => {
             wdMag: 146,
             weaponDelay: 3.12,
         }),
-        {}, level, getLevelStats(level), 'WAR', fakeSheetWAR.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'WAR', fakeSheetWAR.classJobStats, 0, getRaceStats("The Lost"));
         const fellCleavePotency = 580;
         const dmg100p = baseDamageFull(stats, fellCleavePotency, 'Weaponskill', true, false);
         expect(dmg100p.expected).to.eq(25898);
@@ -804,7 +804,7 @@ describe("Final damage values for known values", () => {
             wdMag: 36,
             weaponDelay: 2.96,
         }),
-        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, getRaceStats("The Lost"));
 
 
         // These match up with observed values.
@@ -828,7 +828,7 @@ describe("Final damage values for known values", () => {
         const stats = finalizeStats(new RawStats({
             hp: 7707,
             vitality: 489,
-            strength: 467,
+            strength: 469,
             dexterity: 421,
             intelligence: 261,
             mind: 179,
@@ -843,8 +843,9 @@ describe("Final damage values for known values", () => {
             wdMag: 35,
             weaponDelay: 2.96,
         }),
-        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, "Rava");
-        expect(stats.mainStatValue).to.eq(467);
+        // Using Rava for consistency with spreadsheet
+        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, getRaceStats("The Lost"));
+        expect(stats.mainStatValue).to.eq(469);
         expect(stats.determination).to.eq(440);
         expect(stats.wdMag).to.eq(35);
         expect(stats.wdPhys).to.eq(35);
@@ -886,7 +887,7 @@ describe("Final damage values for known values", () => {
             wdMag: 146,
             weaponDelay: 2.96,
         }),
-        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, "The Lost");
+        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, getRaceStats("The Lost"));
         expect(stats.mainStatValue).to.eq(4842);
 
         // These match up with observed values.
@@ -895,14 +896,14 @@ describe("Final damage values for known values", () => {
 
         // 420 potency Living Shadow Attack
         const damageBeforeCrit420 = baseDamageFull(stats, 420, 'Ability', false, false, livingShadowScalingOverrides);
-        expect(damageBeforeCrit420.expected).to.eq(21770);
+        expect(damageBeforeCrit420.expected).to.eq(21762);
 
         // 570 potency Living Shadow Attack
         const damageBeforeCrit570 = baseDamageFull(stats, 570, 'Ability', false, false, livingShadowScalingOverrides);
-        expect(damageBeforeCrit570.expected).to.eq(29546);
+        expect(damageBeforeCrit570.expected).to.eq(29533);
 
         // 620 potency Living Shadow Attack
         const damageBeforeCrit620 = baseDamageFull(stats, 620, 'Ability', false, false, livingShadowScalingOverrides);
-        expect(damageBeforeCrit620.expected).to.eq(32140);
+        expect(damageBeforeCrit620.expected).to.eq(32125);
     });
 });

--- a/packages/core/src/test/stats/general_stats_tests.ts
+++ b/packages/core/src/test/stats/general_stats_tests.ts
@@ -844,7 +844,7 @@ describe("Final damage values for known values", () => {
             weaponDelay: 2.96,
         }),
         // Using Rava for consistency with spreadsheet
-        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, getRaceStats("The Lost"));
+        {}, level, getLevelStats(level), 'DRK', fakeSheetDRK.classJobStats, 0, getRaceStats("Rava"));
         expect(stats.mainStatValue).to.eq(469);
         expect(stats.determination).to.eq(440);
         expect(stats.wdMag).to.eq(35);

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -334,11 +334,11 @@ export interface ComputedSetStats extends RawStats {
      */
     readonly gearStats: RawStats
     /**
-     * Stats coming from race. Will be the total value, after modification, e.g. 20 if unmodified
-     * or 23 if the race has a +3 modifier. Important to calculate special strength values for
-     * some abilities' alternate scalings (e.g. Living Shadow, Bunshin)
+     * Base main stat, multiplied by the job stat multiplier, plus racial bonus. For example, the main stat (e.g. 440 at level 100) multiplied by the
+     * jobStatMultiplier (e.g. 1.05 at level 100) plus the racial stat (e.g. +3 for The Lost's strength). This is useful for being able to unwind
+     * it later for abilities with different scaling, e.g. Living Shadow.
      */
-    readonly racialStats: RawStats
+    readonly baseMainStatPlusRace: number
 
     /**
      * Trait multiplier

--- a/packages/xivmath/src/xivmath.ts
+++ b/packages/xivmath/src/xivmath.ts
@@ -1,4 +1,4 @@
-import {AttackType, ComputedSetStats, JobData, JobDataConst, LevelStats, RawStats, ScalingOverrides} from "./geartypes";
+import {AttackType, ComputedSetStats, JobData, JobDataConst, LevelStats, ScalingOverrides} from "./geartypes";
 import {chanceMultiplierStdDev, fixedValue, multiplyValues, ValueWithDev} from "./deviation";
 
 /*
@@ -312,20 +312,14 @@ function usesCasterDamageFormula(stats: ComputedSetStats, attackType: AttackType
  * Gets Living Shadow's strength value from a given set of gear stats and racial bonuses.
  *
  * @param rawStrength The raw strength (pre party bonus)
- * @param racialStats the (total) stats for the race performing the attack
+ * @param baseMainStat The base main stat for this level
+ * @param playerBaseMainStat The player's base main stat, i.e. main stat for this level + job mod + racial bonus
  */
-export function getLivingShadowStrength(rawStrength: number, racialStats: RawStats): number {
-    // Remove the strength racial bonus
-    if (racialStats) {
-        const strengthBonus = racialStats['strength'];
-        if (strengthBonus) {
-            rawStrength -= strengthBonus;
-        }
-    }
-
+export function getLivingShadowStrength(rawStrength: number, baseMainStat: number, playerBaseMainStat: number): number {
     const livingShadowRacialBonus = 2;
-    rawStrength += livingShadowRacialBonus;
-    return rawStrength;
+    console.log(`Violet Living Shadow rawStrength=${rawStrength} - playerBaseMainStat=${playerBaseMainStat} + baseMainStat=${baseMainStat} + livingShadowRacialBonus=${livingShadowRacialBonus}`);
+    const livingShadowStrength = rawStrength - playerBaseMainStat + baseMainStat + livingShadowRacialBonus;
+    return livingShadowStrength;
 }
 
 /**

--- a/packages/xivmath/src/xivmath.ts
+++ b/packages/xivmath/src/xivmath.ts
@@ -317,7 +317,6 @@ function usesCasterDamageFormula(stats: ComputedSetStats, attackType: AttackType
  */
 export function getLivingShadowStrength(rawStrength: number, baseMainStat: number, playerBaseMainStat: number): number {
     const livingShadowRacialBonus = 2;
-    console.log(`Violet Living Shadow rawStrength=${rawStrength} - playerBaseMainStat=${playerBaseMainStat} + baseMainStat=${baseMainStat} + livingShadowRacialBonus=${livingShadowRacialBonus}`);
     const livingShadowStrength = rawStrength - playerBaseMainStat + baseMainStat + livingShadowRacialBonus;
     return livingShadowStrength;
 }

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -5,6 +5,7 @@ import {
     FoodStatBonus,
     JobData,
     LevelStats,
+    Mainstat,
     PartyBonusAmount,
     RawStatKey,
     RawStats
@@ -31,7 +32,7 @@ import {
     vitToHp,
     wdMulti
 } from "./xivmath";
-import {getRaceStats, JobName, RaceName, SupportedLevel} from "./xivconstants";
+import {JobName, SupportedLevel} from "./xivconstants";
 import {sum} from "@xivgear/util/array_utils";
 
 /**
@@ -47,6 +48,18 @@ export function addStats(baseStats: RawStats, addedStats: RawStats): void {
         const stat = entry[0] as keyof RawStats;
         baseStats[stat] = addedStats[stat] + (baseStats[stat] ?? 0);
     }
+}
+
+/**
+ * Gets the base main stat, multiplied by the job stat modifier (typically 1.05) and
+ * rounds it.
+ *
+ * @param levelStats the level stats
+ * @param classJobStats the job data
+ * @param stat which stat to get
+ */
+export function getBaseMainStat(levelStats: LevelStats, classJobStats: JobData, stat: Mainstat): number {
+    return Math.floor(levelStats.baseMainStat * classJobStats.jobStatMultipliers[stat] / 100);
 }
 
 /**
@@ -165,7 +178,6 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
     protected readonly finalBonusStats: RawBonusStats;
     // This is initialized when the ctor calls this.recalc()
     private currentStats!: RawStats;
-    private _racialStats: RawStats;
     private _effectiveFoodBonuses!: RawStats;
 
     constructor(
@@ -176,7 +188,7 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
         private readonly classJob: JobName,
         private readonly classJobStats: JobData,
         readonly partyBonus: PartyBonusAmount,
-        private readonly race: RaceName
+        readonly racialStats: RawStats
     ) {
         this.finalBonusStats = new RawBonusStats();
         // TODO: order of operations here
@@ -192,33 +204,6 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
                 trait.apply(this.finalBonusStats);
             });
         }
-
-        const racialStats = new RawStats({
-            vitality: 20,
-            strength: 20,
-            intelligence: 20,
-            dexterity: 20,
-            mind: 20,
-        });
-        const racialBonus = getRaceStats(this.race);
-        if (racialBonus) {
-            if (racialBonus.vitality) {
-                racialStats['vitality'] += racialBonus.vitality;
-            }
-            if (racialBonus.strength) {
-                racialStats['strength'] += racialBonus.strength;
-            }
-            if (racialBonus.intelligence) {
-                racialStats['intelligence'] += racialBonus.intelligence;
-            }
-            if (racialBonus.dexterity) {
-                racialStats['dexterity'] += racialBonus.dexterity;
-            }
-            if (racialBonus.mind) {
-                racialStats['mind'] += racialBonus.mind;
-            }
-        }
-        this._racialStats = racialStats;
     }
 
     private recalc() {
@@ -247,7 +232,7 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
             this.classJob,
             this.classJobStats,
             this.partyBonus,
-            this.race
+            this.racialStats
         );
         Object.assign(out.finalBonusStats, this.finalBonusStats);
         modifications(out, out.finalBonusStats);
@@ -347,10 +332,6 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
         return this.classJobStats;
     }
 
-    get racialStats(): RawStats {
-        return this._racialStats;
-    }
-
     get baseCritChance(): number {
         return clamp(0, 1, critChance(this.levelStats, this.crit));
     }
@@ -414,6 +395,11 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
         return mainStatMulti(this.levelStats, this.classJobStats, this.mainStatValue);
     };
 
+    get baseMainStatPlusRace(): number {
+        const mainStat = this.classJobStats.mainStat;
+        return getBaseMainStat(this.levelStats, this.classJobStats, this.classJobStats.mainStat) + this.racialStats[mainStat];
+    }
+
     get aaStatMulti(): number {
         return mainStatMulti(this.levelStats, this.classJobStats, this[this.classJobStats.autoAttackStat]);
     };
@@ -460,10 +446,10 @@ export function finalizeStats(
     classJob: JobName,
     classJobStats: JobData,
     partyBonus: PartyBonusAmount,
-    race: RaceName
+    racialStats: RawStats
 ) {
     return new ComputedSetStatsImpl(
-        gearStats, foodStats, level, levelStats, classJob, classJobStats, partyBonus, race
+        gearStats, foodStats, level, levelStats, classJob, classJobStats, partyBonus, racialStats
     );
 
 }


### PR DESCRIPTION
The old one was 'correct' by accident at level 100 because 440 * 1.05 = 462 which is suspiciously similar to +22. tl;dr:
- Living Shadow was 2 strength off at level 100
- It was incorrect by I can't be bothered to figure it out at 90 and 80

Correct value is ⌊440 * 1.00⌋ + 2, and correct base for player is ⌊440 * 1.05⌋ + RacialOffset

I also feel like the code was messy/bad so I cleaned it up a bit. No reason to re-get racial stats when they're right there. This also should help us better split up gear stats and non-gear stats if we ever need to in the future, also.