### PR TITLE
Make status ID required, implement helper

### DIFF
--- a/packages/core/src/sims/buff_helpers.ts
+++ b/packages/core/src/sims/buff_helpers.ts
@@ -36,3 +36,13 @@ export function buffRelevantAtSnapshot(buff: Buff): boolean {
         // As a fallback, also force this to return true if the buff is not relevant at start
         || !buffRelevantAtStart(buff);
 }
+
+let nextRandomBuffId = -10_000_000;
+
+/**
+ * For status effects without a real status ID (e.g. using a status effect as a pseudo-gauge, or fake statuses used
+ * for unit tests), this will assign a unique ID that will not give it a status effect icon.
+ */
+export function noStatusId(): number {
+    return nextRandomBuffId--;
+}

--- a/packages/core/src/sims/melee/mnk/mnk_actions.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_actions.ts
@@ -1,6 +1,7 @@
 import {BuffController, PersonalBuff, PartyBuff, OgcdAbility} from "@xivgear/core/sims/sim_types";
 import {MNKGauge} from "./mnk_gauge";
 import {FuryAbility, MnkGcdAbility, MnkOgcdAbility} from "./mnk_types";
+import {noStatusId} from "../../buff_helpers";
 
 export const OpoForm: PersonalBuff = {
     name: "Opo-Opo Form",
@@ -44,6 +45,7 @@ export const OpoFury: PersonalBuff = {
             potency: ability.potency + 200,
         };
     },
+    statusId: noStatusId(),
 };
 
 export const RaptorForm: PersonalBuff = {
@@ -72,6 +74,7 @@ export const RaptorFury: PersonalBuff = {
             potency: ability.potency + 200,
         };
     },
+    statusId: noStatusId(),
 };
 
 
@@ -103,6 +106,7 @@ export const CoeurlFury: PersonalBuff = {
             potency: ability.potency + 200,
         };
     },
+    statusId: noStatusId(),
 };
 
 export const PerfectBalanceBuff: PersonalBuff = {

--- a/packages/core/src/sims/melee/vpr/vpr_buffs.ts
+++ b/packages/core/src/sims/melee/vpr/vpr_buffs.ts
@@ -1,5 +1,6 @@
-import {Ability, Buff, BuffController, PersonalBuff} from "@xivgear/core/sims/sim_types";
+import {Ability, BuffController, PersonalBuff} from "@xivgear/core/sims/sim_types";
 import * as Actions from "./vpr_actions";
+import {noStatusId} from "../../buff_helpers";
 
 export const HonedReavers: PersonalBuff = {
     name: "Honed Reavers",
@@ -61,9 +62,7 @@ export const Swiftscaled: PersonalBuff = {
     statusId: 3669,
 };
 
-const ComboFinisherBaseBuff: Buff = {
-    name: null,
-    saveKey: null,
+const ComboFinisherBaseBuff = {
     duration: 60,
     selfOnly: true,
     effects: {
@@ -76,7 +75,7 @@ const ComboFinisherBaseBuff: Buff = {
             potency: ability.potency + 100,
         };
     },
-};
+} as const satisfies Readonly<Partial<PersonalBuff>>;
 
 export const FlankstungVenom: PersonalBuff = {
     ...ComboFinisherBaseBuff,
@@ -145,6 +144,7 @@ export const HuntersVenom: PersonalBuff = {
             potency: 170,
         };
     },
+    statusId: noStatusId(),
 };
 
 export const SwiftskinsVenom: PersonalBuff = {
@@ -163,6 +163,7 @@ export const SwiftskinsVenom: PersonalBuff = {
             potency: 170,
         };
     },
+    statusId: noStatusId(),
 };
 
 export const PoisedForTwinfang: PersonalBuff = {
@@ -181,6 +182,7 @@ export const PoisedForTwinfang: PersonalBuff = {
             potency: 170,
         };
     },
+    statusId: noStatusId(),
 };
 
 export const PoisedForTwinblood: PersonalBuff = {
@@ -199,4 +201,5 @@ export const PoisedForTwinblood: PersonalBuff = {
             potency: 170,
         };
     },
