### PR TITLE
Always show level sync info on small screens

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2567,6 +2567,10 @@ div.labeled-checkbox {
       }
     }
 
+    .level-sync-info {
+      display: inline-block;
+    }
+
     .show-hide-button {
       display: revert;
     }

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1494,6 +1494,16 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
         const sheetOptions = new DropdownActionMenu('More Actions...');
 
+        const siFmt = formatSyncInfo(this.syncInfo, this.level);
+        if (siFmt !== null) {
+            const span = quickElement('span', [], [siFmt]);
+            const ilvlSyncLabel = quickElement('div', ['like-a-button', 'level-sync-info'], [span]);
+            ilvlSyncLabel.title = 'To change the item level sync, click the "Save As" button to create a new sheet with a different level/ilvl.';
+            ilvlSyncLabel.setAttribute("display", "inline-block");
+            //ilvlSyncLabel.classList.add('level-sync-info');
+            buttonsArea.appendChild(ilvlSyncLabel);
+        }
+
         if (!this.isViewOnly) {
             const addRowButton = makeActionButton("New Gear Set", () => {
                 const newSet = new CharacterGearSet(this);
@@ -1523,10 +1533,6 @@ export class GearPlanSheetGui extends GearPlanSheet {
                     this.addGearSet(set, undefined, true);
                 },
             });
-            // const renameButton = makeActionButton("Sheet Name/Description", () => {
-            //     startRenameSheet(this);
-            // });
-            // buttonsArea.appendChild(renameButton);
             buttonsArea.appendChild(sheetOptions);
         }
         sheetOptions.addAction({
@@ -1536,14 +1542,6 @@ export class GearPlanSheetGui extends GearPlanSheet {
                 new SheetInfoModal(this, selectedGearSet).attachAndShow();
             },
         });
-
-        const siFmt = formatSyncInfo(this.syncInfo, this.level);
-        if (siFmt !== null) {
-            const span = quickElement('span', [], [siFmt]);
-            const ilvlSyncLabel = quickElement('div', ['like-a-button'], [span]);
-            ilvlSyncLabel.title = 'To change the item level sync, click the "Save As" button to create a new sheet with a different level/ilvl.';
-            buttonsArea.appendChild(ilvlSyncLabel);
-        }
 
         if (this.isViewOnly) {
             const saveAsButton = makeActionButton("Save As", () => {

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1497,7 +1497,6 @@ export class GearPlanSheetGui extends GearPlanSheet {
             const span = quickElement('span', [], [siFmt]);
             const ilvlSyncLabel = quickElement('div', ['like-a-button', 'level-sync-info'], [span]);
             ilvlSyncLabel.title = 'To change the item level sync, click the "Save As" button to create a new sheet with a different level/ilvl.';
-            ilvlSyncLabel.setAttribute("display", "inline-block");
             buttonsArea.appendChild(ilvlSyncLabel);
         }
 

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1500,7 +1500,6 @@ export class GearPlanSheetGui extends GearPlanSheet {
             const ilvlSyncLabel = quickElement('div', ['like-a-button', 'level-sync-info'], [span]);
             ilvlSyncLabel.title = 'To change the item level sync, click the "Save As" button to create a new sheet with a different level/ilvl.';
             ilvlSyncLabel.setAttribute("display", "inline-block");
-            //ilvlSyncLabel.classList.add('level-sync-info');
             buttonsArea.appendChild(ilvlSyncLabel);
         }
 

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1489,8 +1489,6 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
         this._gearPlanTable = new GearPlanTable(this, item => this.editorItem = item);
         this.showAdvancedStats = SETTINGS.viewDetailedStats ?? false;
-        // Buttons and controls at the bottom of the table
-        // this.buttonRow.id = 'gear-sheet-button-row';
 
         const sheetOptions = new DropdownActionMenu('More Actions...');
 


### PR DESCRIPTION
I also made the decision to move it to the front in edit mode too, so that it wouldn't move around.
Before:
![image](https://github.com/user-attachments/assets/51a30f29-11fc-4ff4-b2b3-367a494237d4)
![image](https://github.com/user-attachments/assets/16f3d89d-1ba7-48e9-b78a-584433a21aab)



After:
![image](https://github.com/user-attachments/assets/42c342ac-5735-4383-8de4-0cb3ab4ad5f7)
![image](https://github.com/user-attachments/assets/6891d141-5b03-483c-b3e0-c336b70c9922)
