### PR TITLE
Remove validation for item level filters

### DIFF
--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -80,6 +80,7 @@ body {
   --role-color-tank: #4848ff;
   --role-color-healer: #13a813;;
   --role-color-dps: #ff0000;
+  --invalid-input-box-shadow: 1px 1px 2px red inset, -1px -1px 2px #ff6000 inset;
 
   --perfect-tiering-box-shadow: 0 0 5px -1px inset color-mix(in srgb, var(--stat-color) 50%, var(--border-color));
 
@@ -714,17 +715,14 @@ button {
   padding-right: 8px;
 }
 
-
 input {
   &[type="text"],
   &[type="number"],
   &[type="password"],
   &[type="email"] {
     color: var(--fg-color);
-    //background-color: var(--input-background-color);
     .standard-border-radius();
     border-color: var(--border-color);
-
     &:invalid {
       border-color: var(--error-border-color);
     }
@@ -2637,7 +2635,7 @@ input.gear-items-table-relic-stat-input, select.gear-items-table-relic-stat-inpu
   height: calc(100% - 4px);
 
   &.relic-validation-failed {
-    box-shadow: 1px 1px 2px red inset, -1px -1px 2px #ff6000 inset;
+    box-shadow: var(--invalid-input-box-shadow);
   }
 
   &:hover, &:active, &:focus {

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -318,6 +318,10 @@ body {
   border: var(--standard-border);
 }
 
+.invalid-numeric-input {
+  box-shadow: var(--invalid-input-box-shadow);
+}
+
 .standard-round-border {
   .standard-border-radius();
   .standard-border();
@@ -2635,7 +2639,7 @@ input.gear-items-table-relic-stat-input, select.gear-items-table-relic-stat-inpu
   height: calc(100% - 4px);
 
   &.relic-validation-failed {
-    box-shadow: var(--invalid-input-box-shadow);
+    .invalid-numeric-input();
   }
 
   &:hover, &:active, &:focus {

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1085,8 +1085,6 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
             if (min > max) {
                 lowerBoundControl.classList.add("invalid-numeric-input");
                 upperBoundControl.classList.add("invalid-numeric-input");
-                //lowerBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
-                //upperBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
             }
             else {
                 lowerBoundControl.classList.remove("invalid-numeric-input");

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1081,6 +1081,26 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
 
         const lowerBoundControl = new FieldBoundIntField(obj, minField);
         const upperBoundControl = new FieldBoundIntField(obj, maxField);
+        // const lowerBoundControl = new FieldBoundIntField(obj, minField, {
+        //     postValidators: [(ctx) => {
+        //         if (ctx.newValue >= (obj[maxField] as number)) {
+        //             const warningMessage = "Warning: minimum item level number equal or higher than maximum item level number.";
+        //             lowerBoundControl._validationMessage = warningMessage;
+        //         } else {
+        //             lowerBoundControl._validationMessage = undefined;
+        //         }
+        //     }],
+        // });
+        // const upperBoundControl = new FieldBoundIntField(obj, maxField, {
+        //     postValidators: [(ctx) => {
+        //         if (ctx.newValue <= (obj[minField] as number)) {
+        //             const warningMessage = "Warning: minimum item level number equal or higher than maximum item level number.";
+        //             upperBoundControl._validationMessage = warningMessage;
+        //         } else {
+        //             upperBoundControl._validationMessage = undefined;
+        //         }
+        //     }],
+        // });
         lowerBoundControl.addListener(() => this.runListeners());
         upperBoundControl.addListener(() => this.runListeners());
         const hyphen = document.createElement('span');
@@ -1088,6 +1108,33 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
         this.appendChild(lowerBoundControl);
         this.appendChild(hyphen);
         this.appendChild(upperBoundControl);
+
+        // const borderListener = function(min: number, max: number) {
+
+        //     if (min >= max) {
+        //         const warningMessage = "Warning: minimum item level number equal or higher than maximum item level number.";
+        //         lowerBoundControl._validationMessage = warningMessage;
+        //         upperBoundControl._validationMessage = warningMessage;
+        //     }
+        //     else {
+        //         lowerBoundControl._validationMessage = undefined;
+        //         upperBoundControl._validationMessage = undefined;
+        //         //lowerBoundControl.setCustomValidity("");
+        //         //.setCustomValidity("");
+        //     }
+        // };
+        // this._listeners.push(borderListener);
+
+        // const minFieldNumber = minField as number;
+        // const maxFieldNumber = maxField as number;
+        // if (minFieldNumber >= maxFieldNumber) {
+        //     //lowerBoundControl
+        //     //lowerBoundControl.classList.add("invalid");
+        // }
+        // else {
+        //     this.style.borderStyle = "none";
+        // }
+        this.runListeners();
     }
 
     addListener(listener: (min: number, max: number) => void) {
@@ -1095,8 +1142,23 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
     }
 
     private runListeners() {
+        const minField = this.obj[this.minField] as number;
+        const maxField = this.obj[this.maxField] as number;
         for (const listener of this._listeners) {
-            listener(this.obj[this.minField] as number, this.obj[this.maxField] as number);
+            listener(minField, maxField);
+        }
+        this.highlightIncorrectConfig(minField, maxField);
+    }
+
+    // highlightIncorrectConfig highlights, but does not block, incorrect config.
+    // it will also remove the highlight when it is correct again.
+    private highlightIncorrectConfig(minField: number, maxField: number) {
+        if (minField >= maxField) {
+            this.style.borderStyle = "solid";
+            this.style.borderColor = "var(--error-border-color)";
+        }
+        else {
+            this.style.borderStyle = "none";
         }
     }
 }

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1079,20 +1079,8 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
             this.appendChild(labelElement);
         }
 
-        const lowerBoundControl = new FieldBoundIntField(obj, minField, {
-            postValidators: [(ctx) => {
-                if (ctx.newValue > (obj[maxField] as number)) {
-                    ctx.failValidation('Minimum level must be less than the maximum level');
-                }
-            }],
-        });
-        const upperBoundControl = new FieldBoundIntField(obj, maxField, {
-            postValidators: [(ctx) => {
-                if (ctx.newValue < (obj[minField] as number)) {
-                    ctx.failValidation('Maximum level must be greater than the minimum level');
-                }
-            }],
-        });
+        const lowerBoundControl = new FieldBoundIntField(obj, minField);
+        const upperBoundControl = new FieldBoundIntField(obj, maxField);
         lowerBoundControl.addListener(() => this.runListeners());
         upperBoundControl.addListener(() => this.runListeners());
         const hyphen = document.createElement('span');

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1081,6 +1081,18 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
 
         const lowerBoundControl = new FieldBoundIntField(obj, minField);
         const upperBoundControl = new FieldBoundIntField(obj, maxField);
+        const borderListener = function(min: number, max: number) {
+            if (min >= max) {
+                lowerBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
+                upperBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
+            }
+            else {
+                lowerBoundControl.style.boxShadow = "";
+                upperBoundControl.style.boxShadow = "";
+            }
+        };
+        this._listeners.push(borderListener);
+
         lowerBoundControl.addListener(() => this.runListeners());
         upperBoundControl.addListener(() => this.runListeners());
         const hyphen = document.createElement('span');
@@ -1100,19 +1112,6 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
         const maxField = this.obj[this.maxField] as number;
         for (const listener of this._listeners) {
             listener(minField, maxField);
-        }
-        this.highlightIncorrectConfig(minField, maxField);
-    }
-
-    // highlightIncorrectConfig highlights, but does not block, incorrect config.
-    // it will also remove the highlight when it is correct again.
-    private highlightIncorrectConfig(minField: number, maxField: number) {
-        if (minField >= maxField) {
-            this.style.borderStyle = "solid";
-            this.style.borderColor = "var(--error-border-color)";
-        }
-        else {
-            this.style.borderStyle = "none";
         }
     }
 }

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1082,13 +1082,15 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
         const lowerBoundControl = new FieldBoundIntField(obj, minField);
         const upperBoundControl = new FieldBoundIntField(obj, maxField);
         const borderListener = function(min: number, max: number) {
-            if (min >= max) {
-                lowerBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
-                upperBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
+            if (min > max) {
+                lowerBoundControl.classList.add("invalid-numeric-input");
+                upperBoundControl.classList.add("invalid-numeric-input");
+                //lowerBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
+                //upperBoundControl.style.boxShadow = "var(--invalid-input-box-shadow)";
             }
             else {
-                lowerBoundControl.style.boxShadow = "";
-                upperBoundControl.style.boxShadow = "";
+                lowerBoundControl.classList.remove("invalid-numeric-input");
+                upperBoundControl.classList.remove("invalid-numeric-input");
             }
         };
         this._listeners.push(borderListener);

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1081,26 +1081,6 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
 
         const lowerBoundControl = new FieldBoundIntField(obj, minField);
         const upperBoundControl = new FieldBoundIntField(obj, maxField);
-        // const lowerBoundControl = new FieldBoundIntField(obj, minField, {
-        //     postValidators: [(ctx) => {
-        //         if (ctx.newValue >= (obj[maxField] as number)) {
-        //             const warningMessage = "Warning: minimum item level number equal or higher than maximum item level number.";
-        //             lowerBoundControl._validationMessage = warningMessage;
-        //         } else {
-        //             lowerBoundControl._validationMessage = undefined;
-        //         }
-        //     }],
-        // });
-        // const upperBoundControl = new FieldBoundIntField(obj, maxField, {
-        //     postValidators: [(ctx) => {
-        //         if (ctx.newValue <= (obj[minField] as number)) {
-        //             const warningMessage = "Warning: minimum item level number equal or higher than maximum item level number.";
-        //             upperBoundControl._validationMessage = warningMessage;
-        //         } else {
-        //             upperBoundControl._validationMessage = undefined;
-        //         }
-        //     }],
-        // });
         lowerBoundControl.addListener(() => this.runListeners());
         upperBoundControl.addListener(() => this.runListeners());
         const hyphen = document.createElement('span');
@@ -1108,32 +1088,6 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
         this.appendChild(lowerBoundControl);
         this.appendChild(hyphen);
         this.appendChild(upperBoundControl);
-
-        // const borderListener = function(min: number, max: number) {
-
-        //     if (min >= max) {
-        //         const warningMessage = "Warning: minimum item level number equal or higher than maximum item level number.";
-        //         lowerBoundControl._validationMessage = warningMessage;
-        //         upperBoundControl._validationMessage = warningMessage;
-        //     }
-        //     else {
-        //         lowerBoundControl._validationMessage = undefined;
-        //         upperBoundControl._validationMessage = undefined;
-        //         //lowerBoundControl.setCustomValidity("");
-        //         //.setCustomValidity("");
-        //     }
-        // };
-        // this._listeners.push(borderListener);
-
-        // const minFieldNumber = minField as number;
-        // const maxFieldNumber = maxField as number;
-        // if (minFieldNumber >= maxFieldNumber) {
-        //     //lowerBoundControl
-        //     //lowerBoundControl.classList.add("invalid");
-        // }
-        // else {
-        //     this.style.borderStyle = "none";
-        // }
         this.runListeners();
     }
 


### PR DESCRIPTION
This is my number one UX pain point with xivgear that I finally remembered to get around to fixing.

With the current validator, it prevents you from changing them in the 'wrong order', leaving the one you tried to initially change as an incorrect input (e.g. if you were trying to type 500, it might be left as 50), meaning you have to re-enter everything.

It's super common for me to want to change the minimum first, and it commonly prevents me and it's very very annoying.

I considered adding some other kind of warning, but I think that's kind of solved by the existing items message
<img width="388" height="235" alt="image" src="https://github.com/user-attachments/assets/4c9d5b81-2500-4283-8b54-45dd78ec4cee" />
