### PR TITLE
More translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "npm run --workspaces --if-present test",
     "serve": "npx -w @xivgear/gearplan-frontend webpack serve",
     "lint": "npx --workspaces eslint ./src/**/*.ts --exit-on-fatal-error --max-warnings 0",
-    "dataschema": "npx -w @xivgear/data-api-client swagger-typescript-api -o ./src/ -n dataapi.ts -p https://data.xivgear.app/swagger/xivgear-reference-data-api-0.1.yml --api-class-name DataApiClient",
-    "dataschemalocal": "npx -w @xivgear/data-api-client swagger-typescript-api -o ./src/ -n dataapi.ts -p http://localhost:8085/swagger/xivgear-reference-data-api-0.1.yml --api-class-name DataApiClient"
+    "dataschema": "npx -w @xivgear/data-api-client swagger-typescript-api -o=./src/ -n=dataapi.ts -p=https://data.xivgear.app/swagger/xivgear-reference-data-api-0.1.yml --api-class-name=DataApiClient",
+    "dataschemalocal": "npx -w @xivgear/data-api-client swagger-typescript-api -o=./src/ -n=dataapi.ts -p=http://localhost:8085/swagger/xivgear-reference-data-api-0.1.yml --api-class-name=DataApiClient"
   }
 }

--- a/packages/backend-resolver/src/server.ts
+++ b/packages/backend-resolver/src/server.ts
@@ -3,7 +3,7 @@ import {setServerOverride} from "@xivgear/core/external/shortlink_server";
 import {setFrontendClient, setFrontendServer} from "./frontend_file_server";
 import {buildPreviewServer, buildStatsServer} from "./server_builder";
 import {FastifyInstance} from "fastify";
