### PR TITLE
Add level 80 and 90 monk support by updating potencies and openers

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -302,6 +302,12 @@ export const Bootshine: FuryAbility = {
             gauge.beastChakra.push('opo');
         }
     },
+    levelModifiers: [{
+        minLevel: 92,
+        name: "Leaping Opo",
+        id: 36945,
+        potency: 260,
+    }],
 };
 
 export const TrueStrike: FuryAbility = {
@@ -320,6 +326,12 @@ export const TrueStrike: FuryAbility = {
             gauge.beastChakra.push('raptor');
         }
     },
+    levelModifiers: [{
+        minLevel: 92,
+        name: "Rising Raptor",
+        id: 36946,
+        potency: 340,
+    }],
 };
 
 export const SnapPunch: FuryAbility = {
@@ -338,6 +350,12 @@ export const SnapPunch: FuryAbility = {
             gauge.beastChakra.push('coeurl');
         }
     },
+    levelModifiers: [{
+        minLevel: 92,
+        name: "Pouncing Couerl",
+        id: 36947,
+        potency: 370, // assumed positional hit
+    }],
 };
 
 // I'm not implementing all 4 meditations lol
@@ -466,6 +484,12 @@ export const ElixirField: MnkGcdAbility = {
         gauge.beastChakra = [];
     },
     activatesBuffs: [FormlessFist],
