### PR TITLE
Fix blitz window entry for "-3" opos

### DIFF
--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -403,7 +403,7 @@ class MNKCycleProcessor extends CycleProcessor {
             }
             return form?.statusId !== PerfectBalanceBuff.statusId // not already building a blitz
                 && OPO_ABILITIES.includes(gcd.id) // just executed an opo ability
-                && riddleStatus.readyAt.relative <= this.timeToExecuteNGcds(3) // Within 3 gcds of RoF coming off cooldown
+                && riddleStatus.readyAt.relative <= this.timeToExecuteNGcds(4) // Within 4 gcds of RoF coming off cooldown (allows our blitz to fall first gcd under RoF)
                 && this.cdTracker.canUse(PerfectBalance);
         }
     }


### PR DESCRIPTION
While implementing the triple lunar rotation I noticed that the 8 minute burst window entry was incorrect in all rotations due to drift / GCD alignment. This caused all rotations to desync brotherhood and rof double weaves while entering the 8 minute window, because the blitz entry logic was not considering windows that would allow the first GCD under buffs to be a blitz.