### PR TITLE
Fix monk fury stack application

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -34,7 +34,7 @@ export const OpoForm: PersonalBuff = {
 export const OpoFury: PersonalBuff = {
     name: "Opo-Opo Fury",
     // fake status ID until issue 613 is fixed
-    statusId: -999,
+    statusId: noStatusId(),
     selfOnly: true,
     effects: {
         // flat 200 potency increase
@@ -47,7 +47,6 @@ export const OpoFury: PersonalBuff = {
             potency: ability.potency + 200,
         };
     },
-    statusId: noStatusId(),
 };
 
 export const RaptorForm: PersonalBuff = {
@@ -75,7 +74,7 @@ export const RaptorForm: PersonalBuff = {
 export const RaptorFury: PersonalBuff = {
     name: "Raptor Fury",
     // fake status ID until issue 613 is fixed
-    statusId: -998,
+    statusId: noStatusId(),
     selfOnly: true,
     effects: {
         // flat 200 potency increase
@@ -88,7 +87,6 @@ export const RaptorFury: PersonalBuff = {
             potency: ability.potency + 200,
         };
     },
-    statusId: noStatusId(),
 };
 
 
@@ -118,7 +116,7 @@ export const CoeurlForm: PersonalBuff = {
 export const CoeurlFury: PersonalBuff = {
     name: "Coeurl Fury",
     // fake status ID until issue 613 is fixed
-    statusId: -997,
+    statusId: noStatusId(),
     selfOnly: true,
     stacks: 2,
     effects: {
@@ -132,7 +130,6 @@ export const CoeurlFury: PersonalBuff = {
             potency: ability.potency + 150,
         };
     },
-    statusId: noStatusId(),
 };
 
 export const PerfectBalanceBuff: PersonalBuff = {

--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -33,6 +33,8 @@ export const OpoForm: PersonalBuff = {
 
 export const OpoFury: PersonalBuff = {
     name: "Opo-Opo Fury",
+    // fake status ID until issue 613 is fixed
+    statusId: -999,
     selfOnly: true,
     effects: {
         // flat 200 potency increase
@@ -57,11 +59,23 @@ export const RaptorForm: PersonalBuff = {
         // allows execution of twin snakes and true strike I and II
     },
     appliesTo: (ability) => RAPTOR_ABILITIES.includes(ability.id),
-    beforeSnapshot: (controller: BuffController, ability) => controller.removeSelf(),
+    beforeSnapshot: (controller: BuffController, ability) => {
+        controller.removeSelf();
+        if (ability.id === TwinSnakes.id) {
+            const a =  {
+                ...ability,
+                activatesBuffs: [...ability.activatesBuffs, RaptorFury],
+            };
+            return a;
+        }
+        return ability;
+    },
 };
 
 export const RaptorFury: PersonalBuff = {
     name: "Raptor Fury",
+    // fake status ID until issue 613 is fixed
+    statusId: -998,
     selfOnly: true,
     effects: {
         // flat 200 potency increase
@@ -87,23 +101,35 @@ export const CoeurlForm: PersonalBuff = {
         // allows execution of demolish, snap punch I and II
     },
     appliesTo: (ability) => COUERL_ABILITIES.includes(ability.id),
-    beforeSnapshot: (controller: BuffController, ability) => controller.removeSelf(),
+    beforeSnapshot: (controller: BuffController, ability) => {
+        controller.removeSelf();
+        if (ability.id === Demolish.id) {
+            const a =  {
+                ...ability,
+                activatesBuffs: [...ability.activatesBuffs, CoeurlFury],
+            };
+            return a;
+        }
+        return ability;
+    },
 };
 
 
 export const CoeurlFury: PersonalBuff = {
-    name: "Couerl Fury",
+    name: "Coeurl Fury",
+    // fake status ID until issue 613 is fixed
+    statusId: -997,
     selfOnly: true,
     stacks: 2,
     effects: {
-        // flat 200 potency increase
+        // flat 150 potency increase
     },
     appliesTo: (ability) => [SnapPunch.id, PouncingCoeurl.id].includes(ability.id),
     beforeSnapshot: (controller: BuffController, ability) => {
         controller.subtractStacksSelf(1);
         return {
             ...ability,
-            potency: ability.potency + 200,
+            potency: ability.potency + 150,
         };
     },
     statusId: noStatusId(),
@@ -133,6 +159,18 @@ export const PerfectBalanceBuff: PersonalBuff = {
                 activatesBuffs: [...ability.activatesBuffs, OpoFury],
             };
         }
+        else if (ability.id === TwinSnakes.id) {
+            return {
+                ...ability,
+                activatesBuffs: [...ability.activatesBuffs, RaptorFury],
+            };
+        }
+        else if (ability.id === Demolish.id) {
+            return {
+                ...ability,
+                activatesBuffs: [...ability.activatesBuffs, CoeurlFury],
+            };
+        }
         return ability;
     },
 };
@@ -158,6 +196,18 @@ export const FormlessFist: PersonalBuff = {
             return {
                 ...ability,
                 activatesBuffs: [...ability.activatesBuffs, OpoFury],
+            };
+        }
+        else if (ability.id === TwinSnakes.id) {
+            return {
+                ...ability,
+                activatesBuffs: [...ability.activatesBuffs, RaptorFury],
+            };
+        }
+        else if (ability.id === Demolish.id) {
+            return {
+                ...ability,
+                activatesBuffs: [...ability.activatesBuffs, CoeurlFury],
             };
         }
         return ability;


### PR DESCRIPTION
- Fix the potency of coeurl fury as it applies to snap punch
- Fix furies not applying to their relative GCDs whatsoever
- Add fake statusIds to work around fake buff overwriting #613 