+    levelModifiers: [{
+        minLevel: 92,
+        name: "Elixir Burst",
+        id: 36948,
+        potency: 900,
+    }],
 };
 
 export const FlintStrike: MnkGcdAbility = {
@@ -525,7 +549,11 @@ export const RiddleOfFire: MnkOgcdAbility = {
     cooldown: {
         time: 60,
     },
-    activatesBuffs: [RiddleOfFireBuff, FiresRumination],
+    activatesBuffs: [RiddleOfFireBuff],
+    levelModifiers: [{
+        minLevel: 100,
+        activatesBuffs: [RiddleOfFireBuff, FiresRumination],
+    }],
 };
 export const Brotherhood: MnkOgcdAbility = {
     name: "Brotherhood",
@@ -548,7 +576,11 @@ export const RiddleOfWind: MnkOgcdAbility = {
     cooldown: {
         time: 90,
     },
-    activatesBuffs: [RiddleOfWindBuff, WindsRumination],
+    activatesBuffs: [RiddleOfWindBuff],
+    levelModifiers: [{
+        minLevel: 96,
+        activatesBuffs: [RiddleOfWindBuff, WindsRumination],
+    }],
 };
 
 export const SixSidedStar: MnkGcdAbility = {
@@ -624,6 +656,7 @@ export const FiresReply: MnkGcdAbility = {
 };
 
 export const OPO_ABILITIES: number[] = [Bootshine.id, DragonKick.id, LeapingOpo.id];
+export const BOOTSHINE_ABILITIES: number[] = [Bootshine.id, LeapingOpo.id];
 const RAPTOR_ABILITIES: number[] = [TrueStrike.id, TwinSnakes.id, RisingRaptor.id];
 const COUERL_ABILITIES: number[] = [SnapPunch.id, Demolish.id, PouncingCoeurl.id];
 const FORM_ABILITIES: number[] = [Bootshine.id, DragonKick.id, LeapingOpo.id, TrueStrike.id, TwinSnakes.id, RisingRaptor.id, SnapPunch.id, Demolish.id, PouncingCoeurl.id];

--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -291,7 +291,7 @@ export const Bootshine: FuryAbility = {
     id: 53,
     type: 'gcd',
     gcd: 2.5,
-    potency: 220,
+    potency: 180,
     attackType: "Weaponskill",
     activatesBuffs: [RaptorForm],
     fury: 'opo',
@@ -302,12 +302,17 @@ export const Bootshine: FuryAbility = {
             gauge.beastChakra.push('opo');
         }
     },
-    levelModifiers: [{
-        minLevel: 92,
-        name: "Leaping Opo",
-        id: 36945,
-        potency: 260,
-    }],
+    levelModifiers: [
+        {
+            minLevel: 84,
+            potency: 220,
+        },
+        {
+            minLevel: 92,
+            name: "Leaping Opo",
+            id: 36945,
+            potency: 260,
+        }],
 };
 
 export const TrueStrike: FuryAbility = {
@@ -315,7 +320,7 @@ export const TrueStrike: FuryAbility = {
     id: 54,
     type: 'gcd',
     gcd: 2.5,
-    potency: 220,
+    potency: 260,
     attackType: "Weaponskill",
     activatesBuffs: [CoeurlForm],
     fury: 'raptor',
@@ -326,12 +331,18 @@ export const TrueStrike: FuryAbility = {
             gauge.beastChakra.push('raptor');
         }
     },
-    levelModifiers: [{
-        minLevel: 92,
-        name: "Rising Raptor",
-        id: 36946,
-        potency: 340,
-    }],
+    levelModifiers: [
+        {
+            minLevel: 84,
+            potency: 300,
+        },
+        {
+            minLevel: 92,
+            name: "Rising Raptor",
+            id: 36946,
+            potency: 340,
+        },
+    ],
 };
 
 export const SnapPunch: FuryAbility = {
@@ -339,7 +350,7 @@ export const SnapPunch: FuryAbility = {
     id: 56,
     type: 'gcd',
     gcd: 2.5,
-    potency: 330, // assumed positional hit
+    potency: 290, // assumed positional hit
     attackType: "Weaponskill",
     activatesBuffs: [OpoForm],
     fury: 'coeurl',
@@ -350,12 +361,17 @@ export const SnapPunch: FuryAbility = {
             gauge.beastChakra.push('coeurl');
         }
     },
-    levelModifiers: [{
-        minLevel: 92,
-        name: "Pouncing Couerl",
-        id: 36947,
-        potency: 370, // assumed positional hit
-    }],
+    levelModifiers: [
+        {
+            minLevel: 84,
+            potency: 330, // assumed positional hit
+        },
+        {
+            minLevel: 92,
+            name: "Pouncing Couerl",
+            id: 36947,
+            potency: 370, // assumed positional hit
+        }],
 };
 
 // I'm not implementing all 4 meditations lol
@@ -377,7 +393,7 @@ export const TwinSnakes: FuryAbility = {
     id: 61,
     type: 'gcd',
     gcd: 2.5,
-    potency: 420,
+    potency: 340,
     attackType: "Weaponskill",
     activatesBuffs: [CoeurlForm],
     fury: 'raptor',
@@ -388,6 +404,16 @@ export const TwinSnakes: FuryAbility = {
             gauge.beastChakra.push('raptor');
         }
     },
+    levelModifiers: [
+        {
+            minLevel: 84,
+            potency: 380,
+        },
+        {
+            minLevel: 94,
+            potency: 420,
+        },
+    ],
 };
 
 export const Demolish: FuryAbility = {
@@ -395,7 +421,7 @@ export const Demolish: FuryAbility = {
     id: 66,
     type: 'gcd',
     gcd: 2.5,
-    potency: 420, // assumed positional hit
+    potency: 280, // assumed positional hit
     attackType: "Weaponskill",
     activatesBuffs: [OpoForm],
     fury: 'coeurl',
@@ -406,6 +432,16 @@ export const Demolish: FuryAbility = {
             gauge.beastChakra.push('coeurl');
         }
     },
+    levelModifiers: [
+        {
+            minLevel: 84,
+            potency: 380, // assumed positional hit
+        },
+        {
+            minLevel: 94,
+            potency: 420, // assumed positional hit
+        },
+    ],
 };
 
 /**
@@ -416,7 +452,7 @@ export const DragonKick: FuryAbility = {
     id: 74,
     type: 'gcd',
     gcd: 2.5,
-    potency: 320,
+    potency: 240,
     attackType: "Weaponskill",
     activatesBuffs: [RaptorForm],
     fury: 'opo',
@@ -429,6 +465,16 @@ export const DragonKick: FuryAbility = {
             gauge.beastChakra.push('opo');
         }
     },
+    levelModifiers: [
+        {
+            minLevel: 84,
+            potency: 280,
+        },
+        {
+            minLevel: 94,
+            potency: 320,
+        },
+    ],
 };
 
 export const PerfectBalance: MnkOgcdAbility = {
@@ -463,13 +509,17 @@ export const TheForbiddenChakra: MnkOgcdAbility = {
     id: 3547,
     type: 'ogcd',
     attackType: 'Ability',
-    potency: 400,
+    potency: 310,
     cooldown: {
         time: 1,
     },
     updateGaugeLegacy: (gauge: MNKGauge) => {
         gauge.chakra -= 5;
     },
+    levelModifiers: [{
+        minLevel: 84,
+        potency: 400,
+    }],
 };
 
 export const ElixirField: MnkGcdAbility = {
@@ -504,6 +554,12 @@ export const FlintStrike: MnkGcdAbility = {
         gauge.beastChakra = [];
     },
     activatesBuffs: [FormlessFist],
+    levelModifiers: [{
+        minLevel: 86,
+        name: "Rising Phoenix",
+        id: 25768,
+        potency: 900,
+    }],
 };
 
 export const CelestialRevolution: MnkGcdAbility = {
@@ -538,6 +594,14 @@ export const TornadoKick: MnkGcdAbility = {
         gauge.beastChakra = [];
     },
     activatesBuffs: [FormlessFist],
+    levelModifiers: [
+        {
+            minLevel: 90,
+            name: "Phantom Rush",
+            id: 25769,
+            potency: 1150,
+        },
+    ],
 };
 
 export const RiddleOfFire: MnkOgcdAbility = {
@@ -589,10 +653,14 @@ export const SixSidedStar: MnkGcdAbility = {
     type: 'gcd',
     gcd: 5,
     attackType: 'Weaponskill',
-    potency: 780, // potency adjusted in MNKCycleProcessor::use
+    potency: 710, // potency adjusted in MNKCycleProcessor::use
     updateGaugeLegacy: (gauge: MNKGauge) => {
         gauge.chakra = 0;
     },
+    levelModifiers: [{
+        minLevel: 94,
+        potency: 780,
+    }],
 };
 
 export const RisingPhoenix: MnkGcdAbility = {
@@ -606,7 +674,11 @@ export const PhantomRush: MnkGcdAbility = {
     ...TornadoKick,
     name: "Phantom Rush",
     id: 25769,
-    potency: 1500,
+    potency: 1150,
+    levelModifiers: [{
+        minLevel: 94,
+        potency: 1500,
+    }],
 };
 
 export const LeapingOpo: FuryAbility = {
@@ -661,5 +733,5 @@ const RAPTOR_ABILITIES: number[] = [TrueStrike.id, TwinSnakes.id, RisingRaptor.i
 const COUERL_ABILITIES: number[] = [SnapPunch.id, Demolish.id, PouncingCoeurl.id];
 const FORM_ABILITIES: number[] = [Bootshine.id, DragonKick.id, LeapingOpo.id, TrueStrike.id, TwinSnakes.id, RisingRaptor.id, SnapPunch.id, Demolish.id, PouncingCoeurl.id];
 /** The priority of gcds to execute when building a solar blitz to push the highest potency sequence under RoF */
-export const SOLAR_WEAKEST_STRONGEST: FuryAbility[] = [DragonKick, Demolish, TwinSnakes, PouncingCoeurl, RisingRaptor, LeapingOpo];
+export const SOLAR_WEAKEST_STRONGEST: FuryAbility[] = [DragonKick, Demolish, TwinSnakes, SnapPunch, TrueStrike, Bootshine];
 export const OGCD_PRIORITY: OgcdAbility[] = [Brotherhood, RiddleOfFire, RiddleOfWind, TheForbiddenChakra];

--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -582,7 +582,7 @@ export const CelestialRevolution: MnkGcdAbility = {
 };
 
 export const TornadoKick: MnkGcdAbility = {
-    name: "TornadoKick",
+    name: "Tornado Kick",
     id: 3543,
     type: 'gcd',
     attackType: 'Weaponskill',
@@ -599,7 +599,13 @@ export const TornadoKick: MnkGcdAbility = {
             minLevel: 90,
             name: "Phantom Rush",
             id: 25769,
-            potency: 1150,
+            potency: 1400,
+        },
+        {
+            minLevel: 94,
+            name: "Phantom Rush",
+            id: 25769,
+            potency: 1500,
         },
     ],
 };

