### PR TITLE
First attempt at improving predictive tiering

### DIFF
--- a/packages/frontend/src/scripts/components/stat_tier_display.ts
+++ b/packages/frontend/src/scripts/components/stat_tier_display.ts
@@ -1,6 +1,6 @@
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {STAT_ABBREVIATIONS, STAT_DISPLAY_ORDER} from "@xivgear/xivmath/xivconstants";
-import {RawStatKey} from "@xivgear/xivmath/geartypes";
+import {RawStatKey, RawStats} from "@xivgear/xivmath/geartypes";
 import {
     critDmg,
     detDmg,
@@ -263,9 +263,13 @@ export class StatTierDisplay extends HTMLDivElement {
             extraOffsets = multipliers.map(multiplier => {
                 const valueRaw = multiplier * materiaValue;
                 const before = computed[stat];
-                const after = computed.withModifications((stats, bonuses) => {
-                    bonuses[stat] += valueRaw;
-                })[stat];
+                const bonuses: Partial<RawStats> = {};
+                bonuses[stat] = valueRaw;
+                // We need it to use this path instead of just adding, because we want to account for potential
+                // uncapped food.
+                const after = computed.withModifications(() => {}, {
+                    extraGearBonuses: bonuses,
+                } )[stat];
                 const valueAdjusted = after - before;
                 const multiplierStr = multiplier < 0 ? multiplier.toString() : '+' + multiplier.toString();
                 // Get the roman numeral part of the materia name

--- a/packages/frontend/src/scripts/components/stat_tier_display.ts
+++ b/packages/frontend/src/scripts/components/stat_tier_display.ts
@@ -261,13 +261,18 @@ export class StatTierDisplay extends HTMLDivElement {
             const materiaValue = materia.primaryStatValue;
             const multipliers = [3, 2, 1, -1, -2, -3];
             extraOffsets = multipliers.map(multiplier => {
-                const value = multiplier * materiaValue;
+                const valueRaw = multiplier * materiaValue;
+                const before = computed[stat];
+                const after = computed.withModifications((stats, bonuses) => {
+                    bonuses[stat] += valueRaw;
+                })[stat];
+                const valueAdjusted = after - before;
                 const multiplierStr = multiplier < 0 ? multiplier.toString() : '+' + multiplier.toString();
                 // Get the roman numeral part of the materia name
                 const split = materia.name.split(' ');
                 const label = `${multiplierStr} ${split[split.length - 1]}:`;
                 return {
-                    offset: value,
+                    offset: valueAdjusted,
                     // Format as +5, +0, -5, etc
                     label: label,
                 };

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -66,6 +66,7 @@ export type StatModification = (stats: ComputedSetStats, bonuses: RawBonusStats)
  * This allows you to change the "base" values rather than merely applying final bonuses.
  */
 export type StatPreModifications = {
+    extraGearBonuses?: RawStats | null,
     newFoodBonuses?: FoodBonuses | null,
 }
 
@@ -236,8 +237,13 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
     }
 
     withModifications(modifications: StatModification, pre: StatPreModifications = {}): ComputedSetStatsImpl {
+        let gearStats = this.gearStats;
+        if (pre.extraGearBonuses) {
+            gearStats = {...gearStats};
+            addStats(gearStats, pre.extraGearBonuses);
+        }
         const out = new ComputedSetStatsImpl(
-            this.gearStats,
+            gearStats,
             // If the new food is not specified, use current food.
             // If the new food is null, use empty food.
             // If the new food is not null, use its bonuses.

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -42,10 +42,10 @@ import {sum} from "@xivgear/util/array_utils";
  * @param baseStats  The base stat sheet. Will be modified.
  * @param addedStats The stats to add.
  */
-export function addStats(baseStats: RawStats, addedStats: RawStats): void {
+export function addStats(baseStats: RawStats, addedStats: Partial<RawStats>): void {
     for (const entry of Object.entries(baseStats)) {
         const stat = entry[0] as keyof RawStats;
-        baseStats[stat] = addedStats[stat] + (baseStats[stat] ?? 0);
+        baseStats[stat] = (addedStats[stat] ?? 0) + (baseStats[stat] ?? 0);
     }
 }
 
@@ -66,7 +66,7 @@ export type StatModification = (stats: ComputedSetStats, bonuses: RawBonusStats)
  * This allows you to change the "base" values rather than merely applying final bonuses.
  */
 export type StatPreModifications = {
-    extraGearBonuses?: RawStats | null,
+    extraGearBonuses?: Partial<RawStats> | null,
     newFoodBonuses?: FoodBonuses | null,
 }
 


### PR DESCRIPTION
When lookin at predicted/extended tiering (i.e. tiering plus or minus a certain amount of materia), this will now reflect the tiering as if you were to actually equip the item, rather than just adding the raw amount that the materia would provide. This provides a more realistic picture when you have food with an uncapped stat.

Fixes #606