+    statusId: noStatusId(),
 };

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -650,9 +650,9 @@ export type BaseBuff = Readonly<{
      */
     modifyDamage?(controller: BuffController, damageResult: DamageResult, ability: Ability): DamageResult | void,
     /**
-     * Optional status effect ID. Used to provide an icon.
+     * Status effect ID. Used to provide an icon, and for equality checks. If not known/needed, use {@link }
      */
-    statusId?: number
+    statusId: number
     /**
      * Stack count of this buff. This should generally not be baked into the buff - it should be inserted at run time.
      */

--- a/packages/core/src/sims/tank/drk/drk_gauge.ts
+++ b/packages/core/src/sims/tank/drk/drk_gauge.ts
@@ -1,5 +1,6 @@
 import {DrkGaugeState} from "./drk_types";
 import {PersonalBuff} from "@xivgear/core/sims/sim_types";
+import {noStatusId} from "../../buff_helpers";
 
 export class DrkGauge {
 
@@ -63,4 +64,5 @@ export const Darkside: PersonalBuff = {
         dmgIncrease: 0.1,
     },
     maxStackingDuration: 60,
+    statusId: noStatusId(),
 };

--- a/packages/core/src/test/sims/common_values.ts
+++ b/packages/core/src/test/sims/common_values.ts
@@ -4,6 +4,7 @@ import {getClassJobStats, getLevelStats} from "@xivgear/xivmath/xivconstants";
 import {finalizeStats} from "@xivgear/xivmath/xivstats";
 import {GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
 import {makeFakeSet} from "../test_utils";
+import {noStatusId} from "../../sims/buff_helpers";
 
 let fakeId = 0x200_0000;
 
@@ -72,6 +73,7 @@ export const pom: OgcdAbility = {
             effects: {
                 haste: 20,
             },
+            statusId: noStatusId(),
         },
     ],
     attackType: "Ability",

--- a/packages/core/src/test/sims/cycle_processor_tests.ts
+++ b/packages/core/src/test/sims/cycle_processor_tests.ts
@@ -34,6 +34,7 @@ import {BaseMultiCycleSim} from '@xivgear/core/sims/processors/sim_processors';
 import {gemdraught1mind} from "../../sims/common/potion";
 import {expect} from "chai";
 import {makeFakeSet} from "../test_utils";
+import {noStatusId} from "../../sims/buff_helpers";
 
 // Example of end-to-end simulation
 // This one is testing the simulation engine itself, so it copies the full simulation code rather than
@@ -113,6 +114,7 @@ const pom: OgcdAbility = {
             effects: {
                 haste: 20,
             },
+            statusId: noStatusId(),
         },
     ],
     attackType: "Ability",
@@ -613,6 +615,7 @@ const potBuff: Buff = {
             potency: ability.potency + 100,
         };
     },
+    statusId: noStatusId(),
 };
 
 const potBuffAbility: GcdAbility = {
@@ -681,6 +684,7 @@ const bristleBuff: Buff = {
     name: "Bristle",
     beforeSnapshot: removeSelf,
     appliesTo: ability => ability.attackType === "Spell" && ability.potency !== null,
+    statusId: noStatusId(),
 };
 
 const bristle: GcdAbility = {
@@ -708,6 +712,7 @@ const bristleBuff2: Buff = {
             return multiplyDamage(damageResult, 1.5, true, true);
         }
     },
+    statusId: noStatusId(),
 };
 
 const bristle2: GcdAbility = {

--- a/packages/core/src/test/stats/auto_crit_dh_tests.ts
+++ b/packages/core/src/test/stats/auto_crit_dh_tests.ts
@@ -5,6 +5,7 @@ import {HEADLESS_SHEET_PROVIDER} from "../../sheet";
 import {expect} from "chai";
 import {Buff, DamagingAbility, GcdAbility} from "../../sims/sim_types";
 import {abilityToDamageNew, combineBuffEffects} from "../../sims/sim_utils";
+import {noStatusId} from "../../sims/buff_helpers";
 
 const level = 100;
 const fakeSheetGNB = HEADLESS_SHEET_PROVIDER.fromScratch("unused", "unused", 'GNB', level, undefined, false);
@@ -115,6 +116,7 @@ const critChanceBuff = {
     effects: {
         critChanceIncrease: 0.5,
     },
+    statusId: noStatusId(),
 } satisfies Buff;
 
 const critForceBuff = {
@@ -122,6 +124,7 @@ const critForceBuff = {
     effects: {
         forceCrit: true,
     },
+    statusId: noStatusId(),
 } satisfies Buff;
 
 const dhChanceBuff = {
@@ -129,6 +132,7 @@ const dhChanceBuff = {
     effects: {
         dhitChanceIncrease: 0.5,
     },
+    statusId: noStatusId(),
 } satisfies Buff;
 
 const dhForceBuff = {
@@ -136,6 +140,7 @@ const dhForceBuff = {
     effects: {
         forceDhit: true,
     },
+    statusId: noStatusId(),
 } satisfies Buff;
 
 describe("Auto Crit and Dh Damage Calculation", () => {
@@ -147,6 +152,7 @@ describe("Auto Crit and Dh Damage Calculation", () => {
                 critChanceIncrease: -1,
                 dhitChanceIncrease: -1,
             },
+            statusId: noStatusId(),
         }]));
         expect(damageResult.directDamage.expected).to.be.closeTo(633, 0.01);
         expect(damageResult.directDamage.stdDev).to.be.closeTo(18.273, 0.01);
@@ -184,6 +190,7 @@ describe("Auto Crit and Dh Damage Calculation", () => {
             effects: {
                 forceCrit: true,
             },
+            statusId: noStatusId(),
         }]));
         expect(damageResult.directDamage.expected).to.be.closeTo(1015.957, 0.01);
         expect(damageResult.directDamage.stdDev).to.be.closeTo(63.376, 0.01);
@@ -206,6 +213,7 @@ describe("Auto Crit and Dh Damage Calculation", () => {
             effects: {
                 forceDhit: true,
             },
+            statusId: noStatusId(),
         }]));
         // We're guaranteeing a 25% damage bonus, so should be about +25% over base.
         expect(damageResult.directDamage.expected).to.be.closeTo(912.166, 0.01);