-import {setDataApi} from "@xivgear/core/datamanager_new";
+import {setDataApi} from "@xivgear/core/data_api_client";
 
 
 function validateUrl(url: string, description: string) {

--- a/packages/common-ui/src/components/util.ts
+++ b/packages/common-ui/src/components/util.ts
@@ -58,9 +58,8 @@ export function randomId(prefix: string = 'unique-id-') : string{
     return prefix + (idCounter++);
 }
 
-export function labelFor(label: string, labelFor: HTMLElement) {
-    const element = document.createElement("label");
-    element.textContent = label;
+export function labelFor(label: string | Node, labelFor: HTMLElement) {
+    const element = quickElement('label', [], [label]);
     if (!labelFor.id) {
         labelFor.id = randomId('lbl-id-');
     }
@@ -520,7 +519,7 @@ export class FieldBoundDataSelect<ObjType, DataType> extends DataSelect<DataType
     }
 }
 
-export function labeledComponent(label: string, check: HTMLElement): HTMLDivElement {
+export function labeledComponent(label: string | Node, check: HTMLElement): HTMLDivElement {
     const labelElement = labelFor(label, check);
     const div = document.createElement("div");
     div.appendChild(check);
@@ -529,7 +528,7 @@ export function labeledComponent(label: string, check: HTMLElement): HTMLDivElem
     return div;
 }
 
-export function labeledCheckbox(label: string, check: HTMLInputElement): HTMLDivElement {
+export function labeledCheckbox(label: string | Node, check: HTMLInputElement): HTMLDivElement {
     const labelElement = labelFor(label, check);
     const div = document.createElement("div");
     div.appendChild(check);
@@ -538,7 +537,7 @@ export function labeledCheckbox(label: string, check: HTMLInputElement): HTMLDiv
     return div;
 }
 
-export function labeledRadioButton(label: string, radioButton: HTMLInputElement): HTMLDivElement {
+export function labeledRadioButton(label: string | Node, radioButton: HTMLInputElement): HTMLDivElement {
     const labelElement = labelFor(label, radioButton);
     const div = document.createElement("div");
     div.appendChild(radioButton);

--- a/packages/core/src/data_api_client.ts
+++ b/packages/core/src/data_api_client.ts
@@ -48,9 +48,9 @@ async function retryFetch(...params: Parameters<typeof fetch>): Promise<Response
 }
 
 export const API_CLIENT = new DataApiClient<never>({
-    // baseUrl: "https://data.xivgear.app",
+    baseUrl: "https://data.xivgear.app",
     // baseUrl: "https://betadata.xivgear.app",
-    baseUrl: "http://localhost:8085",
+    // baseUrl: "http://localhost:8085",
     customFetch: retryFetch,
 });
 

--- a/packages/core/src/data_api_client.ts
+++ b/packages/core/src/data_api_client.ts
@@ -1,0 +1,72 @@
+import {DataApiClient, HttpResponse} from "@xivgear/data-api-client/dataapi";
+
+export type ApiClientRawType<X extends keyof DataApiClient<never>, Y extends keyof DataApiClient<never>[X]> = DataApiClient<never>[X][Y];
+
+export type ApiItemData = Awaited<ReturnType<ApiClientRawType<'items', 'items'>>>['data']['items'][number];
+export type ApiMateriaData = Awaited<ReturnType<ApiClientRawType<'materia', 'materia'>>>['data']['items'][number];
+export type ApiFoodData = Awaited<ReturnType<ApiClientRawType<'food', 'foodItems'>>>['data']['items'][number];
+// type BaseParamType = Awaited<ReturnType<ApiClientRawType<'baseParams', 'baseParams'>>>['data']['items'][number]
+export type ApiJobType = Awaited<ReturnType<ApiClientRawType<'jobs', 'jobs'>>>['data']['items'][number];
+// type ItemLevelType = Awaited<ReturnType<ApiClientRawType<'itemLevel', 'itemLevels'>>>['data']['items'][number]
+
+export type DataManagerErrorReporter = (r: Response, params: Parameters<typeof fetch>) => void;
+
+let errorReporter: DataManagerErrorReporter = () => {
+};
+
+export function setDataManagerErrorReporter(reporter: DataManagerErrorReporter) {
+    errorReporter = reporter;
+}
+
+async function retryFetch(...params: Parameters<typeof fetch>): Promise<Response> {
+    let tries = 5;
+    while (true) {
+        tries--;
+        const result = await fetch(...params);
+        // TODO: add other errors here?
+        if (tries > 0 && result.status === 503 && result.statusText === 'Not Ready') {
+            console.log("data api not ready, retrying", params[0]);
+            await new Promise(r => setTimeout(r, 5_000 + (Math.random() * 1000)));
+            continue;
+        }
+        if (result.status >= 400) {
+            const content = JSON.stringify(await result.json());
+            console.error(`Data API error: ${result.status}: ${result.statusText}`, params[0], content);
+            const error = Error(`Data API error: ${result.status}: ${result.statusText} (${params[0]}\n${content}`);
+            // TODO: it would be nice to be able to record these, but they would create an unacceptable
+            // dependency loop.
+            // recordError("datamanager", error, {fetchUrl: String(params[0])});
+            throw error;
+        }
+        if (!result.ok) {
+            console.error(`Data API error: ${result.status}: ${result.statusText}`, params[0]);
+            errorReporter(result, params);
+            throw new Error(`Data API error: ${result.status}: ${result.statusText} (${params[0]}`);
+        }
+        return result;
+    }
+}
+
+export const API_CLIENT = new DataApiClient<never>({
+    // baseUrl: "https://data.xivgear.app",
+    // baseUrl: "https://betadata.xivgear.app",
+    baseUrl: "http://localhost:8085",
+    customFetch: retryFetch,
+});
+
+export function setDataApi(baseUrl: string) {
+    API_CLIENT.baseUrl = baseUrl;
+}
+
+export function checkResponse<X extends HttpResponse<unknown>>(response: X): X {
+    const url = response.url;
+    if (!response.ok) {
+        errorReporter(response, [url]);
+        throw new Error(`Data API error: response not ok: ${response.status}: ${response.statusText} (${url}`);
+    }
+    else if (!response.data) {
+        errorReporter(response, [url]);
+        throw new Error(`Data API error: no data: ${response.status}: ${response.statusText} (${url}`);
+    }
+    return response;
+}

--- a/packages/core/src/external/xivapi.ts
+++ b/packages/core/src/external/xivapi.ts
@@ -23,6 +23,7 @@ export type XivApiSearchRequest = XivApiRequest & {
 // TODO: migrate this to v2.xivapi.com
 // TODO: put the /api/ part in here and rename to XIVAPI_BASE_URL
 export const XIVAPI_SERVER = "https://beta.xivapi.com";
+export const XIVAPI_SERVER_V2 = "https://v2.xivapi.com/api/";
 
 export type XivApiResultSingle<Cols extends readonly string[], TrnCols extends readonly string[] = []> = {
     [K in Cols[number]]: unknown;
@@ -69,12 +70,15 @@ export async function xivApiSingle(sheet: string, id: number) {
     return xivApiFetch(query).then(response => response.json()).then(response => response['fields']);
 }
 
-export async function xivApiSingleCols<Columns extends readonly string[]>(sheet: string, id: number, cols: Columns): Promise<{
+export async function xivApiSingleCols<Columns extends readonly string[]>(sheet: string, id: number, cols: Columns, lang?: string): Promise<{
     [K in Columns[number]]: unknown;
 } & {
     ID: number
 }> {
-    const query = `${XIVAPI_SERVER}/api/1/sheet/${sheet}/${id}?fields=${cols.join(',')}`;
+    let query = new URL(`sheet/${sheet}/${id}?fields=${cols.join(',')}`, XIVAPI_SERVER_V2);
+    if (lang) {
+        query = new URL(`?language=${lang}`, query);
+    }
     return xivApiFetch(query).then(response => response.json()).then(response => {
         const responseOut = response['fields'];
         responseOut['ID'] = response['row_id'];

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -667,6 +667,12 @@ export type BaseBuff = Readonly<{
      * Add a key for this buff for import/export functionality. If not specified, will use the name as the key.
      */
     saveKey?: string
+
+    /**
+     * By default, names will be translated on the UI when language is not English.
+     * You can force translation on or off via this property.
+     */
+    translate?: boolean,
 } & ({
     descriptionExtras?: never,
     descriptionOverride?: never,

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -355,6 +355,12 @@ export type BaseAbility = Readonly<LevelModifiable<{
      * scaling or using the pet action Weapon Damage multiplier.
      */
     alternativeScalings?: AlternativeScaling[],
+
+    /**
+     * By default, actions will be translated on the UI when language is not English.
+     * You can force translation on or off via this property.
+     */
+    translate?: boolean,
 }> & (LevelModifiable<NonDamagingAbility> | LevelModifiable<DamagingAbility>)>;
 
 

--- a/packages/data-api-client/src/dataapi.ts
+++ b/packages/data-api-client/src/dataapi.ts
@@ -1,5 +1,6 @@
 /* eslint-disable */
 /* tslint:disable */
+// @ts-nocheck
 /*
  * ---------------------------------------------------------------
  * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
@@ -8,6 +9,25 @@
  * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
  * ---------------------------------------------------------------
  */
+
+export enum GearAcquisitionSource {
+  NormalRaid = "NormalRaid",
+  SavageRaid = "SavageRaid",
+  Tome = "Tome",
+  AugTome = "AugTome",
+  Crafted = "Crafted",
+  AugCrafted = "AugCrafted",
+  Relic = "Relic",
+  Dungeon = "Dungeon",
+  ExtremeTrial = "ExtremeTrial",
+  Ultimate = "Ultimate",
+  Artifact = "Artifact",
+  AllianceRaid = "AllianceRaid",
+  Criterion = "Criterion",
+  Other = "Other",
+  Custom = "Custom",
+  Unknown = "Unknown",
+}
 
 export type BaseParam = XivApiObject &
   XivApiBase & {
@@ -45,6 +65,8 @@ export interface BaseParamEndpointResponse {
 export type ClassJob = XivApiObject &
   XivApiBase & {
     abbreviation?: string;
+    abbreviationTranslations?: XivApiLangValueString;
+    nameTranslations?: XivApiLangValueString;
     /** @format int32 */
     modifierDexterity?: number;
     /** @format int32 */
@@ -122,25 +144,6 @@ export interface FoodStatBonus {
   percentage: number;
   /** @format int32 */
   max: number;
-}
-
-export enum GearAcquisitionSource {
-  NormalRaid = "NormalRaid",
-  SavageRaid = "SavageRaid",
-  Tome = "Tome",
-  AugTome = "AugTome",
-  Crafted = "Crafted",
-  AugCrafted = "AugCrafted",
-  Relic = "Relic",
-  Dungeon = "Dungeon",
-  ExtremeTrial = "ExtremeTrial",
-  Ultimate = "Ultimate",
-  Artifact = "Artifact",
-  AllianceRaid = "AllianceRaid",
-  Criterion = "Criterion",
-  Other = "Other",
-  Custom = "Custom",
-  Unknown = "Unknown",
 }
 
 export type Icon = XivApiStruct &
@@ -308,16 +311,22 @@ export interface FullRequestParams extends Omit<RequestInit, "body"> {
   cancelToken?: CancelToken;
 }
 
-export type RequestParams = Omit<FullRequestParams, "body" | "method" | "query" | "path">;
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
 
 export interface ApiConfig<SecurityDataType = unknown> {
   baseUrl?: string;
   baseApiParams?: Omit<RequestParams, "baseUrl" | "cancelToken" | "signal">;
-  securityWorker?: (securityData: SecurityDataType | null) => Promise<RequestParams | void> | RequestParams | void;
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<RequestParams | void> | RequestParams | void;
   customFetch?: typeof fetch;
 }
 
-export interface HttpResponse<D extends unknown, E extends unknown = unknown> extends Response {
+export interface HttpResponse<D extends unknown, E extends unknown = unknown>
+  extends Response {
   data: D;
   error: E;
 }
@@ -336,7 +345,8 @@ export class HttpClient<SecurityDataType = unknown> {
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
-  private customFetch = (...fetchParams: Parameters<typeof fetch>) => fetch(...fetchParams);
+  private customFetch = (...fetchParams: Parameters<typeof fetch>) =>
+    fetch(...fetchParams);
 
   private baseApiParams: RequestParams = {
     credentials: "same-origin",
@@ -369,9 +379,15 @@ export class HttpClient<SecurityDataType = unknown> {
 
   protected toQueryString(rawQuery?: QueryParamsType): string {
     const query = rawQuery || {};
-    const keys = Object.keys(query).filter((key) => "undefined" !== typeof query[key]);
+    const keys = Object.keys(query).filter(
+      (key) => "undefined" !== typeof query[key],
+    );
     return keys
-      .map((key) => (Array.isArray(query[key]) ? this.addArrayQueryParam(query, key) : this.addQueryParam(query, key)))
+      .map((key) =>
+        Array.isArray(query[key])
+          ? this.addArrayQueryParam(query, key)
+          : this.addQueryParam(query, key),
+      )
       .join("&");
   }
 
@@ -382,8 +398,13 @@ export class HttpClient<SecurityDataType = unknown> {
 
   private contentFormatters: Record<ContentType, (input: any) => any> = {
     [ContentType.Json]: (input: any) =>
-      input !== null && (typeof input === "object" || typeof input === "string") ? JSON.stringify(input) : input,
-    [ContentType.Text]: (input: any) => (input !== null && typeof input !== "string" ? JSON.stringify(input) : input),
+      input !== null && (typeof input === "object" || typeof input === "string")
+        ? JSON.stringify(input)
+        : input,
+    [ContentType.Text]: (input: any) =>
+      input !== null && typeof input !== "string"
+        ? JSON.stringify(input)
+        : input,
     [ContentType.FormData]: (input: any) =>
       Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
@@ -400,7 +421,10 @@ export class HttpClient<SecurityDataType = unknown> {
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
   };
 
-  protected mergeRequestParams(params1: RequestParams, params2?: RequestParams): RequestParams {
+  protected mergeRequestParams(
+    params1: RequestParams,
+    params2?: RequestParams,
+  ): RequestParams {
     return {
       ...this.baseApiParams,
       ...params1,
@@ -413,7 +437,9 @@ export class HttpClient<SecurityDataType = unknown> {
     };
   }
 
-  protected createAbortSignal = (cancelToken: CancelToken): AbortSignal | undefined => {
+  protected createAbortSignal = (
+    cancelToken: CancelToken,
+  ): AbortSignal | undefined => {
     if (this.abortControllers.has(cancelToken)) {
       const abortController = this.abortControllers.get(cancelToken);
       if (abortController) {
@@ -457,15 +483,26 @@ export class HttpClient<SecurityDataType = unknown> {
     const payloadFormatter = this.contentFormatters[type || ContentType.Json];
     const responseFormat = format || requestParams.format;
 
-    return this.customFetch(`${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`, {
-      ...requestParams,
-      headers: {
-        ...(requestParams.headers || {}),
-        ...(type && type !== ContentType.FormData ? { "Content-Type": type } : {}),
+    return this.customFetch(
+      `${baseUrl || this.baseUrl || ""}${path}${queryString ? `?${queryString}` : ""}`,
+      {
+        ...requestParams,
+        headers: {
+          ...(requestParams.headers || {}),
+          ...(type && type !== ContentType.FormData
+            ? { "Content-Type": type }
+            : {}),
+        },
+        signal:
+          (cancelToken
+            ? this.createAbortSignal(cancelToken)
+            : requestParams.signal) || null,
+        body:
+          typeof body === "undefined" || body === null
+            ? null
+            : payloadFormatter(body),
       },
-      signal: (cancelToken ? this.createAbortSignal(cancelToken) : requestParams.signal) || null,
-      body: typeof body === "undefined" || body === null ? null : payloadFormatter(body),
-    }).then(async (response) => {
+    ).then(async (response) => {
       const r = response.clone() as HttpResponse<T, E>;
       r.data = null as unknown as T;
       r.error = null as unknown as E;
@@ -504,7 +541,9 @@ export class HttpClient<SecurityDataType = unknown> {
  *
  * Game data API for XivGear
  */
-export class DataApiClient<SecurityDataType extends unknown> extends HttpClient<SecurityDataType> {
+export class DataApiClient<
+  SecurityDataType extends unknown,
+> extends HttpClient<SecurityDataType> {
   baseParams = {
     /**
      * No description

--- a/packages/frontend/src/scripts/components/abilities.ts
+++ b/packages/frontend/src/scripts/components/abilities.ts
@@ -1,20 +1,24 @@
 import {xivApiIconUrl, xivApiSingleCols} from "@xivgear/core/external/xivapi";
 import {XivApiIcon} from "@xivgear/common-ui/util/types";
+import {getCurrentLanguage} from "@xivgear/i18n/translation";
+import {quickElement} from "@xivgear/common-ui/components/util";
+import {Ability} from "@xivgear/core/sims/sim_types";
 
 interface XivApiAbilityData {
-    Icon: XivApiIcon
+    Icon: XivApiIcon,
+    Name: string,
 }
 
-const abilityIconMap = new Map<number, Promise<XivApiAbilityData>>();
+const actionDataMap = new Map<number, Promise<XivApiAbilityData>>();
 
 // TODO: can this be consolidated with other job loading stuff in DataManager?
 async function getDataFor(abilityId: number): Promise<XivApiAbilityData> {
-    if (abilityIconMap.has(abilityId)) {
-        return abilityIconMap.get(abilityId);
+    if (actionDataMap.has(abilityId)) {
+        return actionDataMap.get(abilityId);
     }
     else {
-        const out = xivApiSingleCols('Action', abilityId, ['Icon'] as const) as Promise<XivApiAbilityData>;
-        abilityIconMap.set(abilityId, out);
+        const out = xivApiSingleCols('Action', abilityId, ['Icon', 'Name'] as const, getCurrentLanguage()) as Promise<XivApiAbilityData>;
+        actionDataMap.set(abilityId, out);
         return out;
     }
 }
@@ -26,6 +30,18 @@ export class AbilityIcon extends HTMLImageElement {
         this.setAttribute('intrinsicsize', '64x64');
         getDataFor(abilityId).then(data => this.src = xivApiIconUrl(data.Icon.id, false));
     }
+}
+
+export function actionNameTranslated(ability: Ability): HTMLSpanElement {
+    const text = quickElement('span', ['ability-name'], [ability.name]);
+    // Don't translate 'auto-attack' in en, just leave it as the original string
+    const shouldTranslate: boolean = ability.translate ?? getCurrentLanguage() !== 'en';
+    if (shouldTranslate) {
+        getDataFor(ability.id).then(data => {
+            text.textContent = data.Name;
+        });
+    }
+    return text;
 }
 
 customElements.define("ffxiv-ability-icon", AbilityIcon, {extends: "img"});

--- a/packages/frontend/src/scripts/components/job_name_translator.ts
+++ b/packages/frontend/src/scripts/components/job_name_translator.ts
@@ -1,0 +1,34 @@
+import {JobName} from "@xivgear/xivmath/xivconstants";
+import {API_CLIENT, ApiJobType, checkResponse} from "@xivgear/core/data_api_client";
+import {RoleKey} from "@xivgear/xivmath/geartypes";
+import {quickElement} from "@xivgear/common-ui/components/util";
+import {toTranslatable} from "@xivgear/i18n/translation";
+
+let dataPromise: Promise<Map<JobName, ApiJobType>> | null = null;
+
+function getDataPromise(): Promise<Map<JobName, ApiJobType>> {
+    if (dataPromise === null) {
+        dataPromise = API_CLIENT.jobs.jobs().then(raw => {
+            checkResponse(raw);
+            const map = new Map<JobName, ApiJobType>();
+            raw.data.items.forEach(job => {
+                map.set(job.abbreviation as JobName, job);
+            });
+            return map;
+        });
+    }
+    return dataPromise;
+}
+
+export function jobAbbrevTranslated(job: JobName | RoleKey): HTMLSpanElement {
+    const text = quickElement('span', ['job-name-translation'], [job]);
+    getDataPromise().then(pr => {
+        // If it is a role key, then it will miss on this lookup and do nothing, which is as good as we can get without
+        // a programmatic source.
+        const translation = pr.get(job as JobName)?.abbreviationTranslations;
+        if (translation) {
+            text.textContent = toTranslatable(job, translation).asCurrentLang;
+        }
+    });
+    return text;
+}

--- a/packages/frontend/src/scripts/components/saved_sheet_picker.ts
+++ b/packages/frontend/src/scripts/components/saved_sheet_picker.ts
@@ -15,6 +15,7 @@ import {getHashForSaveKey, openSheetByKey, showNewSheetForm} from "../base_ui";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";
 import {JobIcon} from "./job_icon";
 import {JOB_DATA} from "@xivgear/xivmath/xivconstants";
+import {jobAbbrevTranslated} from "./job_name_translator";
 
 export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionModel<SheetExport, never, never, SheetExport | null>> {
     constructor() {
@@ -59,7 +60,7 @@ export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionMod
                     return sheet.job;
                 },
                 renderer: job => {
-                    return document.createTextNode(job);
+                    return jobAbbrevTranslated(job);
                 },
             }),
             col({

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -90,9 +90,9 @@ import {SETTINGS} from "@xivgear/common-ui/settings/persistent_settings";
 import {isInIframe} from "@xivgear/common-ui/util/detect_iframe";
 import {recordError, recordEvent} from "@xivgear/common-ui/analytics/analytics";
 import {ExpandableText} from "@xivgear/common-ui/components/expandy_text";
-import {setDataManagerErrorReporter} from "@xivgear/core/datamanager_new";
 import {SheetInfoModal} from "./sheet_info_modal";
 import {FramelessJobIcon, JobIcon} from "./job_icon";
+import {setDataManagerErrorReporter} from "@xivgear/core/data_api_client";
 
 const noSeparators = (set: CharacterGearSet) => !set.isSeparator;
 

--- a/packages/frontend/src/scripts/components/stat_tier_display.ts
+++ b/packages/frontend/src/scripts/components/stat_tier_display.ts
@@ -330,8 +330,8 @@ export class StatTierDisplay extends HTMLDivElement {
             case "dhit":
                 return [{
                     label: abbrev,
-                    fullName: 'direct hit change',
-                    description: 'Change to land a direct hit',
+                    fullName: 'direct hit chance',
+                    description: 'Chance to land a direct hit',
                     tieringFunc: makeTiering(value => dhitChance(levelStats, value)),
                     extraOffsets: extraOffsets,
                 }];

--- a/packages/frontend/src/scripts/components/status_effects.ts
+++ b/packages/frontend/src/scripts/components/status_effects.ts
@@ -2,6 +2,7 @@ import {xivApiIconUrl, xivApiSingleCols} from "@xivgear/core/external/xivapi";
 import {AnyStringIndex} from "@xivgear/util/types";
 import {getCurrentLanguage} from "@xivgear/i18n/translation";
 import {Buff} from "@xivgear/core/sims/sim_types";
+import {quickElement} from "@xivgear/common-ui/components/util";
 
 export interface XivApiStatusData {
     ID: number,
@@ -55,8 +56,28 @@ export class StatusIcon extends HTMLImageElement {
     }
 }
 
+function shouldTranslate(buff: Buff) {
+    return buff.statusId > 0 && (buff.translate ?? getCurrentLanguage() !== 'en');
+}
+
+export function statusNameTranslated(buff: Buff): HTMLSpanElement {
+    const text = quickElement('span', ['status-name'], [buff.name]);
+    // Don't translate 'auto-attack' in en, just leave it as the original string
+    if (shouldTranslate(buff)) {
+        getDataFor(buff.statusId).then(data => {
+            text.textContent = data.Name;
+        });
+    }
+    return text;
+}
+
 export async function translatedStatusName(buff: Buff): Promise<string> {
-    return (await getDataFor(buff.statusId)).Name;
+    if (shouldTranslate(buff)) {
+        return (await getDataFor(buff.statusId)).Name;
+    }
+    else {
+        return Promise.resolve(buff.name);
+    }
 }
 
 customElements.define("ffxiv-status-icon", StatusIcon, {extends: "img"});

--- a/packages/frontend/src/scripts/sims/components/ability_used_table.ts
+++ b/packages/frontend/src/scripts/sims/components/ability_used_table.ts
@@ -1,6 +1,6 @@
 import {col, CustomColumnSpec, CustomTable, HeaderRow} from "@xivgear/common-ui/table/tables";
 import {toRelPct} from "@xivgear/util/strutils";
-import {AbilityIcon} from "../../components/abilities";
+import {AbilityIcon, actionNameTranslated} from "../../components/abilities";
 import {BuffListDisplay} from "./buff_list_display";
 import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {AutoAttack, Buff, CombinedBuffEffect, GcdAbility, OgcdAbility} from "@xivgear/core/sims/sim_types";
@@ -85,9 +85,7 @@ export class AbilitiesUsedTable extends CustomTable<DisplayRecordFinalized> {
                                 out.appendChild(new AbilityIcon(ability.id));
                             }
                         }
-                        const abilityNameSpan = document.createElement('span');
-                        abilityNameSpan.textContent = ability.name;
-                        abilityNameSpan.classList.add('ability-name');
+                        const abilityNameSpan = actionNameTranslated(ability);
                         out.appendChild(abilityNameSpan);
                         return out;
                     }

--- a/packages/frontend/src/scripts/sims/components/buff_list_display.ts
+++ b/packages/frontend/src/scripts/sims/components/buff_list_display.ts
@@ -1,10 +1,11 @@
-import {StatusIcon} from "../../components/status_effects";
+import {StatusIcon, translatedStatusName} from "../../components/status_effects";
 import {toRelPct} from "@xivgear/util/strutils";
 import {Buff} from "@xivgear/core/sims/sim_types";
 
 
-export function describeBuff(buff: Buff) {
-    const baseName = buff.stacks ? `${buff.name} (${buff.stacks} stacks)` : buff.name;
+export function describeBuff(buff: Buff, nameOverride: string | null) {
+    const effectiveName = nameOverride ?? buff.name;
+    const baseName = buff.stacks ? `${effectiveName} (${buff.stacks} stacks)` : effectiveName;
     if ('descriptionOverride' in buff) {
         return `${baseName}: ${buff.descriptionOverride}`;
     }
@@ -33,15 +34,33 @@ export function describeBuff(buff: Buff) {
     }
 }
 
+type BuffInfo = {
+    buff: Buff,
+    translation: string | null,
+}
+
+/**
+ * Element which displays a list of buffs.
+ */
 export class BuffListDisplay extends HTMLDivElement {
+
+    private readonly buffInfo: BuffInfo[] = [];
+    private dirtyTooltip: boolean = false;
+
     constructor(buffs: Buff[]) {
         super();
         this.classList.add('active-buffs-list');
-        let tooltip = '';
+        if (buffs.length === 0) {
+            return;
+        }
         const textOnly: Buff[] = [];
         let hasImage = false;
         for (const buff of buffs) {
-            tooltip += describeBuff(buff) + '\n';
+            const bi: BuffInfo = {
+                buff: buff,
+                translation: null,
+            };
+            this.buffInfo.push(bi);
             if (buff.statusId !== undefined && buff.statusId > 0) {
                 this.appendChild(new StatusIcon(buff.statusId, buff.stacks));
                 hasImage = true;
@@ -49,6 +68,14 @@ export class BuffListDisplay extends HTMLDivElement {
             else {
                 textOnly.push(buff);
             }
+            translatedStatusName(buff).then(name => {
+                // Ignore no-ops
+                if (name === bi.buff.name) {
+                    return;
+                }
+                bi.translation = name;
+                this.reformatTooltipLazy();
+            });
         }
         if (textOnly.length > 0) {
             const textPart = document.createElement('span');
@@ -59,6 +86,28 @@ export class BuffListDisplay extends HTMLDivElement {
             textPart.textContent = textOut;
             this.appendChild(textPart);
         }
+        this.reformatTooltipNow();
+    }
+
+    reformatTooltipLazy(): void {
+        console.log('reformatLazy');
+        if (!this.dirtyTooltip) {
+            this.dirtyTooltip = true;
+            // Unlikely that the user will try to view the tooltip within 500ms, so coalesce tooltip updates into a
+            // single op within a particular timeout.
+            setTimeout(() => this.reformatTooltipNow(), 500);
+        }
+    }
+
+    reformatTooltipNow(): void {
+        console.log('reformatNow');
+        this.dirtyTooltip = false;
+        let tooltip = '';
+        this.buffInfo.forEach(bi => {
+            const buff = bi.buff;
+            const translated = bi.translation;
+            tooltip += describeBuff(buff, translated) + '\n';
+        });
         this.title = tooltip;
     }
 }

--- a/packages/frontend/src/scripts/sims/components/buff_list_display.ts
+++ b/packages/frontend/src/scripts/sims/components/buff_list_display.ts
@@ -90,7 +90,6 @@ export class BuffListDisplay extends HTMLDivElement {
     }
 
     reformatTooltipLazy(): void {
-        console.log('reformatLazy');
         if (!this.dirtyTooltip) {
             this.dirtyTooltip = true;
             // Unlikely that the user will try to view the tooltip within 500ms, so coalesce tooltip updates into a
@@ -100,7 +99,6 @@ export class BuffListDisplay extends HTMLDivElement {
     }
 
     reformatTooltipNow(): void {
-        console.log('reformatNow');
         this.dirtyTooltip = false;
         let tooltip = '';
         this.buffInfo.forEach(bi => {

--- a/packages/frontend/src/scripts/sims/party_comp_settings.ts
+++ b/packages/frontend/src/scripts/sims/party_comp_settings.ts
@@ -2,6 +2,7 @@ import {NamedSection} from "../components/section";
 import {BuffSettingsManager} from "@xivgear/core/sims/common/party_comp_settings";
 import {FieldBoundCheckBox, labeledCheckbox} from "@xivgear/common-ui/components/util";
 import {jobAbbrevTranslated} from "../components/job_name_translator";
+import {statusNameTranslated, translatedStatusName} from "../components/status_effects";
 
 /**
  * Provides the settings area for configuring party buffs.
@@ -27,7 +28,7 @@ export class BuffSettingsArea extends NamedSection {
             job.allBuffs.forEach(buff => {
                 const buffCb = new FieldBoundCheckBox(buff, 'enabled');
                 buffCb.addListener(updateCallback);
-                buffsCell.append(labeledCheckbox(buff.buff.name, buffCb));
+                buffsCell.append(labeledCheckbox(statusNameTranslated(buff.buff), buffCb));
                 jobCb.addAndRunListener(val => buffCb.disabled = !val);
             });
             row.append(buffsCell);

--- a/packages/frontend/src/scripts/sims/party_comp_settings.ts
+++ b/packages/frontend/src/scripts/sims/party_comp_settings.ts
@@ -2,7 +2,7 @@ import {NamedSection} from "../components/section";
 import {BuffSettingsManager} from "@xivgear/core/sims/common/party_comp_settings";
 import {FieldBoundCheckBox, labeledCheckbox} from "@xivgear/common-ui/components/util";
 import {jobAbbrevTranslated} from "../components/job_name_translator";
-import {statusNameTranslated, translatedStatusName} from "../components/status_effects";
+import {statusNameTranslated} from "../components/status_effects";
 
 /**
  * Provides the settings area for configuring party buffs.

--- a/packages/frontend/src/scripts/sims/party_comp_settings.ts
+++ b/packages/frontend/src/scripts/sims/party_comp_settings.ts
@@ -1,6 +1,7 @@
 import {NamedSection} from "../components/section";
 import {BuffSettingsManager} from "@xivgear/core/sims/common/party_comp_settings";
 import {FieldBoundCheckBox, labeledCheckbox} from "@xivgear/common-ui/components/util";
+import {jobAbbrevTranslated} from "../components/job_name_translator";
 
 /**
  * Provides the settings area for configuring party buffs.
@@ -19,7 +20,7 @@ export class BuffSettingsArea extends NamedSection {
             const jobCell = document.createElement('td');
             const jobCb = new FieldBoundCheckBox(job, 'enabled');
             jobCb.addListener(updateCallback);
-            jobCell.append(labeledCheckbox(job.job, jobCb));
+            jobCell.append(labeledCheckbox(jobAbbrevTranslated(job.job), jobCb));
             row.append(jobCell);
 
             const buffsCell = document.createElement('td');

--- a/packages/i18n/src/translation.ts
+++ b/packages/i18n/src/translation.ts
@@ -47,6 +47,7 @@ class TranslatableImpl implements TranslatableString {
     }
 
     get ja() {
+        // TODO
         return this.data['ja'] ?? this.defaultValue;
     }
 


### PR DESCRIPTION
Closes #332 

- [X] Job names on sheet picker
- [x] Job names on buff picker
- [x] Actions
- [x] Status effects
  - [x] Tooltip
  - [x] Buff picker
- [x] Xivapi-java release to fix jp
- [x] Merge changes on data API

Out of scope:
- Base Params: These are always referred to by abbreviations rather than full names, and there do not seem to be any official abbreviations
- Races: For now, this is blocked until I fix a couple of the names not matching exactly what is in the data files
- Text-only buff labels: This is typically only done for "fake buffs" so we wouldn't be looking them up in xivapi anyway.