### PR TITLE
Add concurrency controls to github actions

### DIFF
--- a/.github/workflows/backend_docker.yml
+++ b/.github/workflows/backend_docker.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.numbner || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/xivgear-stats-server

--- a/.github/workflows/frontend_docker.yml
+++ b/.github/workflows/frontend_docker.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.numbner || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/xivgear-static

--- a/.github/workflows/lint_only.yml
+++ b/.github/workflows/lint_only.yml
@@ -6,6 +6,10 @@ on:
 #    branches: [ "master" ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.numbner || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/math_frontend_docker.yml
+++ b/.github/workflows/math_frontend_docker.yml
@@ -4,6 +4,10 @@ on:
   push:
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.numbner || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository_owner }}/xivgear-mathcorner

--- a/.github/workflows/test_only.yml
+++ b/.github/workflows/test_only.yml
@@ -6,6 +6,10 @@ on:
 #    branches: [ "master" ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.numbner || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This will cause obsolete workflows (i.e. those which are still running when a new commit has been added to the branch or PR in question) to be canceled.