--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -27,7 +27,7 @@ export const mnkSpec: SimSpec<MnkSim, MnkSettingsExternal> = {
         return new MnkSim(exported);
     },
     supportedJobs: ['MNK'],
-    supportedLevels: [100],
+    supportedLevels: [100, 90, 80],
     isDefaultSim: true,
 };
 

--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -5,7 +5,7 @@ import {CharacterGearSet} from "@xivgear/core/gear";
 import {BaseMultiCycleSim, RotationCacheKey} from "@xivgear/core/sims/processors/sim_processors";
 import {FuryAbility, MnkAbility, MNKExtraData, MnkGcdAbility, Opener} from "./mnk_types";
 import {MNKGauge as MnkGauge} from "./mnk_gauge";
-import {BOOTSHINE_ABILITIES, Bootshine, Brotherhood, BrotherhoodBuff, CelestialRevolution, CoeurlForm, Demolish, DragonKick, ElixirField, FiresReply, FiresRumination, ForbiddenMeditation, FormShift, FormlessFist, MeditativeBrotherhood, OGCD_PRIORITY, OPO_ABILITIES, OpoForm, PerfectBalance, PerfectBalanceBuff, PhantomRush, RaptorForm, RiddleOfFire, RiddleOfFireBuff, RiddleOfWind, RisingPhoenix, SOLAR_WEAKEST_STRONGEST, SixSidedStar, SnapPunch, TheForbiddenChakra, TrueStrike, TwinSnakes, WindsReply, WindsRumination} from "./mnk_actions";
+import {BOOTSHINE_ABILITIES, Bootshine, Brotherhood, BrotherhoodBuff, CelestialRevolution, CoeurlForm, Demolish, DragonKick, ElixirField, FiresReply, FiresRumination, FlintStrike, ForbiddenMeditation, FormShift, FormlessFist, MeditativeBrotherhood, OGCD_PRIORITY, OPO_ABILITIES, OpoForm, PerfectBalance, PerfectBalanceBuff, PhantomRush, RaptorForm, RiddleOfFire, RiddleOfFireBuff, RiddleOfWind, SOLAR_WEAKEST_STRONGEST, SixSidedStar, SnapPunch, TheForbiddenChakra, TrueStrike, TwinSnakes, WindsReply, WindsRumination} from "./mnk_actions";
 import {Brotherhood as BrotherhoodGlobalBuff} from "@xivgear/core/sims/buffs";
 import {sum} from "@xivgear/util/array_utils";
 import {STANDARD_ANIMATION_LOCK, SupportedLevel} from "@xivgear/xivmath/xivconstants";
