### PR TITLE
Replace | and %7C with _ in xivgear URLs

### DIFF
--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -22,10 +22,10 @@ import {
     NavState,
     ONLY_SET_QUERY_PARAM,
     parsePath,
-    PATH_SEPARATOR,
     PREVIEW_MAX_DESC_LENGTH,
     PREVIEW_MAX_NAME_LENGTH,
     SELECTION_INDEX_QUERY_PARAM,
+    splitPath,
     tryParseOptionalIntParam
 } from "@xivgear/core/nav/common_nav";
 import {nonCachedFetch} from "./polyfills";
@@ -241,7 +241,7 @@ export function buildStatsServer() {
         const path = request.query?.[HASH_QUERY_PARAM] ?? '';
         const osIndex: number | undefined = tryParseOptionalIntParam(request.query[ONLY_SET_QUERY_PARAM]);
         const selIndex: number | undefined = tryParseOptionalIntParam(request.query[SELECTION_INDEX_QUERY_PARAM]);
-        const pathPaths = path.split(PATH_SEPARATOR);
+        const pathPaths = splitPath(path);
         const state = new NavState(pathPaths, osIndex, selIndex);
         const nav = parsePath(state);
         request.log.info(pathPaths, 'Path');
@@ -279,7 +279,7 @@ export function buildStatsServer() {
         const path = request.query?.[HASH_QUERY_PARAM] ?? '';
         const osIndex: number | undefined = tryParseOptionalIntParam(request.query[ONLY_SET_QUERY_PARAM]);
         const selIndex: number | undefined = tryParseOptionalIntParam(request.query[SELECTION_INDEX_QUERY_PARAM]);
-        const pathPaths = path.split(PATH_SEPARATOR);
+        const pathPaths = splitPath(path);
         const state = new NavState(pathPaths, osIndex, selIndex);
         const nav = parsePath(state);
         request.log.info(pathPaths, 'Path');
@@ -297,7 +297,7 @@ export function buildStatsServer() {
         const path = request.query?.[HASH_QUERY_PARAM] ?? '';
         const osIndex: number | undefined = tryParseOptionalIntParam(request.query[ONLY_SET_QUERY_PARAM]);
         const selIndex: number | undefined = tryParseOptionalIntParam(request.query[SELECTION_INDEX_QUERY_PARAM]);
-        const pathPaths = path.split(PATH_SEPARATOR);
+        const pathPaths = splitPath(path);
         const state = new NavState(pathPaths, osIndex, selIndex);
         const nav = parsePath(state);
         request.log.info(pathPaths, 'Path');
@@ -401,7 +401,7 @@ export function buildPreviewServer() {
             const path = request.query[HASH_QUERY_PARAM] ?? '';
             const osIndex: number | undefined = tryParseOptionalIntParam(request.query[ONLY_SET_QUERY_PARAM]);
             const selIndex: number | undefined = tryParseOptionalIntParam(request.query[SELECTION_INDEX_QUERY_PARAM]);
-            const pathPaths = path.split(PATH_SEPARATOR);
+            const pathPaths = splitPath(path);
             const state = new NavState(pathPaths, osIndex, selIndex);
             const nav = parsePath(state);
             request.log.info(pathPaths, 'Path');

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -22,8 +22,10 @@ export const VIEW_SET_HASH = 'viewset';
 export const EMBED_HASH = 'embed';
 /** Prefix for formula pages */
 export const CALC_HASH = 'math';
-/** Path separator */
-export const PATH_SEPARATOR = '|';
+/** The path separator */
+export const PATH_SEPARATOR = '_';
+/** The legacy path separator */
+export const PATH_SEPARATOR_LEGACY = '|';
 /** The query param used to represent the path */
 export const HASH_QUERY_PARAM = 'page';
 
@@ -281,7 +283,7 @@ export function makeUrlSimple(...path: string[]): URL {
 export function makeUrl(navState: NavState): URL {
     const joinedPath = navState.path
         .map(pp => encodeURIComponent(pp))
-        .map(pp => pp.replaceAll(PATH_SEPARATOR, VERTICAL_BAR_REPLACEMENT))
+        .map(pp => pp.replaceAll(PATH_SEPARATOR_LEGACY, VERTICAL_BAR_REPLACEMENT))
         .join(PATH_SEPARATOR);
     const currentLocation = document.location;
     const params = new URLSearchParams(currentLocation.search);
@@ -317,16 +319,24 @@ export function splitHashLegacy(input: string) {
 
 /**
  * Given a page path, split it into constituent parts
- * (e.g. for ?page=foo|bar, splitPath('foo|bar') => ['foo', 'bar']
+ * e.g. for ?page=foo_bar, splitPath('foo_bar') => ['foo', 'bar']
+ * or, legacy: for ?page=foo|bar, splitPath('foo|bar') => ['foo', 'bar']
  *
  * @param input The path, not including ?page=
  */
 export function splitPath(input: string) {
-    return (input.startsWith(PATH_SEPARATOR) ? input.substring(1) : input)
-        .split(PATH_SEPARATOR)
+    let separatorToUse = PATH_SEPARATOR;
+
+    // If this link includes the old separator, use that instead.
+    if (input.includes(VERTICAL_BAR_REPLACEMENT) || input.includes(PATH_SEPARATOR_LEGACY)) {
+        separatorToUse = PATH_SEPARATOR_LEGACY;
+    }
+
+    return (input.startsWith(separatorToUse) ? input.substring(1) : input)
+        .split(separatorToUse)
         .filter(item => item)
         .map(item => decodeURIComponent(item))
-        .map(pp => pp.replaceAll(VERTICAL_BAR_REPLACEMENT, PATH_SEPARATOR));
+        .map(pp => pp.replaceAll(VERTICAL_BAR_REPLACEMENT, PATH_SEPARATOR_LEGACY));
 }
 
 export function tryParseOptionalIntParam(input: string | undefined): number | undefined {

--- a/packages/core/src/test/common_nav_test.ts
+++ b/packages/core/src/test/common_nav_test.ts
@@ -5,17 +5,26 @@ describe('path splitting and joining', () => {
     it('legacy handling converts properly', () => {
         const pathOriginal = '#/foo|bar/asdf|zxcv';
         const legacySplit = splitHashLegacy(pathOriginal);
-        expect(legacySplit).to.deep.equals(['foo|bar', 'asdf|zxcv']);
+        expect(legacySplit).to.deep.equals(['foo_bar', 'asdf_zxcv']);
     });
-    it('splitting splits properly', () => {
+    it('splitting splits properly legacy separator', () => {
         const pathOriginal = 'foo/bar|asdf/zxcv';
         const newSplit = splitPath(pathOriginal);
         expect(newSplit).to.deep.equals(['foo/bar', 'asdf/zxcv']);
     });
+    it('splitting splits properly', () => {
+        const pathOriginal = 'foo/bar_asdf/zxcv';
+        const newSplit = splitPath(pathOriginal);
+        expect(newSplit).to.deep.equals(['foo/bar', 'asdf/zxcv']);
+    });
+    it('splitting splits properly 2', () => {
+        const pathOriginal = 'foo_bar_asdf_zxcv';
+        const newSplit = splitPath(pathOriginal);
+        expect(newSplit).to.deep.equals(['foo', 'bar', 'asdf', 'zxcv']);
+    });
 });
 
 describe('parsePath', () => {
-
     describe('mysheets', () => {
         it('resolves empty path to mysheets', () => {
             const result = parsePath(new NavState([]));


### PR DESCRIPTION
This commit replaces `|`/`%7C` in xivgear URLs with `_`. 

It really affects the readability of e.g. <https://xivgear.app/?page=bis%7Cdrk%7Cultimate%7Cucob#> and there have been issues in the past with knowing where the GUID starts ends for e.g. <https://xivgear.app/?page=sl%7C9d117608-acc4-415f-97fd-6c4dddbd790a> because the '7C' looks like part of it.

Advantages:
- It doesn't ever get URL encoded
- It's not part of a GUID, like `-` or alphanumeric characters
- I should make gaps in words clear, unlike e.g. `.` (one of the few other options)

This means URLs will have `_` in them instead of `%7C`, which I think makes them much more readable.

Death to `%7C`, long live the new flesh