### PR TITLE
Sim table enhancements

### DIFF
--- a/packages/common-ui/styles/gauge.less
+++ b/packages/common-ui/styles/gauge.less
@@ -43,6 +43,12 @@ gauge-bar {
     width: 16px;
     display: inline-block;
     overflow: hidden;
+    flex-basis: 16px;
+    flex-shrink: 0;
+    flex-grow: 0;
+  }
+  > span:not(:empty) {
+    flex-grow: 1;
   }
 }
 
@@ -104,6 +110,9 @@ gauge-bar {
 .mnk-chakra-gauge-orange {
   .mnk-chakra-gauge();
   background-color: #f37208;
+}
+.mnk-chakra-gauge-number {
+  min-width: 50px;
 }
 
 .mnk-beastfury-gauge {

--- a/packages/core/src/sims/melee/mnk/mnk_sim.ts
+++ b/packages/core/src/sims/melee/mnk/mnk_sim.ts
@@ -437,7 +437,6 @@ export class MnkSim extends BaseMultiCycleSim<CycleSimResult, MnkSettings, MNKCy
     spec = mnkSpec;
     shortName = 'mnk-sim';
     displayName = mnkSpec.displayName;
-    cycleSettings: CycleSettings = this.defaultCycleSettings();
     manuallyActivatedBuffs = [BrotherhoodGlobalBuff];
 
     constructor(settings?: MnkSettingsExternal) {

--- a/packages/frontend/src/scripts/sims/healer/ast_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/healer/ast_sheet_sim_ui.ts
@@ -1,6 +1,6 @@
 import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {col, CustomColumn} from "@xivgear/common-ui/table/tables";
+import {col, CustomColumn, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {AbilitiesUsedTable} from "../components/ability_used_table";
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
 import {AstExtraData, AstSettings, AstSimResult} from "@xivgear/core/sims/healer/ast_sheet_sim";
@@ -86,6 +86,12 @@ class AstGaugeGui {
 }
 
 export class AstSheetSimGui extends BaseMultiCycleSimGui<AstSimResult, AstSettings> {
+
+    //
+    // protected extraAbilityUsedColumns(result: AstSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+    //     return AstGaugeGui.generateResultColumns(res)
+    //     return super.extraAbilityUsedColumns(result);
+    // }
 
     override makeAbilityUsedTable(result: AstSimResult): AbilitiesUsedTable {
         const extraColumns = AstGaugeGui.generateResultColumns(result);

--- a/packages/frontend/src/scripts/sims/healer/ast_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/healer/ast_sheet_sim_ui.ts
@@ -1,14 +1,14 @@
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {col, CustomColumn, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
-import {AbilitiesUsedTable} from "../components/ability_used_table";
+import {col, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
 import {AstExtraData, AstSettings, AstSimResult} from "@xivgear/core/sims/healer/ast_sheet_sim";
 import {StyleSwitcher, WritableCssProp} from "@xivgear/common-ui/util/types";
 
-class AstGaugeGui {
+export class AstSheetSimGui extends BaseMultiCycleSimGui<AstSimResult, AstSettings> {
 
-    static generateResultColumns(result: CycleSimResult): CustomColumn<DisplayRecordFinalized, unknown, unknown>[] {
+
+    protected extraAbilityUsedColumns(result: AstSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [col({
             shortName: 'cards',
             displayName: 'Cards',
@@ -74,7 +74,8 @@ class AstGaugeGui {
                             stack.style.background = '#00000033';
                         }
                         div.appendChild(stack);
-                    };
+                    }
+                    ;
 
                     return div;
                 }
@@ -82,23 +83,5 @@ class AstGaugeGui {
             },
         }),
         ];
-    }
-}
-
-export class AstSheetSimGui extends BaseMultiCycleSimGui<AstSimResult, AstSettings> {
-
-    //
-    // protected extraAbilityUsedColumns(result: AstSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
-    //     return AstGaugeGui.generateResultColumns(res)
-    //     return super.extraAbilityUsedColumns(result);
-    // }
-
-    override makeAbilityUsedTable(result: AstSimResult): AbilitiesUsedTable {
-        const extraColumns = AstGaugeGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 }

--- a/packages/frontend/src/scripts/sims/healer/sch_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/healer/sch_sheet_sim_ui.ts
@@ -1,14 +1,13 @@
 import {FieldBoundIntField, labelFor, nonNegative, quickElement} from "@xivgear/common-ui/components/util";
-import {AbilitiesUsedTable} from "../components/ability_used_table";
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {ColDefs} from "@xivgear/common-ui/table/tables";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {SchExtraData, SchSettings, SchSimResult} from "@xivgear/core/sims/healer/sch_sheet_sim";
 
-class SchGaugeGui {
+export class SchSimGui extends BaseMultiCycleSimGui<SchSimResult, SchSettings> {
 
-    static generateResultColumns(result: CycleSimResult): ColDefs<DisplayRecordFinalized> {
+    protected extraAbilityUsedColumns(result: SchSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [{
             shortName: 'aetherflow',
             displayName: 'Aetherflow',
@@ -30,9 +29,7 @@ class SchGaugeGui {
         },
         ];
     }
-}
 
-export class SchSimGui extends BaseMultiCycleSimGui<SchSimResult, SchSettings> {
     makeCustomConfigInterface(settings: SchSettings, updateCallback: () => void): HTMLElement | null {
         const configDiv = document.createElement("div");
         const edField = new FieldBoundIntField<SchSettings>(settings, 'edsPerAfDiss', {
@@ -45,15 +42,6 @@ export class SchSimGui extends BaseMultiCycleSimGui<SchSimResult, SchSettings> {
         configDiv.appendChild(label);
         configDiv.appendChild(edField);
         return configDiv;
-    }
-
-    makeAbilityUsedTable(result: SchSimResult): AbilitiesUsedTable {
-        const extraColumns = SchGaugeGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/healer/whm_new_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/healer/whm_new_sheet_sim_ui.ts
@@ -1,14 +1,13 @@
 import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {col, ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
-import {AbilitiesUsedTable} from "../components/ability_used_table";
+import {col, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
 import {WhmGaugeState, WhmSettings, WhmSimResult} from "@xivgear/core/sims/healer/whm_new_sheet_sim";
 import {quickElement} from "@xivgear/common-ui/components/util";
 
-class WhmGaugeGui {
+export class WhmSimGui extends BaseMultiCycleSimGui<WhmSimResult, WhmSettings> {
 
-    static generateResultColumns(): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+    protected extraAbilityUsedColumns(result: WhmSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [col({
             shortName: 'lilies',
             displayName: 'Lilies',
@@ -34,17 +33,6 @@ class WhmGaugeGui {
             },
         }),
         ];
-    }
-}
-
-export class WhmSimGui extends BaseMultiCycleSimGui<WhmSimResult, WhmSettings> {
-    override makeAbilityUsedTable(result: WhmSimResult): AbilitiesUsedTable {
-        const extraColumns = WhmGaugeGui.generateResultColumns();
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/melee/mnk/mnk_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/melee/mnk/mnk_sim_ui.ts
@@ -1,15 +1,14 @@
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
-import {ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
-import {AbilitiesUsedTable} from "../../components/ability_used_table";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {BaseMultiCycleSimGui} from "../../multicyclesim_ui";
 import {MnkSettings, MnkSimResult} from "@xivgear/core/sims/melee/mnk/mnk_sim";
 import {MNKExtraData} from "@xivgear/core/sims/melee/mnk/mnk_types";
 import {quickElement} from "@xivgear/common-ui/components/util";
 import {gaugeRenderer} from "../../common/sim_ui_utils";
 
-class MNKGaugeGui {
+export class MnkSimGui extends BaseMultiCycleSimGui<MnkSimResult, MnkSettings> {
 
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+    protected extraAbilityUsedColumns(_: MnkSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [
             {
                 shortName: 'chakra',
@@ -29,9 +28,7 @@ class MNKGaugeGui {
                             children.push(quickElement('span', ['mnk-chakra-gauge-default'], []));
                         }
                     }
-                    const span = document.createElement('span');
-                    span.textContent = `${chakra.toLocaleString(undefined, {minimumFractionDigits: 3})}`;
-                    children.push(span);
+                    children.push(quickElement('span', ['mnk-chakra-gauge-number'], [`${chakra.toLocaleString(undefined, {minimumFractionDigits: 3})}`]));
                     return children;
                 }),
             },
@@ -106,24 +103,6 @@ class MNKGaugeGui {
                 }),
             },
         ];
-    }
-}
-
-export class MnkSimGui extends BaseMultiCycleSimGui<MnkSimResult, MnkSettings> {
-
-    override makeCustomConfigInterface(settings: MnkSettings, _updateCallback: () => void): HTMLElement | null {
-        const configDiv = document.createElement("div");
-
-        return configDiv;
-    }
-
-    override makeAbilityUsedTable(result: MnkSimResult): AbilitiesUsedTable {
-        const extraColumns = MNKGaugeGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/melee/nin/nin_lvl100_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/melee/nin/nin_lvl100_sim_ui.ts
@@ -1,14 +1,14 @@
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
-import {AbilitiesUsedTable} from "../../components/ability_used_table";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {BaseMultiCycleSimGui} from "../../multicyclesim_ui";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {NinSettings, NinSimResult} from "@xivgear/core/sims/melee/nin/nin_lv100_sim";
 import {NINExtraData} from "@xivgear/core/sims/melee/nin/nin_types";
 import {GaugeWithText} from "@xivgear/common-ui/components/gauges";
 
-export class NINGaugeGui {
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+export class NinSheetSimGui extends BaseMultiCycleSimGui<NinSimResult, NinSettings> {
+
+    protected extraAbilityUsedColumns(result: NinSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [{
             shortName: 'ninkiGauge',
             displayName: 'Ninki',
@@ -42,16 +42,4 @@ export class NINGaugeGui {
         }];
     }
 
-}
-
-export class NinSheetSimGui extends BaseMultiCycleSimGui<NinSimResult, NinSettings> {
-
-    override makeAbilityUsedTable(result: NinSimResult): AbilitiesUsedTable {
-        const extraColumns = NINGaugeGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
-    }
 }

--- a/packages/frontend/src/scripts/sims/melee/rpr/rpr_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/melee/rpr/rpr_sheet_sim_ui.ts
@@ -1,14 +1,12 @@
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
-import {AbilitiesUsedTable} from "../../components/ability_used_table";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {BaseMultiCycleSimGui} from "../../multicyclesim_ui";
 import {RprSheetSimResult, RprSimSettings} from "@xivgear/core/sims/melee/rpr/rpr_sheet_sim";
 import {RprExtraData} from "@xivgear/core/sims/melee/rpr/rpr_types";
 
-export class RprGaugeGui {
-
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+export class RprSheetSimGui extends BaseMultiCycleSimGui<RprSheetSimResult, RprSimSettings> {
+    protected extraAbilityUsedColumns(result: RprSheetSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [{
             shortName: 'soulGauge',
             displayName: 'Soul',
@@ -50,8 +48,7 @@ export class RprGaugeGui {
                 }
                 return document.createTextNode("");
             },
-        },
-        {
+        }, {
             shortName: 'shroudGauge',
             displayName: 'Shroud',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
@@ -92,20 +89,7 @@ export class RprGaugeGui {
                 }
                 return document.createTextNode("");
             },
-        },
-        ];
+        }];
     }
-}
 
-export class RprSheetSimGui extends BaseMultiCycleSimGui<RprSheetSimResult, RprSimSettings> {
-
-    // TODO: since these are all pretty much the same, just make an actual method for inserting custom columns
-    override makeAbilityUsedTable(result: RprSheetSimResult): AbilitiesUsedTable {
-        const extraColumns = RprGaugeGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
-    }
 }

--- a/packages/frontend/src/scripts/sims/melee/sam/sam_lvl100_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/melee/sam/sam_lvl100_sim_ui.ts
@@ -1,16 +1,15 @@
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
-import {AbilitiesUsedTable} from "../../components/ability_used_table";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {BaseMultiCycleSimGui} from "../../multicyclesim_ui";
-import {FieldBoundFloatField, FieldBoundCheckBox, labelFor, labeledCheckbox} from "@xivgear/common-ui/components/util";
-import {SamSimResult, SamSettings} from "@xivgear/core/sims/melee/sam/sam_lv100_sim";
+import {FieldBoundCheckBox, FieldBoundFloatField, labeledCheckbox, labelFor} from "@xivgear/common-ui/components/util";
+import {SamSettings, SamSimResult} from "@xivgear/core/sims/melee/sam/sam_lv100_sim";
 import {SAMExtraData} from "@xivgear/core/sims/melee/sam/sam_types";
 import {StyleSwitcher, WritableCssProp} from "@xivgear/common-ui/util/types";
 
-class SAMGaugeGui {
+export class SamSimGui extends BaseMultiCycleSimGui<SamSimResult, SamSettings> {
 
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+    protected extraAbilityUsedColumns(result: SamSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [{
             shortName: 'kenkiGauge',
             displayName: 'Kenki',
@@ -141,28 +140,17 @@ class SAMGaugeGui {
             },
         }];
     }
-}
-export class SamSimGui extends BaseMultiCycleSimGui<SamSimResult, SamSettings> {
 
     override makeCustomConfigInterface(settings: SamSettings, _updateCallback: () => void): HTMLElement | null {
         const configDiv = document.createElement("div");
 
-        const ppField = new FieldBoundFloatField(settings, "prePullMeikyo", { inputMode: 'number' });
+        const ppField = new FieldBoundFloatField(settings, "prePullMeikyo", {inputMode: 'number'});
         const potCb = new FieldBoundCheckBox(settings, "usePotion");
 
         configDiv.appendChild(labelFor("Meikyo Pre-Pull Time:", ppField));
         configDiv.appendChild(ppField);
         configDiv.appendChild(labeledCheckbox("Use Potion", potCb));
         return configDiv;
-    }
-
-    override makeAbilityUsedTable(result: SamSimResult): AbilitiesUsedTable {
-        const extraColumns = SAMGaugeGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns : ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/melee/vpr/vpr_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/melee/vpr/vpr_sheet_sim_ui.ts
@@ -1,14 +1,13 @@
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
-import {AbilitiesUsedTable} from "../../components/ability_used_table";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {BaseMultiCycleSimGui} from "../../multicyclesim_ui";
 import {VprSimResult, VprSimSettings} from "@xivgear/core/sims/melee/vpr/vpr_sheet_sim";
 import {VprExtraData} from "@xivgear/core/sims/melee/vpr/vpr_types";
 
-class VprGaugeGui {
+export class VprSimGui extends BaseMultiCycleSimGui<VprSimResult, VprSimSettings> {
 
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+    protected extraAbilityUsedColumns(result: VprSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [{
             shortName: 'serpentOfferings',
             displayName: 'Serpent Offerings',
@@ -50,8 +49,7 @@ class VprGaugeGui {
                 }
                 return document.createTextNode("");
             },
-        },
-        {
+        }, {
             shortName: 'rattlingCoils',
             displayName: 'Rattling Coils',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
@@ -88,17 +86,6 @@ class VprGaugeGui {
             },
         },
         ];
-    }
-}
-export class VprSimGui extends BaseMultiCycleSimGui<VprSimResult, VprSimSettings> {
-
-    override makeAbilityUsedTable(result: VprSimResult): AbilitiesUsedTable {
-        const extraColumns = VprGaugeGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
+++ b/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
@@ -1,4 +1,10 @@
-import {CycleProcessor, CycleSimResult, CycleSimResultFull, ExternalCycleSettings} from "@xivgear/core/sims/cycle_sim";
+import {
+    CycleProcessor,
+    CycleSimResult,
+    CycleSimResultFull,
+    DisplayRecordFinalized,
+    ExternalCycleSettings
+} from "@xivgear/core/sims/cycle_sim";
 import {SimulationGui} from "./simulation_gui";
 import {SimSettings} from "@xivgear/core/sims/sim_types";
 import {cycleSettingsGui} from "./components/cycle_settings_components";
@@ -13,9 +19,14 @@ import {quickElement} from "@xivgear/common-ui/components/util";
 import {BaseMultiCycleSim} from "@xivgear/core/sims/processors/sim_processors";
 import {AnyStringIndex} from "@xivgear/util/types";
 import {
-    col, CustomCell, CustomColumn, CustomRow,
+    col,
+    CustomCell,
+    CustomColumn,
+    CustomColumnSpec,
+    CustomRow,
     CustomTable,
-    HeaderRow, SingleCellRowOrHeaderSelection,
+    HeaderRow,
+    SingleCellRowOrHeaderSelection,
     TableSelectionModel
 } from "@xivgear/common-ui/table/tables";
 
@@ -129,14 +140,22 @@ export class BaseMultiCycleSimGui<ResultType extends CycleSimResult, InternalSet
         return out;
     }
 
-    makeAbilityUsedTable(result: ResultType): AbilitiesUsedTable {
-        return new AbilitiesUsedTable(result.displayRecords);
+    protected extraAbilityUsedColumns(result: ResultType): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+        return [];
+    }
+
+    makeAbilityUsedTable(result: ResultType, scrollRoot: HTMLElement | null = null): AbilitiesUsedTable {
+        return new AbilitiesUsedTable(result.displayRecords, this.extraAbilityUsedColumns(result), scrollRoot);
     }
 
     makeResultDisplay(result: FullResultType): HTMLElement {
         const mainResultsTable = this.makeMainResultDisplay(result.best, result.all.length > 1);
-        const abilitiesUsedTable = this.makeAbilityUsedTable(result.best);
         const mainHolder = quickElement('div', ['cycle-sim-table-holder', 'cycle-sim-main-holder'], [mainResultsTable]);
+
+        const abilitiesScrollTable = quickElement('div', ['scroll-table-holder'], []);
+        const abilitiesUsedTable = this.makeAbilityUsedTable(result.best, abilitiesScrollTable);
+        abilitiesScrollTable.append(abilitiesUsedTable);
+
         if (result.all.length > 1) {
             const rotationsTable = this.makeRotationsTable(result, mainHolder, abilitiesUsedTable);
             return quickElement('div', ['cycle-sim-results', 'cycle-sim-results-full'], [
@@ -145,7 +164,7 @@ export class BaseMultiCycleSimGui<ResultType extends CycleSimResult, InternalSet
                 ]),
                 mainHolder,
                 quickElement('div', ['cycle-sim-table-holder', 'cycle-sim-abilities-holder'], [
-                    quickElement('div', ['scroll-table-holder'], [abilitiesUsedTable]),
+                    abilitiesScrollTable,
                 ]),
             ]);
         }
@@ -154,7 +173,7 @@ export class BaseMultiCycleSimGui<ResultType extends CycleSimResult, InternalSet
             return quickElement('div', ['cycle-sim-results', 'cycle-sim-results-full'], [
                 mainHolder,
                 quickElement('div', ['cycle-sim-table-holder', 'cycle-sim-abilities-holder'], [
-                    quickElement('div', ['scroll-table-holder'], [abilitiesUsedTable]),
+                    abilitiesScrollTable,
                 ]),
             ]);
         }

--- a/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
+++ b/packages/frontend/src/scripts/sims/multicyclesim_ui.ts
@@ -144,7 +144,7 @@ export class BaseMultiCycleSimGui<ResultType extends CycleSimResult, InternalSet
         return [];
     }
 
-    makeAbilityUsedTable(result: ResultType, scrollRoot: HTMLElement | null = null): AbilitiesUsedTable {
+    makeAbilityUsedTable(result: ResultType, scrollRoot: HTMLElement | null): AbilitiesUsedTable {
         return new AbilitiesUsedTable(result.displayRecords, this.extraAbilityUsedColumns(result), scrollRoot);
     }
 

--- a/packages/frontend/src/scripts/sims/tank/drk_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/drk_sheet_sim_ui.ts
@@ -3,13 +3,13 @@ import {DrkSettings, DrkSimResult} from "@xivgear/core/sims/tank/drk/drk_sheet_s
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
 import {AbilitiesUsedTable} from "../components/ability_used_table";
 import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
-import {col, CustomColumn} from "@xivgear/common-ui/table/tables";
+import {col, CustomColumn, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {DrkExtraData} from "@xivgear/core/sims/tank/drk/drk_types";
 
 export class DrkSimGui extends BaseMultiCycleSimGui<DrkSimResult, DrkSettings> {
 
-    static generateResultColumns(result: CycleSimResult): CustomColumn<DisplayRecordFinalized, unknown, unknown>[] {
+    protected extraAbilityUsedColumns(result: DrkSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [col({
             shortName: 'bloodGauge',
             displayName: 'Blood',
@@ -182,15 +182,6 @@ export class DrkSimGui extends BaseMultiCycleSimGui<DrkSimResult, DrkSettings> {
 
         configDiv.appendChild(labeledCheckbox("Use The Blackest Night prepull", prepullTBNCB));
         return configDiv;
-    }
-
-    override makeAbilityUsedTable(result: DrkSimResult): AbilitiesUsedTable {
-        const extraColumns = DrkSimGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
@@ -1,14 +1,15 @@
 import {FieldBoundCheckBox, labeledCheckbox} from "@xivgear/common-ui/components/util";
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
-import {AbilitiesUsedTable} from "../components/ability_used_table";
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
-import {ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {GnbExtraData} from "@xivgear/core/sims/tank/gnb/gnb_types";
 import {GnbSettings, GnbSimResult} from "@xivgear/core/sims/tank/gnb/gnb_sheet_sim";
 
 export class GnbSimGui extends BaseMultiCycleSimGui<GnbSimResult, GnbSettings> {
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+
+
+    protected extraAbilityUsedColumns(result: GnbSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [
             {
                 shortName: 'cartridges',
@@ -109,15 +110,6 @@ export class GnbSimGui extends BaseMultiCycleSimGui<GnbSimResult, GnbSettings> {
 
         configDiv.appendChild(labeledCheckbox("Assume that Gnashing Fang microclips don't exist", pretendMicroclipsDontExistCB));
         return configDiv;
-    }
-
-    override makeAbilityUsedTable(result: GnbSimResult): AbilitiesUsedTable {
-        const extraColumns = GnbSimGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/tank/pld_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/pld_sheet_sim_ui.ts
@@ -9,7 +9,7 @@ import {PldSettings, PldSimResult} from "@xivgear/core/sims/tank/pld/pld_sheet_s
 import {GaugeWithText} from "@xivgear/common-ui/components/gauges";
 
 export class PldSimGui extends BaseMultiCycleSimGui<PldSimResult, PldSettings> {
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+    protected extraAbilityUsedColumns(result: PldSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [
             {
                 shortName: 'fight-or-flight',
@@ -36,15 +36,6 @@ export class PldSimGui extends BaseMultiCycleSimGui<PldSimResult, PldSettings> {
 
         configDiv.appendChild(labeledCheckbox("Use Potion", potCb));
         return configDiv;
-    }
-
-    override makeAbilityUsedTable(result: PldSimResult): AbilitiesUsedTable {
-        const extraColumns = PldSimGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
     }
 
 }

--- a/packages/frontend/src/scripts/sims/tank/war_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/war_sheet_sim_ui.ts
@@ -1,15 +1,14 @@
 import {FieldBoundCheckBox, labeledCheckbox} from "@xivgear/common-ui/components/util";
 import {WarSettings, WarSimResult} from "@xivgear/core/sims/tank/war/war_sheet_sim";
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
-import {AbilitiesUsedTable} from "../components/ability_used_table";
-import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
-import {ColDefs, CustomColumnSpec} from "@xivgear/common-ui/table/tables";
+import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
+import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
 import {WarExtraData} from "@xivgear/core/sims/tank/war/war_types";
 
 export class WarSimGui extends BaseMultiCycleSimGui<WarSimResult, WarSettings> {
 
-    static generateResultColumns(result: CycleSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
+    protected extraAbilityUsedColumns(result: WarSimResult): CustomColumnSpec<DisplayRecordFinalized, unknown, unknown>[] {
         return [{
             shortName: 'beastGauge',
             displayName: 'Beast Gauge',
@@ -52,47 +51,47 @@ export class WarSimGui extends BaseMultiCycleSimGui<WarSimResult, WarSettings> {
                 return document.createTextNode("");
             },
         },
-        {
-            shortName: 'surgingTempest',
-            displayName: 'Surging Tempest',
-            getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: PreDmgUsedAbility) => {
-                if (usedAbility?.extraData !== undefined) {
-                    const surgingTempestDuration = (usedAbility.extraData as WarExtraData).surgingTempest;
-                    const div = document.createElement('div');
-                    div.style.height = '100%';
-                    div.style.display = 'flex';
-                    div.style.alignItems = 'center';
-                    div.style.gap = '6px';
-                    div.style.padding = '2px 0 2px 0';
-                    div.style.boxSizing = 'border-box';
+            {
+                shortName: 'surgingTempest',
+                displayName: 'Surging Tempest',
+                getter: used => isFinalizedAbilityUse(used) ? used.original : null,
+                renderer: (usedAbility?: PreDmgUsedAbility) => {
+                    if (usedAbility?.extraData !== undefined) {
+                        const surgingTempestDuration = (usedAbility.extraData as WarExtraData).surgingTempest;
+                        const div = document.createElement('div');
+                        div.style.height = '100%';
+                        div.style.display = 'flex';
+                        div.style.alignItems = 'center';
+                        div.style.gap = '6px';
+                        div.style.padding = '2px 0 2px 0';
+                        div.style.boxSizing = 'border-box';
 
-                    const span = document.createElement('span');
-                    span.textContent = `${surgingTempestDuration}s`;
+                        const span = document.createElement('span');
+                        span.textContent = `${surgingTempestDuration}s`;
 
-                    const barOuter = document.createElement('div');
-                    barOuter.style.borderRadius = '20px';
-                    barOuter.style.background = '#00000033';
-                    barOuter.style.width = '120px';
-                    barOuter.style.height = 'calc(100% - 3px)';
-                    barOuter.style.display = 'inline-block';
-                    barOuter.style.overflow = 'hidden';
-                    barOuter.style.border = '1px solid black';
+                        const barOuter = document.createElement('div');
+                        barOuter.style.borderRadius = '20px';
+                        barOuter.style.background = '#00000033';
+                        barOuter.style.width = '120px';
+                        barOuter.style.height = 'calc(100% - 3px)';
+                        barOuter.style.display = 'inline-block';
+                        barOuter.style.overflow = 'hidden';
+                        barOuter.style.border = '1px solid black';
 
-                    const barInner = document.createElement('div');
-                    barInner.style.backgroundColor = '#ee9199';
-                    barInner.style.height = '100%';
-                    barInner.style.width = `${Math.round((surgingTempestDuration / 60) * 100)}%`;
-                    barOuter.appendChild(barInner);
+                        const barInner = document.createElement('div');
+                        barInner.style.backgroundColor = '#ee9199';
+                        barInner.style.height = '100%';
+                        barInner.style.width = `${Math.round((surgingTempestDuration / 60) * 100)}%`;
+                        barOuter.appendChild(barInner);
 
-                    div.appendChild(barOuter);
-                    div.appendChild(span);
+                        div.appendChild(barOuter);
+                        div.appendChild(span);
 
-                    return div;
-                }
-                return document.createTextNode("");
+                        return div;
+                    }
+                    return document.createTextNode("");
+                },
             },
-        },
         ];
     }
 
@@ -104,14 +103,4 @@ export class WarSimGui extends BaseMultiCycleSimGui<WarSimResult, WarSettings> {
         configDiv.appendChild(labeledCheckbox("Use Potion", potCb));
         return configDiv;
     }
-
-    override makeAbilityUsedTable(result: WarSimResult): AbilitiesUsedTable {
-        const extraColumns = WarSimGui.generateResultColumns(result);
-        const table = super.makeAbilityUsedTable(result);
-        const newColumns: ColDefs<DisplayRecordFinalized> = [...table.columns];
-        newColumns.splice(newColumns.findIndex(col => col.shortName === 'expected-damage') + 1, 0, ...extraColumns);
-        table.columns = newColumns;
-        return table;
-    }
-
 }

--- a/packages/frontend/src/style.less
+++ b/packages/frontend/src/style.less
@@ -276,6 +276,7 @@ img.item-rarity-relic {
 
   td, th {
     &[col-id='time'] {
+      min-width: 65px;
       width: 75px;
       max-width: 75px;
     }


### PR DESCRIPTION
Closes #561 by allowing tables to lazy evaluate rows that are not visible on screen.

Implements this for existing cycle sim UIs. Also provides a method for cycle sim UIs to directly specify their extra columns, rather than needing to override the table method itself. The former was unperformant and broke the lazy behavior because it was adding the columns after the data was already set, which meant there were multiple re-evaluations of the table.