### PR TITLE
Don't add ' copy' to the name of newly imported sheets

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13160,6 +13160,7 @@
       }
     },
     "packages/user-data-client": {
+      "name": "@xivgear/user-data-client",
       "version": "1.0.0"
     },
     "packages/util": {

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -198,7 +198,13 @@ export class SaveAsModal extends BaseModal {
         super();
         this.headerText = 'Save As';
         const form = document.createElement('form');
-        const defaultName = existingSheet.sheetName === SHARED_SET_NAME ? 'Imported Set' : existingSheet.sheetName + ' copy';
+
+        let defaultName = existingSheet.sheetName;
+        // Add 'copy' to the name if we're copying a sheet that has been saved, or one that's in view only mode.
+        if (existingSheet.saveKey !== undefined || existingSheet.isViewOnly) {
+            defaultName = existingSheet.sheetName === SHARED_SET_NAME ? SHARED_SET_NAME :  existingSheet.sheetName + ' copy';
+        }
+
         this.fieldSet = new NewSheetFormFieldSet({
             job: existingSheet.classJobName,
             level: existingSheet.level,


### PR DESCRIPTION
Live:
![image](https://github.com/user-attachments/assets/46243a57-e4c0-47f5-91b6-a7f8dfea734d)

Local:
![image](https://github.com/user-attachments/assets/14c0e785-5527-48d6-89e6-121e9ee4068e)

Still adds 'copy' for exported sheets, or existing saved sheets
Exported:
![image](https://github.com/user-attachments/assets/1731d3ab-76eb-4200-ac7a-d43660a2991f)

Existing:
![image](https://github.com/user-attachments/assets/c598eb9b-50b7-4439-b82e-d6b79541e7a3)