@@ -309,7 +309,7 @@ class MNKCycleProcessor extends CycleProcessor {
             case 2:
                 return CelestialRevolution;
             case 3:
-                return RisingPhoenix;
+                return FlintStrike;
         }
         console.warn(`${this.currentTime} failed to select a blitz, choosing celestial revolution for punishment.`);
         return CelestialRevolution;

--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -5,7 +5,7 @@ import {CharacterGearSet} from "@xivgear/core/gear";
 import {BaseMultiCycleSim, RotationCacheKey} from "@xivgear/core/sims/processors/sim_processors";
 import {FuryAbility, MnkAbility, MNKExtraData, MnkGcdAbility, Opener} from "./mnk_types";
 import {MNKGauge as MnkGauge} from "./mnk_gauge";
-import {BOOTSHINE_ABILITIES, Bootshine, Brotherhood, BrotherhoodBuff, CelestialRevolution, CoeurlForm, Demolish, DragonKick, ElixirField, FiresReply, FiresRumination, FlintStrike, ForbiddenMeditation, FormShift, FormlessFist, MeditativeBrotherhood, OGCD_PRIORITY, OPO_ABILITIES, OpoForm, PerfectBalance, PerfectBalanceBuff, PhantomRush, RaptorForm, RiddleOfFire, RiddleOfFireBuff, RiddleOfWind, SOLAR_WEAKEST_STRONGEST, SixSidedStar, SnapPunch, TheForbiddenChakra, TrueStrike, TwinSnakes, WindsReply, WindsRumination} from "./mnk_actions";
+import {BOOTSHINE_ABILITIES, Bootshine, Brotherhood, BrotherhoodBuff, CelestialRevolution, CoeurlForm, Demolish, DragonKick, ElixirField, FiresReply, FiresRumination, FlintStrike, ForbiddenMeditation, FormShift, FormlessFist, MeditativeBrotherhood, OGCD_PRIORITY, OPO_ABILITIES, OpoForm, PerfectBalance, PerfectBalanceBuff, RaptorForm, RiddleOfFire, RiddleOfFireBuff, RiddleOfWind, SOLAR_WEAKEST_STRONGEST, SixSidedStar, SnapPunch, TheForbiddenChakra, TornadoKick, TrueStrike, TwinSnakes, WindsReply, WindsRumination} from "./mnk_actions";
 import {Brotherhood as BrotherhoodGlobalBuff} from "@xivgear/core/sims/buffs";
 import {sum} from "@xivgear/util/array_utils";
 import {STANDARD_ANIMATION_LOCK, SupportedLevel} from "@xivgear/xivmath/xivconstants";
