### PR TITLE
Custom item improvements

### DIFF
--- a/packages/common-ui/src/components/modal.ts
+++ b/packages/common-ui/src/components/modal.ts
@@ -54,6 +54,7 @@ export abstract class BaseModal extends HTMLElement {
             },
             modalElement: this.inner,
             close(): void {
+                outer.onClose();
                 outer.remove();
             },
         };
@@ -80,5 +81,8 @@ export abstract class BaseModal extends HTMLElement {
 
     close() {
         closeModal();
+    }
+
+    protected onClose(): void {
     }
 }

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -37,7 +37,7 @@ import {
     RelicStatMemoryExport,
     RelicStats,
     SetDisplaySettingsExport,
-    SlotMateriaMemoryExport,
+    SlotMateriaMemoryExport
 } from "@xivgear/xivmath/geartypes";
 import {Inactivitytimer} from "@xivgear/util/inactivitytimer";
 import {addStats, finalizeStats, finalizeStatsInt, getBaseMainStat} from "@xivgear/xivmath/xivstats";

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -368,7 +368,7 @@ export class CharacterGearSet {
      * @param item
      * @param materiaAutoFillController
      */
-    setEquip(slot: EquipSlotKey, item: GearItem, materiaAutoFillController?: MateriaAutoFillController) {
+    setEquip(slot: EquipSlotKey, item: GearItem | null, materiaAutoFillController?: MateriaAutoFillController) {
         if (this.equipment[slot]?.gearItem === item) {
             return;
         }
@@ -544,7 +544,7 @@ export class CharacterGearSet {
     /**
      * All items currently equipped (excluding food)
      */
-    get allEquippedItems(): XivCombatItem[] {
+    get allEquippedItems(): GearItem[] {
         return Object.values(this.equipment)
             .filter(slotEquipment => slotEquipment && slotEquipment.gearItem)
             .map((slotEquipment: EquippedItem) => slotEquipment.gearItem);

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -14,7 +14,8 @@ import {
     SPECIAL_SUB_STATS
 } from "@xivgear/xivmath/xivconstants";
 import {
-    cloneEquipmentSet, CollapsibleSlot,
+    cloneEquipmentSet,
+    CollapsibleSlot,
     ComputedSetStats,
     EquipmentSet,
     EquippedItem,
@@ -37,7 +38,6 @@ import {
     RelicStats,
     SetDisplaySettingsExport,
     SlotMateriaMemoryExport,
-    XivCombatItem
 } from "@xivgear/xivmath/geartypes";
 import {Inactivitytimer} from "@xivgear/util/inactivitytimer";
 import {addStats, finalizeStats, finalizeStatsInt, getBaseMainStat} from "@xivgear/xivmath/xivstats";
@@ -245,6 +245,7 @@ type GearSetCheckpointNode = {
     prev: GearSetCheckpointNode | null;
     next: GearSetCheckpointNode | null;
 }
+
 /**
  * Class representing equipped gear, food, and other overrides.
  */

--- a/packages/frontend/src/scripts/components/custom_item_manager.ts
+++ b/packages/frontend/src/scripts/components/custom_item_manager.ts
@@ -20,6 +20,8 @@ import {OccGearSlots, RawStats, Substat} from "@xivgear/xivmath/geartypes";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";
 import {CustomItem} from "@xivgear/core/customgear/custom_item";
 import {CustomFood} from "@xivgear/core/customgear/custom_food";
+import {conf} from "@xivgear/core/sims/tank/pld/pld_actions_no_sks";
+import {GearPlanSheetGui} from "./sheet";
 
 function ifWeapon(fn: (item: CustomItem) => HTMLElement): (item: CustomItem) => Node {
     return (item: CustomItem) => {
@@ -67,9 +69,13 @@ export class CustomItemTable extends CustomTable<CustomItem> {
                 renderer: (item: CustomItem) => {
                     const out = document.createElement('div');
                     out.appendChild(makeActionButton([faIcon('fa-trash-can')], (ev) => {
-                        if (confirmDelete(ev, `Delete custom item '${item.name}'? Please make sure it is not equipped on any set.`)) {
-                            this.sheet.deleteCustomItem(item);
-                            this.refresh();
+                        if (confirmDelete(ev, `Delete custom item '${item.name}'?`)) {
+                            const deleted = this.sheet.deleteCustomItem(item, setNames => {
+                                return confirmDelete(ev, `Some sets are still using this item:\n${setNames.map(setName => ` - ${setName}`).join('\n')}\nDelete anyway?`);
+                            });
+                            if (deleted) {
+                                this.refresh();
+                            }
                         }
                     }, 'Delete this item'));
                     return out;
@@ -237,14 +243,14 @@ export class CustomItemTable extends CustomTable<CustomItem> {
  * Modal dialog for custom item management.
  */
 export class CustomItemPopup extends BaseModal {
-    constructor(private readonly sheet: GearPlanSheet) {
+    constructor(private readonly sheet: GearPlanSheetGui) {
         super();
         this.headerText = 'Custom Items';
         const table = new CustomItemTable(sheet);
         this.contentArea.appendChild(table);
 
         const notesArea = document.createElement('p');
-        notesArea.innerHTML = 'Limitations:<br />Do not delete items that are currently equipped.<br />If you change the number of materia slots on an item, you will need to re-select the item.<br />Currently, items will not downsync - they will always get their full stat value.';
+        notesArea.innerHTML = 'Limitations:<br />If you change the number of materia slots on an item, you will need to re-select the item.';
         notesArea.classList.add('notes-area');
         this.contentArea.appendChild(notesArea);
 
@@ -271,12 +277,11 @@ export class CustomItemPopup extends BaseModal {
         this.addCloseButton();
     }
 
-    close() {
-        super.close();
+    onClose() {
         this.sheet.requestSave();
-        this.sheet.gearDisplaySettingsUpdateLater();
         this.sheet.recheckCustomItems();
         this.sheet.recalcAll();
+        this.sheet.gearDisplaySettingsUpdateNow();
     }
 }
 
@@ -294,9 +299,13 @@ export class CustomFoodTable extends CustomTable<CustomFood> {
                 renderer: (item: CustomFood) => {
                     const out = document.createElement('div');
                     out.appendChild(makeActionButton([faIcon('fa-trash-can')], (ev) => {
-                        if (confirmDelete(ev, `Delete custom item '${item.name}'? Please make sure it is not equipped on any set.`)) {
-                            this.sheet.deleteCustomFood(item);
-                            this.refresh();
+                        if (confirmDelete(ev, `Delete custom food '${item.name}'?`)) {
+                            const deleted = this.sheet.deleteCustomFood(item, setNames => {
+                                return confirmDelete(ev, `Some sets are still using this item:\n${setNames.map(setName => ` - ${setName}`).join('\n')}\nDelete anyway?`);
+                            });
+                            if (deleted) {
+                                this.refresh();
+                            }
                         }
                     }, 'Delete this item'));
                     return out;
@@ -403,16 +412,16 @@ export class CustomFoodTable extends CustomTable<CustomFood> {
  * Modal dialog for custom item management.
  */
 export class CustomFoodPopup extends BaseModal {
-    constructor(private readonly sheet: GearPlanSheet) {
+    constructor(private readonly sheet: GearPlanSheetGui) {
         super();
         this.headerText = 'Custom Food';
         const table = new CustomFoodTable(sheet);
         this.contentArea.appendChild(table);
 
-        const notesArea = document.createElement('p');
-        notesArea.innerHTML = 'Limitations:<br />Do not delete items that are currently equipped.';
-        notesArea.classList.add('notes-area');
-        this.contentArea.appendChild(notesArea);
+        // const notesArea = document.createElement('p');
+        // notesArea.innerHTML = 'Limitations:<br />Do not delete items that are currently equipped.';
+        // notesArea.classList.add('notes-area');
+        // this.contentArea.appendChild(notesArea);
 
         this.addActionButton('New Food', () => {
             sheet.newCustomFood();
@@ -422,11 +431,11 @@ export class CustomFoodPopup extends BaseModal {
         this.addCloseButton();
     }
 
-    close() {
-        super.close();
+    onClose() {
         this.sheet.requestSave();
         this.sheet.gearDisplaySettingsUpdateLater();
         this.sheet.recalcAll();
+        this.sheet.refreshGearEditor();
     }
 }
 

--- a/packages/frontend/src/scripts/components/custom_item_manager.ts
+++ b/packages/frontend/src/scripts/components/custom_item_manager.ts
@@ -20,7 +20,6 @@ import {OccGearSlots, RawStats, Substat} from "@xivgear/xivmath/geartypes";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";
 import {CustomItem} from "@xivgear/core/customgear/custom_item";
 import {CustomFood} from "@xivgear/core/customgear/custom_food";
-import {conf} from "@xivgear/core/sims/tank/pld/pld_actions_no_sks";
 import {GearPlanSheetGui} from "./sheet";
 
 function ifWeapon(fn: (item: CustomItem) => HTMLElement): (item: CustomItem) => Node {

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1973,8 +1973,13 @@ export class GearPlanSheetGui extends GearPlanSheet {
         gearSet.startCheckpoint(() => this.refreshGearEditor(gearSet));
     }
 
-    refreshGearEditor(set: CharacterGearSet) {
-        if (this._editorItem === set) {
+    /**
+     * Fully refresh the gear editor area.
+     *
+     * @param set If specified, will only perform the refresh if this is the currently selected set.
+     */
+    refreshGearEditor(set?: CharacterGearSet) {
+        if (!set || this._editorItem === set) {
             this.resetEditorArea();
             // this.refreshToolbar();
         }


### PR DESCRIPTION
- Fix custom items not refreshing if the modal was closed by means other than the close button
- You can now safely delete custom items when they are equipped. An extra confirmation will pop up. If you answer yes, it will remove the item from all sets where it is equipped. If you answer no, the deletion will be canceled.