### PR TITLE
Saved sheet improvements

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1087,6 +1087,7 @@ job-picker {
 #content-area > .my-sheets-section {
   .named-section-content-area {
     width: 600px;
+    scrollbar-gutter: stable;
 
     table.gear-sheets-table {
       overflow: auto;
@@ -1098,6 +1099,10 @@ job-picker {
         height: 23px;
         max-height: 23px;
         cursor: pointer;
+        &.dragging {
+          z-index: 5;
+          opacity: 0.75;
+        }
       }
 
       tr:first-child {
@@ -1114,8 +1119,7 @@ job-picker {
         height: 23px;
 
         &[col-id="sheetjob"] {
-          // Why does this work
-          width: 0;
+          width: 60px;
           text-align: right;
 
           img {
@@ -1153,8 +1157,28 @@ job-picker {
         }
       }
 
+      .search-row-outer {
+        cursor: unset;
+      }
+
+      .search-row {
+        display: flex;
+        gap: 5px;
+        width: 100%;
+        * {
+          box-sizing: border-box;
+        }
+        input {
+          width: 100%;
+          padding-left: 5px;
+        }
+        button {
+          aspect-ratio: 1;
+        }
+      }
+
       td[col-id="sheetactions"] {
-        width: 44px;
+        width: 52px;
         max-height: 23px;
         height: 23px;
 

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -17,6 +17,7 @@ import {
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
 import {
+    DEFAULT_SHEET_METADATA,
     EquippedItem,
     EquipSlotKey,
     EquipSlots,
@@ -38,6 +39,7 @@ import {
     SetExportExternalSingle,
     SetStatsExport,
     SheetExport,
+    SheetMetadata,
     SheetStatsExport,
     SimExport,
     Substat
@@ -309,6 +311,10 @@ export class GearPlanSheet {
         return this._saveKey;
     }
 
+    get metaSaveKey() {
+        return this._saveKey + '-meta';
+    }
+
     /**
      * Whether to show advanced stats.
      */
@@ -459,6 +465,23 @@ export class GearPlanSheet {
             this._timestamp = new Date();
             const fullExport = this.exportSheet(false);
             localStorage.setItem(this.saveKey, JSON.stringify(fullExport));
+            const msk = this.metaSaveKey;
+            const metaRaw = localStorage.getItem(msk);
+            let meta: SheetMetadata;
+            if (metaRaw) {
+                meta = {
+                    ...DEFAULT_SHEET_METADATA,
+                    ...JSON.parse(metaRaw),
+                };
+            }
+            else {
+                meta = DEFAULT_SHEET_METADATA;
+            }
+            meta = {
+                ...meta,
+                currentVersion: (meta.currentVersion ?? 1) + 1,
+            };
+            localStorage.setItem(msk, JSON.stringify(meta));
         }
         else {
             console.debug("Ignoring request to save sheet because it has no save key");

--- a/packages/frontend/src/scripts/components/saved_sheet_picker.ts
+++ b/packages/frontend/src/scripts/components/saved_sheet_picker.ts
@@ -1,33 +1,175 @@
-import {
-    col,
-    CustomCell,
-    CustomColumn,
-    CustomRow,
-    CustomTable,
-    SpecialRow,
-    TableSelectionModel,
-    TitleRow
-} from "@xivgear/common-ui/table/tables";
-import {SheetExport} from "@xivgear/xivmath/geartypes";
-import {faIcon, makeActionButton} from "@xivgear/common-ui/components/util";
+import {col, CustomRow, CustomTable, SpecialRow, TableSelectionModel} from "@xivgear/common-ui/table/tables";
+import {DEFAULT_SHEET_METADATA, SheetExport, SheetMetadata} from "@xivgear/xivmath/geartypes";
+import {faIcon, makeActionButton, quickElement} from "@xivgear/common-ui/components/util";
 import {deleteSheetByKey} from "@xivgear/core/persistence/saved_sheets";
 import {getHashForSaveKey, openSheetByKey, showNewSheetForm} from "../base_ui";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";
 import {JobIcon} from "./job_icon";
 import {JOB_DATA} from "@xivgear/xivmath/xivconstants";
 import {jobAbbrevTranslated} from "./job_name_translator";
+import {CharacterGearSet} from "@xivgear/core/gear";
+import {installDragHelper} from "./draghelpers";
 
-export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionModel<SheetExport, never, never, SheetExport | null>> {
+type SelectableSheet = {
+    key: string,
+    sheet: SheetExport,
+    meta: SheetMetadata,
+    get sortOrder(): number,
+    set sortOrder(value: number),
+    save(): void,
+}
+
+export function sheetMetaKey(sheetKey: string): string {
+    return sheetKey + '-meta';
+}
+
+export function readSheetMeta(sheetKey: string): SheetMetadata {
+    const metaKey = sheetMetaKey(sheetKey);
+    const metaRaw = localStorage.getItem(metaKey);
+    let meta: SheetMetadata;
+    if (metaRaw) {
+        meta = {
+            ...DEFAULT_SHEET_METADATA,
+            ...JSON.parse(metaRaw),
+        };
+    }
+    else {
+        meta = {
+            ...DEFAULT_SHEET_METADATA,
+        };
+    }
+    return meta;
+}
+
+class SheetManager {
+    private readonly dataMap = new Map<string, SelectableSheet>();
+    private lastData: SelectableSheet[] = [];
+
+    constructor(private readonly storage: Storage) {
+    }
+
+    readData(): SelectableSheet[] {
+        const items: SelectableSheet[] = [];
+        const outer = this;
+        for (const localStorageKey in localStorage) {
+            if (localStorageKey.startsWith("sheet-save-")) {
+                const imported = JSON.parse(this.storage.getItem(localStorageKey)) as SheetExport;
+                if (imported.saveKey) {
+                    if (this.dataMap.has(localStorageKey)) {
+                        const existing = this.dataMap.get(localStorageKey);
+                        items.push(existing);
+                        continue;
+                    }
+                    const meta = readSheetMeta(localStorageKey);
+                    const defaultSort = parseInt(localStorageKey.split('-')[2]);
+                    let dirty = false;
+                    const item = {
+                        key: localStorageKey,
+                        sheet: imported,
+                        meta: meta,
+                        get sortOrder(): number {
+                            if (meta.sortOrder !== null) {
+                                return meta.sortOrder;
+                            }
+                            return defaultSort;
+                        },
+                        set sortOrder(value: number) {
+                            console.log("new sort", value);
+                            meta.sortOrder = value;
+                            dirty = true;
+                        },
+                        save() {
+                            if (!dirty) {
+                                return;
+                            }
+                            const metaKey = sheetMetaKey(localStorageKey);
+                            outer.storage.setItem(metaKey, JSON.stringify(this.meta));
+                            dirty = false;
+                        },
+                    } satisfies SelectableSheet;
+                    this.dataMap.set(localStorageKey, item);
+                    items.push(item);
+                }
+            }
+        }
+        this.lastData = items;
+        // This has the effect of also sorting items
+        this.resort();
+        return items;
+    }
+
+    reorderTo(draggedSheet: SelectableSheet, draggedTo: SelectableSheet) {
+        // Index where we want the dragged sheet to go to
+        const fromIndex = this.lastData.indexOf(draggedSheet);
+        const toIndex = this.lastData.indexOf(draggedTo);
+        const lastIndex = this.lastData.length - 1;
+        // Four scenarios:
+        // 1. Sheet is dragged to a position between two other sheets
+        //  In this case, we can just set the sheet's sort order to be between the two other sheets
+        // 2. Sheet is dragged to the end of the list
+        //  In this case, we can set the sheet's sort order to the last item's index minus one
+        // 3. Sheet is dragged to the beginning of the list
+        //  In this case, we need to be careful - we want a *new* sheet to still be at the top of the list,
+        //  so we set the sort order to be the index of the first sheet plus a very small amount.
+        // 4. Sheet is dragged to itself
+        //  No-op
+        // TODO: needs to re-sort this.lastData
+        if (toIndex === 0) {
+            // Scenario 3
+            draggedSheet.sortOrder = draggedTo.sortOrder + 0.0001;
+        }
+        else if (toIndex === lastIndex) {
+            draggedSheet.sortOrder = draggedTo.sortOrder - 1;
+        }
+        else if (draggedSheet === draggedTo) {
+            // No-op
+            return;
+        }
+        else {
+            // In-between
+            // e.g. if index 4 is dragged to index 1, then it should push the existing index 1 down by taking on a
+            // sort order value between the current index 0 and 1.
+            // If index 4 is dragged to index 6, then it should push the existing index 6 up by taking on a sort
+            // order value between the current index 6 and 7.
+            const isDown: boolean = toIndex > fromIndex;
+            const secondBasisIndex = toIndex + (isDown ? 1 : -1);
+            const secondBasis = this.lastData[secondBasisIndex].sortOrder;
+            const primaryBasis = draggedTo.sortOrder;
+            const newSort = (primaryBasis + secondBasis) / 2;
+            draggedSheet.sortOrder = newSort;
+        }
+        this.resort();
+    }
+
+    private resort() {
+        this.lastData.sort((left, right) => {
+            return right.sortOrder - left.sortOrder;
+        });
+
+    }
+
+    flush(): void {
+        this.lastData.forEach(item => item.save());
+    }
+}
+
+
+export class SheetPickerTable extends CustomTable<SelectableSheet, TableSelectionModel<SelectableSheet, never, never, SelectableSheet | null>> {
+    private readonly mgr: SheetManager;
+
     constructor() {
         super();
         this.classList.add("gear-sheets-table");
         this.classList.add("hoverable");
+        const outer = this;
+        this.mgr = new SheetManager(localStorage);
         this.columns = [
-            {
+            col({
                 shortName: "sheetactions",
                 displayName: "",
                 getter: sheet => sheet,
-                renderer: (sheet: SheetExport) => {
+                renderer: (sel: SelectableSheet) => {
+                    const sheet = sel.sheet;
                     const div = document.createElement("div");
                     div.appendChild(makeActionButton([faIcon('fa-trash-can')], (ev) => {
                         if (confirmDelete(ev, `Delete sheet '${sheet.name}'?`)) {
@@ -47,17 +189,93 @@ export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionMod
                     newTabLink.classList.add('borderless-button');
                     newTabLink.title = `Open sheet '${sheet.name}' in a new tab/window`;
                     div.appendChild(newTabLink);
+                    // Reorder dragger
+                    const dragger = document.createElement('button');
+                    dragger.title = 'Drag to re-order this set';
+                    dragger.textContent = '≡';
+                    dragger.classList.add('drag-handle');
+                    let rowBeingDragged: null | CustomRow<CharacterGearSet> = null;
+                    let lastDelta: number = 0;
+                    installDragHelper({
+                        dragHandle: dragger,
+                        dragOuter: outer,
+                        downHandler: (ev) => {
+                            let target = ev.target;
+                            while (target) {
+                                if (target instanceof CustomRow) {
+                                    console.log('Drag start: ' + target);
+                                    rowBeingDragged = target;
+                                    rowBeingDragged.classList.add('dragging');
+                                    return;
+                                }
+                                else if (target instanceof Node) {
+                                    target = target.parentElement as EventTarget;
+                                }
+                                else {
+                                    break;
+                                }
+                            }
+                            rowBeingDragged = null;
+                        },
+                        moveHandler: (ev) => {
+                            if (!rowBeingDragged) {
+                                return;
+                            }
+                            // let target = ev.target;
+                            const dragY = ev.clientY;
+                            const target = this._rows.find(row => {
+                                const el = row.element;
+                                if (!el || el === rowBeingDragged) {
+                                    return false;
+                                }
+                                const br = el.getBoundingClientRect();
+                                // Since rows are not necessarily the same height, instead of just checking bounds
+                                // normally, we need to account for the height of whichever is larger.
+                                const effectiveHeight = Math.min(br.height, rowBeingDragged.getBoundingClientRect().height);
+                                return br.y < dragY && dragY < (br.y + effectiveHeight);
+                            });
+                            if (target instanceof CustomRow) {
+                                this.mgr.reorderTo(sel, target.dataItem);
+                                outer.readData();
+                            }
+                            const rect = rowBeingDragged.getBoundingClientRect();
+                            const delta = ev.pageY - (rect.y - lastDelta) - (rect.height / 2);
+                            lastDelta = delta;
+                            rowBeingDragged.style.top = `${delta}px`;
+                        },
+                        upHandler: () => {
+                            // this.sheet.requestSave();
+                            lastDelta = 0;
+                            rowBeingDragged.style.top = '';
+                            rowBeingDragged.classList.remove('dragging');
+                            console.log('Drag end');
+                            rowBeingDragged = null;
+                            outer.mgr.flush();
+                        },
+                    });
+                    div.appendChild(dragger);
                     return div;
                 },
-            },
+            }),
+            // col({
+            //     // TODO remove
+            //     shortName: "sort",
+            //     displayName: "Sort",
+            //     getter: sheet => {
+            //         return sheet.sortOrder;
+            //     },
+            //     // renderer: job => {
+            //     //     return jobAbbrevTranslated(job);
+            //     // },
+            // }),
             col({
                 shortName: "sheetjob",
                 displayName: "Job",
                 getter: sheet => {
-                    if (sheet.isMultiJob) {
-                        return JOB_DATA[sheet.job].role;
+                    if (sheet.sheet.isMultiJob) {
+                        return JOB_DATA[sheet.sheet.job].role;
                     }
-                    return sheet.job;
+                    return sheet.sheet.job;
                 },
                 renderer: job => {
                     return jobAbbrevTranslated(job);
@@ -67,10 +285,10 @@ export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionMod
                 shortName: "sheetjobicon",
                 displayName: "Job Icon",
                 getter: sheet => {
-                    if (sheet.isMultiJob) {
-                        return JOB_DATA[sheet.job].role;
+                    if (sheet.sheet.isMultiJob) {
+                        return JOB_DATA[sheet.sheet.job].role;
                     }
-                    return sheet.job;
+                    return sheet.sheet.job;
                 },
                 renderer: jobOrRole => {
                     return new JobIcon(jobOrRole);
@@ -79,36 +297,34 @@ export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionMod
             {
                 shortName: "sheetlevel",
                 displayName: "Lvl",
-                getter: sheet => sheet.level,
+                getter: sheet => sheet.sheet.level,
                 fixedWidth: 40,
             },
             {
                 shortName: "sheetname",
                 displayName: "Sheet Name",
-                getter: sheet => sheet.name,
+                getter: sheet => sheet.sheet.name,
             },
         ];
         this.readData();
         this.selectionModel = {
-            clickCell(cell: CustomCell<SheetExport, SheetExport>) {
-
+            clickCell() {
             },
-            clickColumnHeader(col: CustomColumn<SheetExport>) {
-
+            clickColumnHeader() {
             },
-            clickRow(row: CustomRow<SheetExport>) {
-                openSheetByKey(row.dataItem.saveKey);
+            clickRow(row: CustomRow<SelectableSheet>) {
+                openSheetByKey(row.dataItem.key);
             },
-            getSelection(): SheetExport | null {
+            getSelection(): null {
                 return null;
             },
-            isCellSelectedDirectly(cell: CustomCell<SheetExport, SheetExport>) {
+            isCellSelectedDirectly() {
                 return false;
             },
-            isColumnHeaderSelected(col: CustomColumn<SheetExport>) {
+            isColumnHeaderSelected() {
                 return false;
             },
-            isRowSelected(row: CustomRow<SheetExport>) {
+            isRowSelected() {
                 return false;
             },
             clearSelection(): void {
@@ -119,7 +335,8 @@ export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionMod
 
     readData() {
         const data: typeof this.data = [];
-        data.push(new SpecialRow((table) => {
+        // "New sheet" button/row
+        data.push(new SpecialRow(() => {
             const div = document.createElement("div");
             div.replaceChildren(faIcon('fa-plus', 'fa-solid'), 'New Sheet');
             return div;
@@ -127,25 +344,45 @@ export class SheetPickerTable extends CustomTable<SheetExport, TableSelectionMod
             row.classList.add('special-row-hoverable', 'new-sheet-row');
             row.addEventListener('click', () => startNewSheet());
         }));
-        const items: SheetExport[] = [];
-        for (const localStorageKey in localStorage) {
-            if (localStorageKey.startsWith("sheet-save-")) {
-                const imported = JSON.parse(localStorage.getItem(localStorageKey)) as SheetExport;
-                if (imported.saveKey) {
-                    items.push(imported);
+        // Search row
+        data.push(new SpecialRow(() => {
+            const searchBox = document.createElement("input");
+            searchBox.type = 'text';
+            searchBox.placeholder = "Search";
+            const clearBtn = makeActionButton('X', () => {
+                searchBox.value = '';
+                searchBox.dispatchEvent(new Event('input'));
+            });
+            clearBtn.disabled = true;
+            searchBox.addEventListener('input', () => {
+                const searchValue = (searchBox.value ?? '').toLowerCase().trim();
+                clearBtn.disabled = !searchValue;
+                this.search(searchValue);
+            });
+            return quickElement('div', ['search-row'], [clearBtn, searchBox]);
+        }, row => {
+            row.classList.add('search-row-outer');
+        }));
+        const items: SelectableSheet[] = this.mgr.readData();
+        data.push(...items);
+        this.data = data;
+    }
+
+    search(searchValue: string | null) {
+        this.dataRowMap.forEach(row => {
+            if (!searchValue) {
+                // Display everything if no search value
+                row.style.display = '';
+            }
+            else {
+                if (row.textContent.toLowerCase().includes(searchValue)) {
+                    row.style.display = '';
+                }
+                else {
+                    row.style.display = 'none';
                 }
             }
-        }
-        if (items.length === 0) {
-            data.push(new TitleRow("You don't have any sheets. Click 'New Sheet' to get started."));
-        }
-        else {
-            items.sort((left, right) => {
-                return parseInt(right.saveKey.split('-')[2]) - parseInt(left.saveKey.split('-')[2]);
-            });
-            data.push(...items);
-        }
-        this.data = data;
+        });
     }
 }
 

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -735,6 +735,22 @@ export interface SheetExport {
     specialStats?: string | null,
 }
 
+export type SheetMetadata = {
+    currentVersion: number,
+    lastSyncedVersion: number,
+    sortOrder: number | null,
+    hasConflict: boolean,
+    forcePush: boolean,
+}
+
+export const DEFAULT_SHEET_METADATA: SheetMetadata = {
+    currentVersion: 1,
+    lastSyncedVersion: 0,
+    sortOrder: null,
+    hasConflict: false,
+    forcePush: false,
+};
+
 export type CustomItemExport = {
     ilvl: number;
     equipLvl: number;


### PR DESCRIPTION
- Adds the ability to re-order saved sheets by dragging the drag handle like how you can re-order sets
- Adds a search box to the saved sheet picker (searches all text within the row)
- Introduces the concept of "saved sheet metadata" which will later be used as part of #649 to track sheet syncing