@@ -301,7 +301,7 @@ class MNKCycleProcessor extends CycleProcessor {
     chooseBlitz(): MnkGcdAbility {
         if (this.gauge.lunarNadi && this.gauge.solarNadi) {
             // regardless of correct execution (Celestial Revolution) we get a phantom rush
-            return PhantomRush;
+            return TornadoKick;
         }
 
         const s = new Set(this.gauge.beastChakra);

--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -94,7 +94,9 @@ class MNKCycleProcessor extends CycleProcessor {
             const probableChakraGain = BOOTSHINE_ABILITIES.includes(usedAbility.ability.id) && usedAbility.buffs.find(buff => [PerfectBalanceBuff.statusId, FormlessFist.statusId, OpoForm.statusId].includes(buff.statusId))
                 ? 1
                 : this.stats.critChance + usedAbility.combinedEffects.critChanceIncrease;
-            const brotherhoodChakra = usedAbility.buffs.find(buff => buff.statusId === BrotherhoodBuff.statusId)
+
+            // Brotherhood only guarantees a chakra after the level 88 trait enhanced brotherhood
+            const brotherhoodChakra = this.level > 88 && usedAbility.buffs.find(buff => buff.statusId === BrotherhoodBuff.statusId)
                 ? 1
                 : 0;
             const meditativeBhChakra = usedAbility.buffs.find(buff => buff.statusId === MeditativeBrotherhood.statusId)

--- a/packages/core/src/sims/melee/mnk/mnk_types.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_types.ts
@@ -1,16 +1,16 @@
-import {Ability, Buff, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
+import {Ability, Buff, GcdAbility, LevelModifiable, OgcdAbility} from "@xivgear/core/sims/sim_types";
 import {MNKGauge} from "./mnk_gauge";
 
 /** Represents a Monk-specific Ability */
-export type MnkAbility = Ability & Readonly<{
+export type MnkAbility = Ability & Readonly<LevelModifiable<{
     /** Custom function to run to apply gauge updates relating to this ability */
     updateGaugeLegacy?(gauge: MNKGauge, form?: Buff, inCombat?: boolean): void,
-}>;
+}>>;
 
 /** Represents a Monk-specific GCD Ability */
 export type MnkGcdAbility = GcdAbility & MnkAbility;
 
-export type FuryAbility =  MnkGcdAbility & Readonly<{
+export type FuryAbility = MnkGcdAbility & Readonly<{
     fury: FuryType;
     /** Whether the ability fills or drains balls */
     buildsFury: boolean;


### PR DESCRIPTION
This copies the only differences from the new abilities monk gains from 91-100 to the basic GCDs that they are upgrades for.

I checked that this behaves identical to live for level 100 using the MNK bis sheet and the opener looks good at 90, however without published resources for 90 openers it's a best effort.