--- a/packages/core/src/test/stats/buff_helpers_tests.ts
+++ b/packages/core/src/test/stats/buff_helpers_tests.ts
@@ -1,6 +1,6 @@
 import {Buff} from "../../sims/sim_types";
 import {expect} from "chai";
-import {buffRelevantAtSnapshot, buffRelevantAtStart} from "../../sims/buff_helpers";
+import {buffRelevantAtSnapshot, buffRelevantAtStart, noStatusId} from "../../sims/buff_helpers";
 
 describe("Buff Helpers", () => {
     describe('simple damage buff', () => {
@@ -11,6 +11,7 @@ describe("Buff Helpers", () => {
             effects: {
                 dmgIncrease: 0.5,
             },
+            statusId: noStatusId(),
         };
 
         it('is not relevant at start', () => {
@@ -31,6 +32,7 @@ describe("Buff Helpers", () => {
             effects: {
                 haste: 10,
             },
+            statusId: noStatusId(),
         };
 
         it('is relevant at start', () => {
@@ -50,6 +52,7 @@ describe("Buff Helpers", () => {
             selfOnly: true,
             name: "Test buff",
             effects: {},
+            statusId: noStatusId(),
         };
 
         it('is not relevant at start', () => {
@@ -70,6 +73,7 @@ describe("Buff Helpers", () => {
                 haste: 10,
                 dmgIncrease: 0.1,
             },
+            statusId: noStatusId(),
         };
 
         it('is relevant at start', () => {
@@ -89,6 +93,7 @@ describe("Buff Helpers", () => {
             beforeAbility() {
             },
             effects: {},
+            statusId: noStatusId(),
         };
 
         it('is relevant at start', () => {
@@ -109,6 +114,7 @@ describe("Buff Helpers", () => {
             beforeSnapshot() {
             },
             effects: {},
+            statusId: noStatusId(),
         };
 
         it('is not relevant at start', () => {
@@ -130,6 +136,7 @@ describe("Buff Helpers", () => {
             modifyDamage() {
             },
             effects: {},
+            statusId: noStatusId(),
         };
 
         it('is not relevant at start', () => {

--- a/packages/frontend/src/scripts/sims/components/buff_list_display.ts
+++ b/packages/frontend/src/scripts/sims/components/buff_list_display.ts
@@ -42,7 +42,7 @@ export class BuffListDisplay extends HTMLDivElement {
         let hasImage = false;
         for (const buff of buffs) {
             tooltip += describeBuff(buff) + '\n';
-            if (buff.statusId !== undefined) {
+            if (buff.statusId !== undefined && buff.statusId > 0) {
                 this.appendChild(new StatusIcon(buff.statusId, buff.stacks));
                 hasImage = true;
             }


### PR DESCRIPTION
Status effects now require an ID. Negative numbers can be used to indicate that the ID is fake, and no Xivapi lookup should be performed. The `noStatusId()` function can be used to assign a unique negative ID. 