### PR TITLE
Updated BLM sim

### DIFF
--- a/packages/core/src/sims/caster/blm/blm_actions.ts
+++ b/packages/core/src/sims/caster/blm/blm_actions.ts
@@ -1,110 +1,150 @@
-import {BlmGcdAbility, BlmOgcdAbility, FirestarterBuff, LeyLinesBuff, SwiftcastBuff, TriplecastBuff} from "./blm_types";
+import {HasGaugeUpdate, HasGaugeCondition} from "@xivgear/core/sims/sim_types";
+import {BlmGaugeManager} from "./blm_gauge";
+import {BlmElement, BlmGcdAbility, BlmOgcdAbility, FirestarterBuff, LeyLinesBuff, SwiftcastBuff, TriplecastBuff} from "./blm_types";
 
 // GCDs
 
 export const Fire3: BlmGcdAbility = {
     type: 'gcd',
     name: "Fire III",
-    element: 'fire',
+    element: BlmElement.Fire,
     id: 152,
     potency: 290,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 1.292,
     cast: 3.5,
-    mp: 2000,
-    updateGaugeLegacy: gauge => {
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.updateForFireSpell(2000);
         gauge.giveAstralFire(3);
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.canUseFireSpell(2000);
     },
 };
 
 export const Fire4: BlmGcdAbility = {
     type: 'gcd',
     name: "Fire IV",
-    element: 'fire',
+    element: BlmElement.Fire,
     id: 3577,
     potency: 300,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 1.159,
     cast: 2.0,
-    mp: 800,
-    updateGaugeLegacy: gauge => gauge.astralSoul += 1,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.updateForFireSpell(800);
+        gauge.astralSoul += 1;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.isInFire() && gauge.canUseFireSpell(800);
+    },
 };
 
 export const Flare: BlmGcdAbility = {
     type: 'gcd',
     name: "Flare",
-    element: 'fire',
+    element: BlmElement.Fire,
     id: 162,
     potency: 240,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 1.157,
     cast: 2.0,
-    mp: 'flare',
-    updateGaugeLegacy: gauge => gauge.astralSoul += 3,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.updateForFireSpell('flare');
+        gauge.astralSoul += 3;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.isInFire() && gauge.canUseFireSpell('flare');
+    },
 };
 
 export const FlareStar: BlmGcdAbility = {
     type: 'gcd',
     name: "Flare Star",
-    element: 'fire',
+    element: BlmElement.Fire,
     id: 36989,
     potency: 500,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 0.622,
     cast: 2.0,
-    mp: 0,
-    updateGaugeLegacy: gauge => gauge.astralSoul -= 6,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.astralSoul = 0;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.astralSoul === 6;
+    },
 };
 
 export const Despair: BlmGcdAbility = {
     type: 'gcd',
     name: "Despair",
-    element: 'fire',
+    element: BlmElement.Fire,
     id: 16505,
     potency: 300,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 0.556,
     cast: 2.0,
-    mp: 'all',
-    updateGaugeLegacy: gauge => gauge.paradox = false,
+    levelModifiers: [
+        {
+            minLevel: 100,
+            cast: 0,
+        },
+    ],
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.updateForFireSpell('despair');
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.canUseFireSpell('despair');
+    },
 };
 
 export const Blizzard3: BlmGcdAbility = {
     type: 'gcd',
     name: "Blizzard III",
-    element: 'ice',
+    element: BlmElement.Ice,
     id: 154,
     potency: 290,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 0.890,
     cast: 3.5,
-    mp: 800,
-    updateGaugeLegacy: gauge => gauge.giveUmbralIce(3),
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.updateForIceSpell(800);
+        gauge.giveUmbralIce(3);
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.canUseIceSpell(800);
+    },
 };
 
 export const Blizzard4: BlmGcdAbility = {
     type: 'gcd',
     name: "Blizzard IV",
-    element: 'ice',
+    element: BlmElement.Ice,
     id: 3576,
     potency: 300,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 1.158,
-    cast: 3.5,
-    mp: 800,
-    updateGaugeLegacy: gauge => gauge.umbralHearts += 3,
+    cast: 2.0,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.updateForIceSpell(800);
+        gauge.umbralHearts += 3;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.isInIce() && gauge.canUseIceSpell(800);
+    },
 };
 
 export const Thunder3: BlmGcdAbility = {
     type: 'gcd',
     name: "Thunder III",
+    element: BlmElement.Thunder,
     id: 153,
     potency: 120,
     dot: {
@@ -116,12 +156,18 @@ export const Thunder3: BlmGcdAbility = {
     gcd: 2.5,
     appDelay: 1.025,
     cast: 0,
-    mp: 0,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.thunderhead = false;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.thunderhead;
+    },
 };
 
 export const HighThunder: BlmGcdAbility = {
     type: 'gcd',
     name: "High Thunder",
+    element: BlmElement.Thunder,
     id: 36986,
     potency: 150,
     dot: {
@@ -133,25 +179,60 @@ export const HighThunder: BlmGcdAbility = {
     gcd: 2.5,
     appDelay: 0.757,
     cast: 0,
-    mp: 0,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.thunderhead = false;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.thunderhead;
+    },
 };
 
 export const Xenoglossy: BlmGcdAbility = {
     type: 'gcd',
     name: "Xenoglossy",
+    element: BlmElement.Unaspected,
     id: 16507,
     potency: 890,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 0.630,
     cast: 0,
-    mp: 0,
-    updateGaugeLegacy: gauge => gauge.polyglot -= 1,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.polyglot -= 1;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.polyglot > 0;
+    },
+};
+
+export const Foul: BlmGcdAbility = {
+    type: 'gcd',
+    name: "Foul",
+    element: BlmElement.Unaspected,
+    id: 7422,
+    potency: 600,
+    attackType: "Spell",
+    gcd: 2.5,
+    appDelay: 0.630,
+    cast: 2.0,
+    levelModifiers: [
+        {
+            minLevel: 80,
+            cast: 0,
+        },
+    ],
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.polyglot -= 1;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.polyglot > 0;
+    },
 };
 
 export const FireParadox: BlmGcdAbility = {
     type: 'gcd',
     name: "Paradox",
+    element: BlmElement.Unaspected,
     id: 25797,
     potency: 540,
     attackType: "Spell",
@@ -159,26 +240,37 @@ export const FireParadox: BlmGcdAbility = {
     gcd: 2.5,
     appDelay: 0.624,
     cast: 0,
-    mp: 1600,
-    updateGaugeLegacy: gauge => gauge.paradox = false,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.paradox = false;
+        gauge.magicPoints -= 1600;
+        gauge.firestarter = true;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.isInFire() && gauge.magicPoints >= 1600 && gauge.paradox;
+    },
 };
 
 export const IceParadox: BlmGcdAbility = {
     type: 'gcd',
     name: "Paradox",
+    element: BlmElement.Unaspected,
     id: 25797,
     potency: 540,
     attackType: "Spell",
     gcd: 2.5,
     appDelay: 0.624,
     cast: 0,
-    mp: 0,
-    updateGaugeLegacy: gauge => gauge.paradox = false,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.paradox = false;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.isInIce() && gauge.paradox;
+    },
 };
 
 // oGCDs
 
-export const Transpose: BlmOgcdAbility = {
+export const Transpose: BlmOgcdAbility & HasGaugeUpdate<BlmGaugeManager> = {
     type: 'ogcd',
     name: "Transpose",
     id: 149,
@@ -188,12 +280,12 @@ export const Transpose: BlmOgcdAbility = {
         time: 5,
     },
     appDelay: 0,
-    updateGaugeLegacy: gauge => {
-        if (gauge.aspect > 0) {
+    updateGauge: (gauge: BlmGaugeManager) => {
+        if (gauge.isInFire()) {
             // From AFx to UI1
             gauge.giveUmbralIce(1);
         }
-        else if (gauge.aspect < 0) {
+        else if (gauge.isInIce()) {
             // From UIx to AF1
             gauge.giveAstralFire(1);
         }
@@ -251,7 +343,7 @@ export const LeyLines: BlmOgcdAbility = {
     appDelay: 0.491,
 };
 
-export const Amplifier: BlmOgcdAbility = {
+export const Amplifier: BlmOgcdAbility & HasGaugeUpdate<BlmGaugeManager> & HasGaugeCondition<BlmGaugeManager> = {
     type: 'ogcd',
     name: "Amplifier",
     id: 25796,
@@ -262,10 +354,15 @@ export const Amplifier: BlmOgcdAbility = {
         charges: 1,
     },
     appDelay: 0,
-    updateGaugeLegacy: gauge => gauge.polyglot += 1,
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.polyglot += 1;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.isInIce() || gauge.isInFire();
+    },
 };
 
-export const Manafont: BlmOgcdAbility = {
+export const Manafont: BlmOgcdAbility & HasGaugeUpdate<BlmGaugeManager> & HasGaugeCondition<BlmGaugeManager> = {
     type: 'ogcd',
     name: "Manafont",
     id: 158,
@@ -285,9 +382,14 @@ export const Manafont: BlmOgcdAbility = {
             },
         },
     ],
-    updateGaugeLegacy: gauge => {
-        gauge.magicPoints += 10000;
-        gauge.umbralHearts += 3;
+    updateGauge: (gauge: BlmGaugeManager) => {
+        gauge.magicPoints = 10000;
+        gauge.giveAstralFire(3);
+        gauge.thunderhead = true;
+        gauge.umbralHearts = 3;
         gauge.paradox = true;
+    },
+    gaugeConditionSatisfied: (gauge: BlmGaugeManager): boolean => {
+        return gauge.isInFire();
     },
 };

--- a/packages/core/src/sims/caster/blm/blm_gauge.ts
+++ b/packages/core/src/sims/caster/blm/blm_gauge.ts
@@ -1,27 +1,53 @@
-import {BlmGaugeState} from "./blm_types";
+import {GaugeManager} from "@xivgear/core/sims/cycle_sim";
+import {BlmElement, BlmGaugeState, BlmAbility} from "./blm_types";
+import {fl} from "@xivgear/xivmath/xivmath";
 
 const damageUpModifiers = [1.4, 1.6, 1.8];
 const damageDownModifiers = [0.9, 0.8, 0.7];
 
-export class BlmGauge {
+export class BlmGaugeManager implements GaugeManager<BlmGaugeState> {
 
-    private _aspect: number = 0;
-    private _umbralHearts: number = 0;
+    private _level: number;
     private _magicPoints: number = 10000;
+    private _element: BlmElement = BlmElement.Unaspected;
+    private _elementLevel: number = 0;
+    private _firestarter: boolean = false;
+    private _thunderhead: boolean = false;
+    private _umbralHearts: number = 0;
     private _polyglot: number = 0;
     private _paradox: boolean = false;
     private _astralSoul: number = 0;
 
-    get aspect(): number {
-        return this._aspect;
+    constructor(level: number) {
+        this._level = level;
     }
 
-    get umbralHearts(): number {
-        return this._umbralHearts;
+    get level(): number {
+        return this._level;
     }
 
     get magicPoints(): number {
         return this._magicPoints;
+    }
+
+    get element(): BlmElement {
+        return this._element;
+    }
+
+    get elementLevel(): number {
+        return this._elementLevel;
+    }
+
+    get firestarter(): boolean {
+        return this._firestarter;
+    }
+
+    get thunderhead(): boolean {
+        return this._thunderhead;
+    }
+
+    get umbralHearts(): number {
+        return this._umbralHearts;
     }
 
     get polyglot(): number {
@@ -36,17 +62,10 @@ export class BlmGauge {
         return this._astralSoul;
     }
 
-    set aspect(newAspect: number) {
-        this._aspect = Math.max(Math.min(newAspect, 3), -3);
-    }
-
-    set umbralHearts(newUmbralHearts: number) {
-        this._umbralHearts = Math.max(Math.min(newUmbralHearts, 3), 0);
-    }
-
     set magicPoints(newGauge: number) {
         if (newGauge > 10000) {
-            console.warn(`[BLM Sim] Overcapped MP by ${newGauge - 10000}.`);
+            // No need to log this actually.
+            //console.log(`[BLM Sim] Overcapped MP by ${newGauge - 10000}. (This is probably not a problem)`);
         }
         if (newGauge < 0) {
             console.warn(`[BLM Sim] Used ${this._magicPoints - newGauge} MP when you only have ${this._magicPoints}.`);
@@ -54,9 +73,33 @@ export class BlmGauge {
         this._magicPoints = Math.max(Math.min(newGauge, 10000), 0);
     }
 
+    set element(newElement: BlmElement) {
+        this._element = newElement;
+    }
+
+    set elementLevel(newElementLevel: number) {
+        this._elementLevel = newElementLevel;
+    }
+
+    set firestarter(newFirestarter: boolean) {
+        if (this._firestarter && newFirestarter) {
+            console.warn(`[BLM Sim] Overwrote Firestarter. (This may be intended)`);
+        }
+        this._firestarter = newFirestarter;
+    }
+
+    set thunderhead(newThunderhead: boolean) {
+        this._thunderhead = newThunderhead;
+    }
+
+    set umbralHearts(newUmbralHearts: number) {
+        this._umbralHearts = Math.max(Math.min(newUmbralHearts, 3), 0);
+    }
+
     set polyglot(newPolyglot: number) {
-        if (newPolyglot > 3) {
-            console.warn(`[BLM Sim] Overcapped Polyglot by ${newPolyglot - 3}.`);
+        // Levels for polyglot charges
+        if (newPolyglot > this.getMaxPolyglotCharges()) {
+            console.warn(`[BLM Sim] Overcapped Polyglot by ${newPolyglot - this.getMaxPolyglotCharges()}.`);
         }
         if (newPolyglot < 0) {
             console.warn(`[BLM Sim] Used ${this._polyglot - newPolyglot} Polyglot when you only have ${this._polyglot}.`);
@@ -65,6 +108,9 @@ export class BlmGauge {
     }
 
     set paradox(newParadox: boolean) {
+        // If below level 90, just don't.
+        if (this.level < 90) return;
+
         if (this._paradox && newParadox) {
             console.warn("[BLM Sim] Overwrote Paradox.");
         }
@@ -72,6 +118,9 @@ export class BlmGauge {
     }
 
     set astralSoul(newAstralSoul: number) {
+        // If below level 100, just don't.
+        if (this.level < 100) return;
+
         if (newAstralSoul > 6) {
             console.warn(`[BLM Sim] Overcapped Astral Soul by ${newAstralSoul - 6}.`);
         }
@@ -81,89 +130,150 @@ export class BlmGauge {
         this._astralSoul = Math.max(Math.min(newAstralSoul, 6), 0);
     }
 
+    getMaxPolyglotCharges(): number {
+        if (this.level >= 98) {
+            return 3;
+        }
+        else if (this.level >= 80) {
+            return 2;
+        }
+        else {
+            return 1;
+        }
+    }
+
+    getEnochianModifier(): number {
+        if (this.level >= 96) {
+            return 1.27;
+        }
+        else if (this.level >= 86) {
+            return 1.22;
+        }
+        else if (this.level >= 78) {
+            return 1.15;
+        }
+        else {
+            return 1.10;
+        }
+    }
+
+    isIn(element: BlmElement, level: number = 1): boolean {
+        return this.element === element && this.elementLevel >= level;
+    }
+
+    isInFire(level: number = 1): boolean {
+        return this.isIn(BlmElement.Fire, level);
+    }
+
+    isInIce(level: number = 1): boolean {
+        return this.isIn(BlmElement.Ice, level);
+    }
+
     giveAstralFire(level: number) {
+        // Entering from no element or from UI gives Thunderhead.
+        if (!this.isInFire()) {
+            this.thunderhead = true;
+        }
         // Switching from UI3 gives Paradox.
-        if (this.aspect === -3) {
+        if (this.isInIce(3)) {
             this.paradox = true;
         }
-        this.aspect = level;
+        this.element = BlmElement.Fire;
+        this.elementLevel = level;
     }
 
     giveUmbralIce(level: number) {
+        // Entering from no element or from UI gives Thunderhead.
+        if (!this.isInIce()) {
+            this.thunderhead = true;
+        }
         // Switching from AF3 gives Paradox.
-        if (this.aspect === +3) {
+        if (this.isInFire(3)) {
             this.paradox = true;
         }
         // Switching from any level of AF removes all stacks of Astral Soul.
-        if (this.aspect > 0) {
+        if (this.isInFire()) {
             this.astralSoul = 0;
         }
-        this.aspect = -level;
+        this.element = BlmElement.Ice;
+        this.elementLevel = level;
     }
 
-    getFireMpMulti(): number {
-        // Fire spells cost no MP in umbral ice.
-        if (this.aspect < 0) {
-            return 0;
+    // Gets Fire/Ice spells with potency/cast time/MP cost adjusted for the current element.
+    getAdjustedAbility(ability: BlmAbility): BlmAbility {
+        const mods = {
+            potency: ability.potency,
+            cast: ability.cast ?? 0,
+        };
+        if (ability.element === BlmElement.Fire) {
+            mods.potency *= this._getFirePotencyMulti();
+            mods.cast *= this._getFireCastMulti();
         }
-        // Only increased MP cost if AF3 and no umbral hearts.
-        if (this.aspect === +3 && this.umbralHearts === 0) {
-            return 2;
+        else if (ability.element === BlmElement.Ice) {
+            mods.potency *= this._getIcePotencyMulti();
+            mods.cast *= this._getIceCastMulti();
         }
-        return 1;
+        // Enochian damage buff if Fire/Ice active.
+        if (this.element !== BlmElement.Unaspected) {
+            if (this.level >= 96) {
+                mods.potency *= 1.27;
+            }
+            else if (this.level >= 86) {
+                mods.potency *= 1.22;
+            }
+            else if (this.level >= 78) {
+                mods.potency *= 1.15;
+            }
+            else if (this.level >= 70) {
+                mods.potency *= 1.10;
+            }
+        }
+        return {...ability, ...mods};
     }
 
-    getIceMpMulti(): number {
-        // Ice spells only cost MP with no element at all.
-        if (this.aspect !== 0) {
-            return 0;
+    private _getFirePotencyMulti(): number {
+        if (this.isInFire()) {
+            return damageUpModifiers[this.elementLevel - 1];
         }
-        return 1;
-    }
-
-    getFirePotencyMulti(): number {
-        if (this.aspect > 0) {
-            return damageUpModifiers[this.aspect - 1];
-        }
-        else if (this.aspect < 0) {
-            return damageDownModifiers[-this.aspect - 1];
+        else if (this.isInIce()) {
+            return damageDownModifiers[this.elementLevel - 1];
         }
         else {
             return 1;
         }
     }
 
-    getIcePotencyMulti(): number {
-        if (this.aspect > 0) {
-            return damageDownModifiers[this.aspect - 1];
+    private _getIcePotencyMulti(): number {
+        if (this.isInFire()) {
+            return damageDownModifiers[this.elementLevel - 1];
         }
         else {
             return 1;
         }
     }
 
-    getFireCastMulti(): number {
-        if (this.aspect === -3) {
+    private _getFireCastMulti(): number {
+        if (this.isInIce(3)) {
             return 0.5;
         }
         return 1;
     }
 
-    getIceCastMulti(): number {
-        if (this.aspect === +3) {
+    private _getIceCastMulti(): number {
+        if (this.isInFire(3)) {
             return 0.5;
         }
         return 1;
     }
 
     getIceMpGain(): number {
-        if (this.aspect === -1) {
+        if (this.isInIce(1)) {
             return 2500;
         }
-        else if (this.aspect === -2) {
+        else if (this.isInIce(2)) {
             return 5000;
         }
-        else if (this.aspect === -3) {
+        else if (this.isInIce(3)) {
             return 10000;
         }
         else {
@@ -171,11 +281,93 @@ export class BlmGauge {
         }
     }
 
-    getGaugeState(): BlmGaugeState {
+    canUseFireSpell(mpCost: number | 'flare' | 'despair'): boolean {
+        if (this.isInIce()) {
+            return true;
+        }
+        if (mpCost === 'flare' || mpCost === 'despair') {
+            // 800 MP minimum to be able to cast Flare or Despair.
+            return this.magicPoints >= 800;
+        }
+        if (this.isInFire() && this.umbralHearts === 0) {
+            // Doubled MP cost when in Astral Fire without Umbral Hearts.
+            return this.magicPoints >= (2 * mpCost);
+        }
+        return this.magicPoints >= mpCost;
+    }
+
+    updateForFireSpell(mpCost: number | 'flare' | 'despair') {
+        // Fire spells cost no MP in Umbral Ice. (those that you can even cast from UI.)
+        if (this.isInIce()) {
+            return;
+        }
+
+        if (mpCost === 'flare') {
+            if (this.umbralHearts > 0) {
+                // Flare removes all Umbral Hearts and reduces MP cost by one third.
+                this.umbralHearts = 0;
+                this.magicPoints -= 2 * fl(this.magicPoints / 3);
+            }
+            else {
+                // Otherwise it just consumes all MP.
+                this.magicPoints = 0;
+            }
+        }
+        else if (mpCost === 'despair') {
+            // Despair just does not consume Umbral Hearts and consumes all MP.
+            this.magicPoints = 0;
+        }
+        else {
+            if (!this.isInFire()) {
+                // If neither in Fire or Ice, MP cost is just normal.
+                this.magicPoints -= mpCost;
+            }
+            else if (this.umbralHearts > 0) {
+                // If you have an Umbral Heart, it is consumed to negate the increased MP cost.
+                this.umbralHearts -= 1;
+                this.magicPoints -= mpCost;
+            }
+            else {
+                // Otherwise, the cost is doubled.
+                this.magicPoints -= 2 * mpCost;
+            }
+        }
+    }
+
+    canUseIceSpell(mpCost: number): boolean {
+        // Ice spells only cost MP if cast with no element.
+        if (this.element === BlmElement.Unaspected) {
+            return this.magicPoints >= mpCost;
+        }
+        return true;
+    }
+
+    updateForIceSpell(mpCost: number) {
+        // Ice spells only cost MP if cast with no element.
+        if (this.element === BlmElement.Unaspected) {
+            this.magicPoints -= mpCost;
+        }
+        // Casting an ice spell in Umbral Ice restores MP depending on the level of UI.
+        if (this.isInIce()) {
+            if (this.elementLevel === 1) {
+                this.magicPoints += 2500;
+            }
+            else if (this.elementLevel === 2) {
+                this.magicPoints += 5000;
+            }
+            else if (this.elementLevel === 3) {
+                this.magicPoints += 10000;
+            }
+        }
+    }
+
+    gaugeSnapshot(): BlmGaugeState {
         return {
-            aspect: this.aspect,
+            level: this.level,
+            element: this.element,
+            elementLevel: this.elementLevel,
+            magicPoints: this.magicPoints,
             umbralHearts: this.umbralHearts,
-            mp: this.magicPoints,
             polyglot: this.polyglot,
             paradox: this.paradox,
             astralSoul: this.astralSoul,

--- a/packages/core/src/sims/caster/blm/blm_sheet_sim.ts
+++ b/packages/core/src/sims/caster/blm/blm_sheet_sim.ts
@@ -1,22 +1,29 @@
-import {Ability, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
+import {Ability, GcdAbility, OgcdAbility, SimSettings, SimSpec} from "@xivgear/core/sims/sim_types";
 import {
     CycleProcessor,
     CycleSimResult,
     ExternalCycleSettings,
     MultiCycleSettings,
     AbilityUseResult,
-    Rotation,
-    PreDmgAbilityUseRecordUnf
+    Rotation
 } from "@xivgear/core/sims/cycle_sim";
 import {CycleSettings} from "@xivgear/core/sims/cycle_settings";
 import {CharacterGearSet} from "@xivgear/core/gear";
 import {STANDARD_ANIMATION_LOCK} from "@xivgear/xivmath/xivconstants";
-import {BlmGauge} from "./blm_gauge";
-import {BlmExtraData, BlmAbility, BlmGcdAbility, LeyLinesBuff, FirestarterBuff, ThunderheadBuff} from "./blm_types";
+import {BlmGaugeManager} from "./blm_gauge";
+import {BlmAbility, BlmGcdAbility, LeyLinesBuff, FirestarterBuff, ThunderheadBuff, TriplecastBuff, SwiftcastBuff} from "./blm_types";
 import * as Actions from './blm_actions';
 import {BaseMultiCycleSim} from "@xivgear/core/sims/processors/sim_processors";
 import {potionMaxInt} from "@xivgear/core/sims/common/potion";
-import {fl} from "@xivgear/xivmath/xivmath";
+
+function formatTime(time: number) {
+    const negative = time < 0;
+    // noinspection AssignmentToFunctionParameterJS
+    time = Math.abs(time);
+    const minute = Math.floor(time / 60);
+    const second = time % 60;
+    return (`${negative ? '-' : ''}${minute}:${second.toFixed(2).padStart(5, '0')}`);
+}
 
 export interface BlmSimResult extends CycleSimResult {
 
@@ -44,9 +51,14 @@ export interface BlmSettingsExternal extends ExternalCycleSettings<BlmSettings> 
 export const blmSpec: SimSpec<BlmSim, BlmSettingsExternal> = {
     stub: "blm-sheet-sim",
     displayName: "BLM Sim",
-    description: `Simulates a BLM rotation for level 100.
+    description: `Simulates a BLM rotation for levels 100/90/80/70.
 If potions are enabled, pots in the burst window every 6m (i.e. 0m, 6m, 12m, etc).
-Defaults to simulating a killtime of 8m 30s (510s).`,
+Defaults to simulating a killtime of 8m 30s (510s) and consistent use of AF1 F3P.
+
+The transpose settings are ignored for levels 80/70.
+At level 70, the sim does not care anymore about clipping GCDs.
+
+Summary of cooldown drift and GCD clips at the end of the list of abilities used.`,
     makeNewSimInstance: function (): BlmSim {
         return new BlmSim();
     },
@@ -54,7 +66,7 @@ Defaults to simulating a killtime of 8m 30s (510s).`,
         return new BlmSim(exported);
     },
     supportedJobs: ['BLM'],
-    supportedLevels: [100],
+    supportedLevels: [100, 90, 80, 70],
     isDefaultSim: true,
     maintainers: [{
         name: 'Rika',
@@ -66,121 +78,52 @@ Defaults to simulating a killtime of 8m 30s (510s).`,
     }],
 };
 
-class BlmCycleProcessor extends CycleProcessor {
-    gauge: BlmGauge;
+class BlmCycleProcessor extends CycleProcessor<BlmGaugeManager> {
     nextThunderTime: number = 0;
     nextPolyglotTime: number = 30;
 
     constructor(settings: MultiCycleSettings) {
         super(settings);
         this.cycleLengthMode = 'full-duration';
-        this.gauge = new BlmGauge();
     }
 
-    // Gets Fire/Ice spells with potency/cast time/MP cost adjusted for the current element.
-    getBlmAbilityAdjusted(ability: BlmAbility): BlmAbility {
-        const mods = {
-            potency: ability.potency,
-            cast: ability.cast ?? 0,
-            mp: ability.mp ?? 0,
-        };
-        if (ability.element === 'fire') {
-            mods.potency *= this.gauge.getFirePotencyMulti();
-            mods.cast *= this.gauge.getFireCastMulti();
-            if (typeof mods.mp === "number") {
-                mods.mp *= this.gauge.getFireMpMulti();
-            }
-        }
-        else if (ability.element === 'ice') {
-            mods.potency *= this.gauge.getIcePotencyMulti();
-            mods.cast *= this.gauge.getIceCastMulti();
-            if (typeof mods.mp === "number") {
-                mods.mp *= this.gauge.getIceMpMulti();
-            }
-        }
-        // Enochian damage buff if Fire/Ice active.
-        if (this.gauge.aspect !== 0) {
-            if (this.stats.level >= 96) {
-                mods.potency *= 1.27;
-            }
-            else if (this.stats.level >= 86) {
-                mods.potency *= 1.22;
-            }
-            else if (this.stats.level >= 78) {
-                mods.potency *= 1.15;
-            }
-            else if (this.stats.level >= 70) {
-                mods.potency *= 1.10;
-            }
-        }
-        return {...ability, ...mods};
+    override createGaugeManager(): BlmGaugeManager {
+        return new BlmGaugeManager(this.stats.level);
     }
 
     getGcdWithLL(): number {
         return this.gcdTime(Actions.Xenoglossy);
     }
 
-    override addAbilityUse(usedAbility: PreDmgAbilityUseRecordUnf) {
-        // Add gauge data to this record for the UI
-        const extraData: BlmExtraData = {
-            gauge: this.gauge.getGaugeState(),
-        };
-
-        const modified: PreDmgAbilityUseRecordUnf = {
-            ...usedAbility,
-            extraData,
-        };
-
-        super.addAbilityUse(modified);
-    }
-
     override use(ability: Ability): AbilityUseResult {
         const abilityWithBuffs = this.beforeAbility(ability, this.getActiveBuffsFor(ability));
-        const blmAbility = this.getBlmAbilityAdjusted(abilityWithBuffs as BlmAbility);
+        const blmAbility = this.gaugeManager.getAdjustedAbility(abilityWithBuffs as BlmAbility);
 
-        // Handle MP costs.
-        if (blmAbility.mp === 'flare') {
-            if (this.gauge.umbralHearts > 0) {
-                blmAbility.mp = fl(this.gauge.magicPoints / 3);
-                this.gauge.umbralHearts = 0;
-            }
-            else {
-                blmAbility.mp = 0;
-            }
-        }
-        else if (blmAbility.mp === 'all') {
-            blmAbility.mp = this.gauge.magicPoints;
-        }
-        else if (blmAbility.mp > 0 && blmAbility.element === 'fire' && this.gauge.umbralHearts > 0) {
-            // MP multi is already done by getBlmAbilityAdjusted, we just consume umbral heart.
-            this.gauge.umbralHearts -= 1;
-        }
-        this.gauge.magicPoints -= blmAbility.mp;
-
-        // Handle MP regen. (ignore natural/lucid ticks, only ice spells)
-        if (blmAbility.element === 'ice') {
-            this.gauge.magicPoints += this.gauge.getIceMpGain();
-        }
+        // Maybe add natural regen / Lucid ticks at some point...
 
         // Handle Thunder refresh.
         if (blmAbility.name === "High Thunder") {
-            this.nextThunderTime = this.nextGcdTime + 30 - blmAbility.appDelay - STANDARD_ANIMATION_LOCK - this.getGcdWithLL();
+            this.nextThunderTime = this.nextGcdTime + 30 - blmAbility.appDelay - STANDARD_ANIMATION_LOCK;
         }
         else if (blmAbility.name === "Thunder III") {
-            this.nextThunderTime = this.nextGcdTime + 27 - blmAbility.appDelay;
-        }
-
-        // Update gauge from the ability itself
-        if (blmAbility.updateGaugeLegacy !== undefined) {
-            blmAbility.updateGaugeLegacy(this.gauge);
+            this.nextThunderTime = this.nextGcdTime + 27 - blmAbility.appDelay - STANDARD_ANIMATION_LOCK;
         }
 
         if (this.nextGcdTime > this.nextPolyglotTime) {
             this.nextPolyglotTime += 30;
-            this.gauge.polyglot += 1;
+            this.gaugeManager.polyglot += 1;
         }
 
         return super.use(blmAbility);
+    }
+
+    override canUseWithoutClipping(action: OgcdAbility) {
+        // Override this to always return true below lv.80 because we have pretty much no weave slots
+        // and getting cooldowns off is more important.
+        if (this.stats.level < 80) {
+            return false;
+        }
+        return super.canUseWithoutClipping(action);
     }
 
     inBurst(): boolean {
@@ -197,16 +140,18 @@ class BlmCycleProcessor extends CycleProcessor {
     }
 
     wouldOvercapPolygotFromAmplifierOrTimer(): boolean {
-        const timeTwoGcds = this.getGcdWithLL() * 2;
-        // From Amplifier
-        if (this.cdTracker.statusOf(Actions.Amplifier).readyAt.relative < timeTwoGcds) {
-            if (this.gauge.polyglot >= 3) {
-                return true;
+        const timeTwoGcds = this.getGcdWithLL() * 3;
+        // From Amplifier (lv.86 or higher)
+        if (this.stats.level >= 86) {
+            if (this.cdTracker.statusOf(Actions.Amplifier).readyAt.relative < timeTwoGcds) {
+                if (this.gaugeManager.polyglot >= this.gaugeManager.getMaxPolyglotCharges()) {
+                    return true;
+                }
             }
         }
         // From Timer
         if (this.nextPolyglotTime - this.nextGcdTime < timeTwoGcds) {
-            if (this.gauge.polyglot >= 3) {
+            if (this.gaugeManager.polyglot >= this.gaugeManager.getMaxPolyglotCharges()) {
                 return true;
             }
         }
@@ -239,6 +184,13 @@ class BlmCycleProcessor extends CycleProcessor {
         const buffs = this.getActiveBuffs();
         const thunderhead = buffs.find(buff => buff.name === ThunderheadBuff.name);
         return thunderhead !== undefined;
+    }
+
+    hasSwiftOrTriple(): boolean {
+        const buffs = this.getActiveBuffs();
+        const swift = buffs.find(buff => buff.name === SwiftcastBuff.name);
+        const triple = buffs.find(buff => buff.name === TriplecastBuff.name);
+        return swift !== undefined || triple !== undefined;
     }
 }
 
@@ -297,13 +249,13 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
         }
 
         // In Astral Fire
-        if (cp.gauge.aspect > 0) {
-            if (cp.gauge.aspect === +1) {
+        if (cp.gaugeManager.isInFire()) {
+            if (cp.gaugeManager.elementLevel === 1) {
                 // If AF1, use Fire 3 if we have Firestarter, otherwise Paradox to generate one.
                 if (cp.hasFirestarter()) {
                     return Actions.Fire3;
                 }
-                else if (cp.gauge.paradox) {
+                else if (cp.gaugeManager.paradox && cp.stats.level >= 90) {
                     return Actions.FireParadox;
                 }
                 else {
@@ -311,42 +263,46 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
                     return Actions.Fire3;
                 }
             }
-            else if (cp.gauge.aspect === +3) {
+            else if (cp.gaugeManager.elementLevel === 3) {
                 // Priority is Blizzard 3, Flare star, Despair, Fire 4, Paradox.
-                if (cp.gauge.magicPoints < 800) {
+                if (cp.gaugeManager.magicPoints < 800) {
                     return Actions.Blizzard3;
                 }
-                else if (cp.gauge.astralSoul === 6) {
+                else if (cp.stats.level < 72 && cp.gaugeManager.magicPoints < 1600) {
+                    // Special case for lv.70, we don't have Despair so fire phase ends early.
+                    return Actions.Blizzard3;
+                }
+                else if (cp.gaugeManager.astralSoul === 6 && cp.stats.level >= 100) {
                     return Actions.FlareStar;
                 }
-                else if (cp.gauge.magicPoints <= 1600) {
+                else if (cp.gaugeManager.magicPoints <= 1600 && cp.stats.level >= 72) {
                     return Actions.Despair;
                 }
-                else if (cp.gauge.astralSoul < 3) {
+                else if (cp.gaugeManager.astralSoul < 3) {
                     return Actions.Fire4;
                 }
-                else if (cp.gauge.paradox) {
+                else if (cp.gaugeManager.paradox && cp.stats.level >= 90) {
                     return Actions.FireParadox;
                 }
-                else if (cp.gauge.astralSoul < 6) {
+                else if (cp.gaugeManager.astralSoul < 6) {
                     return Actions.Fire4;
                 }
             }
             else {
                 // Why are we in AF2?
-                console.warn(`[BLM Sim] We are in AF${cp.gauge.aspect}, something went *really* wrong.`);
+                console.error(`[BLM Sim] We are in AF${cp.gaugeManager.elementLevel}, something went *really* wrong.`);
             }
         }
 
         // In Umbral Ice
-        if (cp.gauge.aspect < 0) {
-            if (cp.gauge.aspect > -3) {
+        if (cp.gaugeManager.isInIce()) {
+            if (cp.gaugeManager.elementLevel < 3) {
                 return Actions.Blizzard3;
             }
-            else if (cp.gauge.umbralHearts < 3) {
+            else if (cp.gaugeManager.umbralHearts < 3) {
                 return Actions.Blizzard4;
             }
-            else if (cp.gauge.paradox) {
+            else if (cp.gaugeManager.paradox) {
                 return Actions.IceParadox;
             }
             else {
@@ -357,26 +313,28 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
         return Actions.Thunder3;
     }
 
-    // Uses DRK actions as part of a rotation.
     useBlmRotation(cp: BlmCycleProcessor) {
+        // TODO: fix the mess and actually handle oGCDs and weaving properly.
+
         ////////
         ///oGCDs
         ////////
 
+        // This is really unnecessary.
         if (cp.inBurst()) {
-            if (cp.cdTracker.statusOf(Actions.Triplecast).readyToUse) {
+            if (!cp.hasSwiftOrTriple() && cp.cdTracker.statusOf(Actions.Triplecast).readyToUse) {
                 if (cp.canUseWithoutClipping(Actions.Triplecast)) {
                     this.use(cp, Actions.Triplecast);
                 }
                 else {
-                    if (cp.gauge.polyglot > 0) {
+                    if (cp.gaugeManager.polyglot > 0) {
                         this.use(cp, Actions.Xenoglossy);
                     }
                     this.use(cp, Actions.Triplecast);
                 }
             }
             else {
-                if (cp.gauge.polyglot > 0) {
+                if (cp.gaugeManager.polyglot > 0) {
                     this.use(cp, Actions.Xenoglossy);
                 }
             }
@@ -386,24 +344,28 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
             this.use(cp, potionMaxInt);
         }
 
-        if (cp.cdTracker.statusOf(Actions.Amplifier).readyToUse) {
-            if (cp.canUseWithoutClipping(Actions.Amplifier)) {
-                this.use(cp, Actions.Amplifier);
-            }
-            else {
-                if (cp.gauge.polyglot > 0) {
-                    this.use(cp, Actions.Xenoglossy);
+        // Amplifier (lv.86 or higher)
+        if (cp.stats.level >= 86) {
+            if (cp.cdTracker.statusOf(Actions.Amplifier).readyToUse) {
+                if (cp.canUseWithoutClipping(Actions.Amplifier)) {
+                    this.use(cp, Actions.Amplifier);
                 }
-                this.use(cp, Actions.Amplifier);
+                else {
+                    if (cp.gaugeManager.polyglot > 0) {
+                        this.use(cp, Actions.Xenoglossy);
+                    }
+                    this.use(cp, Actions.Amplifier);
+                }
             }
         }
 
+        // Ley Lines
         if (cp.cdTracker.statusOf(Actions.LeyLines).readyToUse) {
             if (cp.canUseWithoutClipping(Actions.LeyLines)) {
                 this.use(cp, Actions.LeyLines);
             }
             else {
-                if (cp.gauge.polyglot > 0) {
+                if (cp.gaugeManager.polyglot > 0) {
                     this.use(cp, Actions.Xenoglossy);
                 }
                 this.use(cp, Actions.LeyLines);
@@ -412,31 +374,37 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
 
         // Dump resources in burst or if fight ending soon
         if (cp.inBurst() || cp.fightEndingSoon()) {
-            if (cp.gauge.polyglot > 0) {
+            if (cp.gaugeManager.polyglot > 0) {
                 this.use(cp, Actions.Xenoglossy);
             }
         }
 
-        // End of fire phase is: no MP:
-        if (cp.gauge.aspect === +3 && cp.gauge.magicPoints === 0) {
+        // End of fire phase is: no MP for lv.80 and above, <1600 MP for below
+        if (cp.gaugeManager.isInFire(3) &&
+                (cp.gaugeManager.magicPoints === 0 ||
+                    cp.stats.level < 80 && cp.gaugeManager.magicPoints < 1600)) {
             // Use manafont if available
             if (cp.cdTracker.statusOf(Actions.Manafont).readyToUse) {
                 if (cp.canUseWithoutClipping(Actions.Manafont)) {
                     this.use(cp, Actions.Manafont);
                 }
                 else {
-                    if (cp.gauge.polyglot > 0) {
+                    if (cp.gaugeManager.polyglot > 0) {
                         this.use(cp, Actions.Xenoglossy);
                     }
                     this.use(cp, Actions.Manafont);
                 }
             }
-            else if (this.settings.transposeFromAstralFire) {
+            // IGNORE THIS SETTING IF BELOW LEVEL 90
+            else if (this.settings.transposeFromAstralFire && cp.stats.level >= 90) {
                 // Otherwise: do we have swift/triple? use them to transpose.
-                if (cp.cdTracker.statusOf(Actions.Swiftcast).readyToUse) {
+                if (cp.hasSwiftOrTriple()) {
+                    this.use(cp, Actions.Transpose);
+                }
+                else if (cp.cdTracker.statusOf(Actions.Swiftcast).readyToUse) {
                     this.use(cp, Actions.Swiftcast);
                     if (cp.canUseWithoutClipping(Actions.Transpose)) {
-                        if (cp.gauge.polyglot > 0) {
+                        if (cp.gaugeManager.polyglot > 0) {
                             this.use(cp, Actions.Xenoglossy);
                         }
                         this.use(cp, Actions.Transpose);
@@ -445,7 +413,7 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
                 else if (cp.cdTracker.statusOf(Actions.Triplecast).readyToUse) {
                     this.use(cp, Actions.Triplecast);
                     if (cp.canUseWithoutClipping(Actions.Transpose)) {
-                        if (cp.gauge.polyglot > 0) {
+                        if (cp.gaugeManager.polyglot > 0) {
                             this.use(cp, Actions.Xenoglossy);
                         }
                         this.use(cp, Actions.Transpose);
@@ -454,11 +422,12 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
             }
         }
 
-        if (this.settings.transposeFromUmbralIce) {
+        // IGNORE THIS SETTING IF BELOW LEVEL 90
+        if (this.settings.transposeFromUmbralIce && cp.stats.level >= 90) {
             // End of ice phase is: no Paradox: transpose.
-            if (cp.gauge.aspect === -3 && !cp.gauge.paradox) {
+            if (cp.gaugeManager.isInIce(3) && !cp.gaugeManager.paradox) {
                 if (cp.canUseWithoutClipping(Actions.Transpose)) {
-                    if (cp.gauge.polyglot > 0) {
+                    if (cp.gaugeManager.polyglot > 0) {
                         this.use(cp, Actions.Xenoglossy);
                     }
                     this.use(cp, Actions.Transpose);
@@ -480,7 +449,10 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
             return null;
         }
 
-        //const blmAbility = ability as BlmAbility;
+        // TODO: Use a less hacky way to replace Xeno with Foul below lv.80
+        if (cp.stats.level < 80 && ability.name === "Xenoglossy") {
+            ability = Actions.Foul;
+        }
 
         // If an Ogcd isn't ready yet, but it can still be used without clipping, advance time until ready.
         if (ability.type === 'ogcd' && cp.canUseWithoutClipping(ability)) {
@@ -496,136 +468,108 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
         }
 
         return cp.use(ability);
-
-        /*
-        // Update gauges
-        const abilityWithBloodWeapon = cp.getDrkAbilityWithBloodWeapon(ability);
-        // If we're attempting to use Bloodspiller with Delirium active, we're pre-level 100, and
-        // Bloodspillers are free.
-        if (cp.isDeliriumActive() && drkAbility.id === Actions.Bloodspiller.id) {
-            // Do not spend Blood for Deliriums.
-            // Manually update Blood gauge instead if Blood Weapon is active.
-            if (cp.isBloodWeaponActive()) {
-                cp.gauge.bloodGauge += 10;
-            }
-        }
-        else {
-            if (abilityWithBloodWeapon.updateBloodGauge !== undefined) {
-                // Prevent gauge updates showing incorrectly on autos before this ability
-                if (ability.type === 'gcd' && cp.nextGcdTime > cp.currentTime) {
-                    cp.advanceTo(cp.nextGcdTime);
-                }
-                abilityWithBloodWeapon.updateBloodGauge(cp.gauge);
-            }
-        }
-
-        if (abilityWithBloodWeapon.updateMP !== undefined) {
-            // Prevent gauge updates showing incorrectly on autos before this ability
-            if (ability.type === 'gcd' && cp.nextGcdTime > cp.currentTime) {
-                cp.advanceTo(cp.nextGcdTime);
-            }
-            abilityWithBloodWeapon.updateMP(cp.gauge);
-        }
-
-
-        // Apply Living Shadow abilities before attempting to use an ability
-        // AND after we move the timeline for that ability.
-        this.applyLivingShadowAbilities(cp);
-        */
     }
 
-    /*
-    private useLevel80OrBelowOpener(cp: BlmCycleProcessor, prepullTBN: boolean) {
-        if (prepullTBN) {
+    private useLevel70Opener(cp: BlmCycleProcessor, prepullLL: boolean) {
+        if (prepullLL) {
             this.use(cp, Actions.LeyLines);
-            cp.advanceTo(3 - STANDARD_ANIMATION_LOCK);
-            // Hacky out of combat mana tick.
-            // TODO: Refactor this once MP is handled in a more core way
-            cp.gauge.magicPoints += 600;
         }
-        else {
-            cp.advanceTo(1 - STANDARD_ANIMATION_LOCK);
+        this.use(cp, Actions.Fire3);
+        this.use(cp, Actions.Thunder3);
+        this.use(cp, Actions.Swiftcast);
+        this.use(cp, Actions.Fire4);
+        this.use(cp, potionMaxInt);
+        if (!prepullLL) {
+            this.use(cp, Actions.LeyLines);
         }
-        this.use(cp, Actions.Unmend);
-        cp.advanceForLateWeave([potionMaxStr]);
-        this.use(cp, potionMaxStr);
-        this.use(cp, Actions.HardSlash);
-        this.use(cp, cp.getEdgeAction());
-        if (cp.stats.level >= 80) {
-            this.use(cp, Actions.LivingShadow);
+        for (let i = 0; i < 3; i++) {
+            this.use(cp, Actions.Fire4);
         }
-        this.use(cp, Actions.SyphonStrike);
-        this.use(cp, Actions.Souleater);
-        this.use(cp, Actions.Delirium);
-        this.use(cp, cp.getComboToUse());
-        this.use(cp, Actions.SaltedEarth);
-        this.use(cp, cp.getEdgeAction());
-        this.use(cp, Actions.Bloodspiller);
-        this.use(cp, cp.getEdgeAction());
-        this.use(cp, Actions.Bloodspiller);
-        this.use(cp, Actions.CarveAndSpit);
-        this.use(cp, cp.getEdgeAction());
-        this.use(cp, Actions.Bloodspiller);
-        if (prepullTBN) {
-            this.use(cp, cp.getEdgeAction());
+        this.use(cp, Actions.Foul);
+        this.use(cp, Actions.Manafont);
+        for (let i = 0; i < 4; i++) {
+            this.use(cp, Actions.Fire4);
         }
-        this.use(cp, Actions.Bloodspiller);
-        i
-        f (!prepullTBN) {
-            // Without the extra mana, do two filler GCDs before the Edge of Shadow.
-            // This is a worst-case scenario mana wise, in reality it may be possible
-            // to get the Edge in after the Hard Slash.
-            this.use(cp, cp.getComboToUse());
-            this.use(cp, cp.getComboToUse());
-            this.use(cp, cp.getEdgeAction());
+        this.use(cp, Actions.Thunder3);
+        for (let i = 0; i < 3; i++) {
+            this.use(cp, Actions.Fire4);
         }
+        this.use(cp, Actions.Blizzard3);
+        this.use(cp, Actions.Blizzard4);
+        this.use(cp, Actions.Fire3);
+        this.use(cp, Actions.LeyLines);
     }
 
-    private useLevel90Opener(cp: DrkCycleProcessor, prepullTBN: boolean) {
-        if (prepullTBN) {
-            this.use(cp, Actions.TheBlackestNight);
-            cp.advanceTo(3 - STANDARD_ANIMATION_LOCK);
-            // Hacky out of combat mana tick.
-            // TODO: Refactor this once MP is handled in a more core way
-            cp.gauge.magicPoints += 600;
+    private useLevel80Opener(cp: BlmCycleProcessor, prepullLL: boolean) {
+        if (prepullLL) {
+            this.use(cp, Actions.LeyLines);
         }
-        else {
-            cp.advanceTo(1 - STANDARD_ANIMATION_LOCK);
+        this.use(cp, Actions.Fire3);
+        this.use(cp, Actions.Thunder3);
+        this.use(cp, Actions.Swiftcast);
+        this.use(cp, Actions.Amplifier);
+        this.use(cp, Actions.Fire4);
+        this.use(cp, potionMaxInt);
+        if (!prepullLL) {
+            this.use(cp, Actions.LeyLines);
         }
-        this.use(cp, Actions.Unmend);
-        cp.advanceForLateWeave([potionMaxStr]);
-        this.use(cp, potionMaxStr);
-        this.use(cp, Actions.HardSlash);
-        this.use(cp, Actions.EdgeOfShadow);
-        this.use(cp, Actions.LivingShadow);
-        this.use(cp, Actions.SyphonStrike);
-        this.use(cp, Actions.Souleater);
-        this.use(cp, Actions.Delirium);
-        this.use(cp, cp.getComboToUse());
-        this.use(cp, Actions.SaltedEarth);
-        this.use(cp, Actions.EdgeOfShadow);
-        this.use(cp, Actions.Bloodspiller);
-        this.use(cp, Actions.Shadowbringer);
-        this.use(cp, Actions.EdgeOfShadow);
-        this.use(cp, Actions.Bloodspiller);
-        this.use(cp, Actions.CarveAndSpit);
-        this.use(cp, Actions.EdgeOfShadow);
-        this.use(cp, Actions.Bloodspiller);
-        this.use(cp, Actions.Shadowbringer);
-        if (prepullTBN) {
-            this.use(cp, Actions.EdgeOfShadow);
+        for (let i = 0; i < 3; i++) {
+            this.use(cp, Actions.Fire4);
         }
-        this.use(cp, Actions.Bloodspiller);
-        this.use(cp, Actions.SaltAndDarkness);
-        if (!prepullTBN) {
-            // Without the extra mana, do two filler GCDs before the Edge of Shadow.
-            // This is a worst-case scenario mana wise, in reality it may be possible
-            // to get the Edge in after the Hard Slash.
-            this.use(cp, cp.getComboToUse());
-            this.use(cp, cp.getComboToUse());
-            this.use(cp, Actions.EdgeOfShadow);
+        this.use(cp, Actions.Despair);
+        this.use(cp, Actions.Xenoglossy);
+        this.use(cp, Actions.Manafont);
+        for (let i = 0; i < 3; i++) {
+            this.use(cp, Actions.Fire4);
         }
-    }*/
+        this.use(cp, Actions.Thunder3);
+        for (let i = 0; i < 4; i++) {
+            this.use(cp, Actions.Fire4);
+        }
+        this.use(cp, Actions.Despair);
+        this.use(cp, Actions.Blizzard3);
+        this.use(cp, Actions.Blizzard4);
+        this.use(cp, Actions.Fire3);
+        this.use(cp, Actions.LeyLines);
+    }
+
+    private useLevel90Opener(cp: BlmCycleProcessor, prepullLL: boolean) {
+        if (prepullLL) {
+            this.use(cp, Actions.LeyLines);
+        }
+        this.use(cp, Actions.Fire3);
+        this.use(cp, Actions.Thunder3);
+        this.use(cp, Actions.Swiftcast);
+        this.use(cp, Actions.Amplifier);
+        this.use(cp, Actions.Fire4);
+        this.use(cp, potionMaxInt);
+        if (!prepullLL) {
+            this.use(cp, Actions.LeyLines);
+        }
+        for (let i = 0; i < 3; i++) {
+            this.use(cp, Actions.Fire4);
+        }
+        this.use(cp, Actions.Despair);
+        this.use(cp, Actions.Xenoglossy);
+        this.use(cp, Actions.Manafont);
+        for (let i = 0; i < 3; i++) {
+            this.use(cp, Actions.Fire4);
+        }
+        this.use(cp, Actions.Thunder3);
+        for (let i = 0; i < 3; i++) {
+            this.use(cp, Actions.Fire4);
+        }
+        this.use(cp, Actions.FireParadox);
+        this.use(cp, Actions.Triplecast);
+        this.use(cp, Actions.Despair);
+        this.use(cp, Actions.Transpose);
+        this.use(cp, Actions.Blizzard3);
+        this.use(cp, Actions.Blizzard4);
+        this.use(cp, Actions.IceParadox);
+        this.use(cp, Actions.Transpose);
+        this.use(cp, Actions.Fire3);
+        this.use(cp, Actions.LeyLines);
+    }
 
     private useLevel100Opener(cp: BlmCycleProcessor, prepullLL: boolean) {
         if (prepullLL) {
@@ -719,15 +663,66 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
             }
         }
         else if (cp.stats.level === 90) {
-            //this.useLevel90Opener(cp, prepullTBN);
+            this.useLevel90Opener(cp, prepullLL);
+        }
+        else if (cp.stats.level === 80) {
+            this.useLevel80Opener(cp, prepullLL);
         }
         else {
-            //this.useLevel80OrBelowOpener(cp, prepullTBN);
+            this.useLevel70Opener(cp, prepullLL);
+        }
+    }
+
+    private printCooldownDrift(cp: BlmCycleProcessor, abilityName: string) {
+        const usedAbilities = cp.usedAbilities.filter(used => used.ability.name === abilityName);
+
+        const uses = usedAbilities.length;
+        const drifts = [];
+        for (let i = 0; i < uses - 1; ++i) {
+            const diff = usedAbilities[i + 1].usedAt - usedAbilities[i].usedAt;
+            drifts.push(Math.round(diff));
+        }
+
+        if (drifts.length > 0) {
+            cp.addSpecialRow(`${abilityName} - uses: ${uses}, drift: ${drifts.map(t => `${t}s`).join(", ")}`, 0);
+        }
+        else {
+            cp.addSpecialRow(`${abilityName} - uses: ${uses}`, 0);
+        }
+    }
+
+    private printGcdClipping(cp: BlmCycleProcessor) {
+        const GCD_CLIP_ALLOWED = 0.01;
+
+        const gcds = cp.usedAbilities.filter(used => used.ability.type === 'gcd');
+
+        let totalClip = 0;
+        const clipTimes = [];
+        for (let i = 0; i < gcds.length - 1; ++i) {
+            // The highest between cast time and GCD time.
+            const castTime = cp.castTime(gcds[i].ability as GcdAbility, gcds[i].combinedEffects);
+            const gcdTime = cp.gcdTime(gcds[i].ability as GcdAbility, gcds[i].combinedEffects);
+            const checkTime = Math.max(castTime, gcdTime);
+            if (gcds[i + 1].usedAt - gcds[i].usedAt > checkTime) {
+                const clipAmount = gcds[i + 1].usedAt - gcds[i].usedAt - checkTime;
+                totalClip += clipAmount;
+
+                if (clipAmount > GCD_CLIP_ALLOWED) {
+                    clipTimes.push(formatTime(gcds[i].usedAt));
+                }
+            }
+        }
+
+        if (totalClip > 0) {
+            cp.addSpecialRow(`GCD clips: ${totalClip.toFixed(2)}s, ${clipTimes.join(", ")}`, 0);
+        }
+        else {
+            cp.addSpecialRow(`No GCD clips`, 0);
         }
     }
 
     getRotationsToSimulate(set: CharacterGearSet): Rotation<BlmCycleProcessor>[] {
-        const gcd = set.results.computedStats.gcdPhys(2.5);
+        const gcd = set.results.computedStats.gcdMag(2.5);
         const settings = { ...this.settings };
         const outer = this;
 
@@ -741,6 +736,13 @@ export class BlmSim extends BaseMultiCycleSim<BlmSimResult, BlmSettings, BlmCycl
                 cp.remainingCycles(() => {
                     outer.useBlmRotation(cp);
                 });
+
+                // Recap cooldown drift.
+                cp.addSpecialRow(">>> Recap cooldown drift:", 0);
+                outer.printCooldownDrift(cp, "Ley Lines");
+                outer.printCooldownDrift(cp, "Amplifier");
+                outer.printCooldownDrift(cp, "Manafont");
+                outer.printGcdClipping(cp);
             },
         }];
     }

--- a/packages/frontend/src/scripts/sims/caster/blm_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/caster/blm_sim_ui.ts
@@ -4,7 +4,7 @@ import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
 import {CycleSimResult, DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {col, CustomColumn} from "@xivgear/common-ui/table/tables";
 import {PreDmgUsedAbility} from "@xivgear/core/sims/sim_types";
-import {BlmExtraData} from "@xivgear/core/sims/caster/blm/blm_types";
+import {BlmElement, BlmGaugeState} from "@xivgear/core/sims/caster/blm/blm_types";
 
 export class BlmSimGui extends BaseMultiCycleSimGui<BlmSimResult, BlmSettings> {
 
@@ -13,125 +13,135 @@ export class BlmSimGui extends BaseMultiCycleSimGui<BlmSimResult, BlmSettings> {
             shortName: 'astral-fire-umbral-ice',
             displayName: 'AF/UI',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: PreDmgUsedAbility) => {
-                if (usedAbility?.extraData !== undefined) {
-                    const aspectElement = (usedAbility.extraData as BlmExtraData).gauge.aspect;
-                    const paradox = (usedAbility.extraData as BlmExtraData).gauge.paradox;
-
-                    const children = [];
-
-                    // negative is ice.
-                    if (aspectElement <= 0) {
-                        for (let i = 1; i <= 3; i++) {
-                            children.push(quickElement('span', [i <= (-aspectElement) ? 'blm-element-ice' : 'blm-element-default'], []));
-                        }
-                    }
-                    else {
-                        for (let i = 1; i <= 3; i++) {
-                            children.push(quickElement('span', [i <= (+aspectElement) ? 'blm-element-fire' : 'blm-element-default'], []));
-                        }
-                    }
-
-                    children.push(quickElement('span', [paradox ? 'blm-paradox-full' : 'blm-paradox-default'], []));
-
-                    return quickElement('div', ['icon-gauge-holder'], children);
+            renderer: (usedAbility?: PreDmgUsedAbility<BlmGaugeState>) => {
+                if (usedAbility === null) {
+                    return document.createTextNode("");
                 }
-                return document.createTextNode("");
+
+                const gauge = usedAbility.gaugeAfter;
+
+                const children = [];
+
+                if (gauge.element === BlmElement.Ice) {
+                    for (let i = 1; i <= 3; i++) {
+                        children.push(quickElement('span', [i <= gauge.elementLevel ? 'blm-element-ice' : 'blm-element-default'], []));
+                    }
+                }
+                else if (gauge.element === BlmElement.Fire) {
+                    for (let i = 1; i <= 3; i++) {
+                        children.push(quickElement('span', [i <= gauge.elementLevel ? 'blm-element-fire' : 'blm-element-default'], []));
+                    }
+                }
+                else {
+                    for (let i = 1; i <= 3; i++) {
+                        children.push(quickElement('span', ['blm-element-default'], []));
+                    }
+                }
+
+                if (gauge.level >= 90) {
+                    children.push(quickElement('span', [gauge.paradox ? 'blm-paradox-full' : 'blm-paradox-default'], []));
+                }
+
+                return quickElement('div', ['icon-gauge-holder'], children);
             },
         }), col({
             shortName: 'umbral-hearts',
             displayName: 'Umbral Hearts',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: PreDmgUsedAbility) => {
-                if (usedAbility?.extraData !== undefined) {
-                    const umbralHearts = (usedAbility.extraData as BlmExtraData).gauge.umbralHearts;
-
-                    const children = [];
-
-                    for (let i = 1; i <= 3; i++) {
-                        children.push(quickElement('span', [i <= umbralHearts ? 'blm-umbralhearts-full' : 'blm-umbralhearts-default'], []));
-                    }
-
-                    return quickElement('div', ['icon-gauge-holder'], children);
+            renderer: (usedAbility?: PreDmgUsedAbility<BlmGaugeState>) => {
+                if (usedAbility === null) {
+                    return document.createTextNode("");
                 }
-                return document.createTextNode("");
+
+                const umbralHearts = usedAbility.gaugeAfter.umbralHearts;
+
+                const children = [];
+
+                for (let i = 1; i <= 3; i++) {
+                    children.push(quickElement('span', [i <= umbralHearts ? 'blm-umbralhearts-full' : 'blm-umbralhearts-default'], []));
+                }
+
+                return quickElement('div', ['icon-gauge-holder'], children);
             },
         }), col({
             shortName: 'polyglot',
             displayName: 'Polyglot',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: PreDmgUsedAbility) => {
-                if (usedAbility?.extraData !== undefined) {
-                    const polyglot = (usedAbility.extraData as BlmExtraData).gauge.polyglot;
-
-                    const children = [];
-
-                    for (let i = 1; i <= 3; i++) {
-                        children.push(quickElement('span', [i <= polyglot ? 'blm-polyglot-full' : 'blm-polyglot-default'], []));
-                    }
-
-                    return quickElement('div', ['icon-gauge-holder'], children);
+            renderer: (usedAbility?: PreDmgUsedAbility<BlmGaugeState>) => {
+                if (usedAbility === null) {
+                    return document.createTextNode("");
                 }
-                return document.createTextNode("");
+
+                const polyglot = usedAbility.gaugeAfter.polyglot;
+
+                const children = [];
+
+                for (let i = 1; i <= 3; i++) {
+                    children.push(quickElement('span', [i <= polyglot ? 'blm-polyglot-full' : 'blm-polyglot-default'], []));
+                }
+
+                return quickElement('div', ['icon-gauge-holder'], children);
             },
         }), col({
             shortName: 'astral-soul',
             displayName: 'Astral Soul',
-            getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: PreDmgUsedAbility) => {
-                if (usedAbility?.extraData !== undefined) {
-                    const astralSoul = (usedAbility.extraData as BlmExtraData).gauge.astralSoul;
-
-                    const children = [];
-
-                    for (let i = 1; i <= 6; i++) {
-                        children.push(quickElement('span', [i <= astralSoul ? 'blm-astralsoul-full' : 'blm-astralsoul-default'], []));
-                    }
-
-                    return quickElement('div', ['icon-gauge-holder'], children);
+            getter: used => isFinalizedAbilityUse(used) && ((used.original.gaugeAfter as BlmGaugeState).level === 100) ? used.original : null,
+            renderer: (usedAbility?: PreDmgUsedAbility<BlmGaugeState>) => {
+                if (usedAbility === null || usedAbility.gaugeAfter.level < 100) {
+                    return document.createTextNode("");
                 }
-                return document.createTextNode("");
+
+                const astralSoul = usedAbility.gaugeAfter.astralSoul;
+
+                const children = [];
+
+                for (let i = 1; i <= 6; i++) {
+                    children.push(quickElement('span', [i <= astralSoul ? 'blm-astralsoul-full' : 'blm-astralsoul-default'], []));
+                }
+
+                return quickElement('div', ['icon-gauge-holder'], children);
             },
         }), col({
             shortName: 'mp',
             displayName: 'MP',
             getter: used => isFinalizedAbilityUse(used) ? used.original : null,
-            renderer: (usedAbility?: PreDmgUsedAbility) => {
-                if (usedAbility?.extraData !== undefined) {
-                    const mp = (usedAbility.extraData as BlmExtraData).gauge.mp;
-
-                    const div = document.createElement('div');
-                    div.style.height = '100%';
-                    div.style.display = 'flex';
-                    div.style.alignItems = 'center';
-                    div.style.gap = '6px';
-                    div.style.padding = '2px 0 2px 0';
-                    div.style.boxSizing = 'border-box';
-
-                    const span = document.createElement('span');
-                    span.textContent = `${mp}`;
-
-                    const barOuter = document.createElement('div');
-                    barOuter.style.borderRadius = '20px';
-                    barOuter.style.background = '#00000033';
-                    barOuter.style.width = '120px';
-                    barOuter.style.height = 'calc(100% - 3px)';
-                    barOuter.style.display = 'inline-block';
-                    barOuter.style.overflow = 'hidden';
-                    barOuter.style.border = '1px solid black';
-
-                    const barInner = document.createElement('div');
-                    barInner.style.backgroundColor = '#df5591';
-                    barInner.style.width = `${Math.round((mp / 10000) * 100)}%`;
-                    barInner.style.height = '100%';
-                    barOuter.appendChild(barInner);
-
-                    div.appendChild(barOuter);
-                    div.appendChild(span);
-
-                    return div;
+            renderer: (usedAbility?: PreDmgUsedAbility<BlmGaugeState>) => {
+                if (usedAbility === null) {
+                    return document.createTextNode("");
                 }
-                return document.createTextNode("");
+
+                const mp = usedAbility.gaugeAfter.magicPoints;
+
+                const div = document.createElement('div');
+                div.style.height = '100%';
+                div.style.display = 'flex';
+                div.style.alignItems = 'center';
+                div.style.gap = '6px';
+                div.style.padding = '2px 0 2px 0';
+                div.style.boxSizing = 'border-box';
+
+                const span = document.createElement('span');
+                span.textContent = `${mp}`;
+
+                const barOuter = document.createElement('div');
+                barOuter.style.borderRadius = '20px';
+                barOuter.style.background = '#00000033';
+                barOuter.style.width = '120px';
+                barOuter.style.height = 'calc(100% - 3px)';
+                barOuter.style.display = 'inline-block';
+                barOuter.style.overflow = 'hidden';
+                barOuter.style.border = '1px solid black';
+
+                const barInner = document.createElement('div');
+                barInner.style.backgroundColor = '#df5591';
+                barInner.style.width = `${Math.round((mp / 10000) * 100)}%`;
+                barInner.style.height = '100%';
+                barOuter.appendChild(barInner);
+
+                div.appendChild(barOuter);
+                div.appendChild(span);
+
+                return div;
             },
         })];
     }
@@ -149,7 +159,7 @@ export class BlmSimGui extends BaseMultiCycleSimGui<BlmSimResult, BlmSettings> {
 
         const flareOpenerCB = new FieldBoundCheckBox(settings, "useFlareOpener");
 
-        configDiv.appendChild(labeledCheckbox("Use Flare opener", flareOpenerCB));
+        configDiv.appendChild(labeledCheckbox("Use alternative single-target Flare opener", flareOpenerCB));
 
         const transposeFromUICB = new FieldBoundCheckBox(settings, "transposeFromUmbralIce");
 
@@ -158,6 +168,7 @@ export class BlmSimGui extends BaseMultiCycleSimGui<BlmSimResult, BlmSettings> {
         const transposeFromAFCB = new FieldBoundCheckBox(settings, "transposeFromAstralFire");
 
         configDiv.appendChild(labeledCheckbox("Transpose out of Astral Fire (instant UI1 B3)", transposeFromAFCB));
+
         return configDiv;
     }
 }


### PR DESCRIPTION
Cleaned leftover comments/code from DRK sim

Updated to use the new gauge system instead of a custom gauge
Fixed Blizzard IV having a 3.5s cast time instead of the intended 2.0s cast time

Some notes, I changed the element from being a number between -3 and +3 to being its own type, but with the gauge system change I'm not sure this information is even needed anymore, but it can't hurt to keep it in there.

I added a counter of cooldown drift and GCD clips at the end of the timeline, mostly to sanity check. Still would really like to improve the way oGCD weaves are handled (because burst is a mess atm) but for now I think it's good enough.

Some GCD speeds also don't align properly / align weirdly to refresh Thunder on time due to Thunderhead, this is not handled well for now.

I also just don't bother to check for GCD clips at level 70 because there's so few weave slots to begin with. 