### PR TITLE
Dialog for modifying sync info of an existing sheet

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -19,7 +19,7 @@
     <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myValues">
         <value>
-          <list size="59">
+          <list size="60">
             <item index="0" class="java.lang.String" itemvalue="nobr" />
             <item index="1" class="java.lang.String" itemvalue="noembed" />
             <item index="2" class="java.lang.String" itemvalue="comment" />
@@ -79,6 +79,7 @@
             <item index="56" class="java.lang.String" itemvalue="conflict-resolution-dialog" />
             <item index="57" class="java.lang.String" itemvalue="change-password-modal" />
             <item index="58" class="java.lang.String" itemvalue="finalize-password-reset-modal" />
+            <item index="59" class="java.lang.String" itemvalue="change-props-modal" />
           </list>
         </value>
       </option>

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -982,7 +982,7 @@ div.chance-stat-display, div.multiplier-stat-display, div.multiplier-mit-stat-di
 }
 
 
-#new-sheet-form, save-as-modal {
+#new-sheet-form, save-as-modal, change-props-modal {
   fieldset {
     text-align: center;
     display: inline-grid;

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -190,8 +190,8 @@ export class GearPlanSheet {
     readonly classJobName: JobName;
     readonly altJobs: JobName[];
     readonly isMultiJob: boolean;
-    readonly level: SupportedLevel;
-    readonly ilvlSync: number | undefined;
+    private _level: SupportedLevel;
+    private _ilvlSync: number | undefined;
     private _race: RaceName | undefined;
     private _partyBonus: PartyBonusAmount;
     private readonly _saveKey: string | undefined;
@@ -244,7 +244,7 @@ export class GearPlanSheet {
         this._importedData = importedData;
         this._saveKey = sheetKey;
         this._sheetName = importedData.name;
-        this.level = importedData.level ?? CURRENT_MAX_LEVEL;
+        this._level = importedData.level ?? CURRENT_MAX_LEVEL;
         this._race = importedData.race;
         this._partyBonus = importedData.partyBonus ?? 0;
         // TODO: why does this default to WHM? Shouldn't it just throw?
@@ -256,7 +256,7 @@ export class GearPlanSheet {
                 // Don't include the primary job in the list of alt jobs
                 && job !== this.classJobName),
         ] : [];
-        this.ilvlSync = importedData.ilvlSync;
+        this._ilvlSync = importedData.ilvlSync;
         this._description = importedData.description;
         if (importedData.itemDisplaySettings) {
             Object.assign(this._itemDisplaySettings, importedData.itemDisplaySettings);
@@ -493,6 +493,26 @@ export class GearPlanSheet {
 
     set sheetName(name: string) {
         this._sheetName = name;
+        this.requestSave();
+    }
+
+    get level(): SupportedLevel {
+        return this._level;
+    }
+
+    set level(value: SupportedLevel) {
+        this._level = value;
+        // Defer heavy reloads; caller will reload sheet if necessary
+        this.requestSave();
+    }
+
+    get ilvlSync(): number | undefined {
+        return this._ilvlSync;
+    }
+
+    set ilvlSync(value: number | undefined) {
+        this._ilvlSync = value;
+        // Defer recalculation; caller can reload
         this.requestSave();
     }
 

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -187,9 +187,9 @@ export class GearPlanSheet {
     // General sheet properties
     private _sheetName: string;
     private _description: string | undefined;
-    readonly classJobName: JobName;
+    classJobName: JobName;
     readonly altJobs: JobName[];
-    readonly isMultiJob: boolean;
+    isMultiJob: boolean;
     level: SupportedLevel;
     ilvlSync: number | undefined;
     private _race: RaceName | undefined;
@@ -509,6 +509,7 @@ export class GearPlanSheet {
         this.requestSave();
     }
 
+
     /**
      * Copy this sheet to a new save slot.
      *
@@ -540,6 +541,7 @@ export class GearPlanSheet {
         }
         return this.sheetManager.saveAs(exported);
     }
+
 
     exportSims(external: boolean): SimExport[] {
         return this._sims.filter(sim => !external || sim.settings.includeInExport).map(sim =>
@@ -751,7 +753,7 @@ export class GearPlanSheet {
             if (set.materiaMemory) {
                 out.materiaMemory = set.materiaMemory.export();
             }
-            if (set.jobOverride) {
+            if (this.isMultiJob && set.jobOverride) {
                 out.jobOverride = set.jobOverride;
             }
         }

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -190,8 +190,8 @@ export class GearPlanSheet {
     readonly classJobName: JobName;
     readonly altJobs: JobName[];
     readonly isMultiJob: boolean;
-    private _level: SupportedLevel;
-    private _ilvlSync: number | undefined;
+    level: SupportedLevel;
+    ilvlSync: number | undefined;
     private _race: RaceName | undefined;
     private _partyBonus: PartyBonusAmount;
     private readonly _saveKey: string | undefined;
@@ -244,7 +244,7 @@ export class GearPlanSheet {
         this._importedData = importedData;
         this._saveKey = sheetKey;
         this._sheetName = importedData.name;
-        this._level = importedData.level ?? CURRENT_MAX_LEVEL;
+        this.level = importedData.level ?? CURRENT_MAX_LEVEL;
         this._race = importedData.race;
         this._partyBonus = importedData.partyBonus ?? 0;
         // TODO: why does this default to WHM? Shouldn't it just throw?
@@ -256,7 +256,7 @@ export class GearPlanSheet {
                 // Don't include the primary job in the list of alt jobs
                 && job !== this.classJobName),
         ] : [];
-        this._ilvlSync = importedData.ilvlSync;
+        this.ilvlSync = importedData.ilvlSync;
         this._description = importedData.description;
         if (importedData.itemDisplaySettings) {
             Object.assign(this._itemDisplaySettings, importedData.itemDisplaySettings);
@@ -496,25 +496,6 @@ export class GearPlanSheet {
         this.requestSave();
     }
 
-    get level(): SupportedLevel {
-        return this._level;
-    }
-
-    set level(value: SupportedLevel) {
-        this._level = value;
-        // Defer heavy reloads; caller will reload sheet if necessary
-        this.requestSave();
-    }
-
-    get ilvlSync(): number | undefined {
-        return this._ilvlSync;
-    }
-
-    set ilvlSync(value: number | undefined) {
-        this._ilvlSync = value;
-        // Defer recalculation; caller can reload
-        this.requestSave();
-    }
 
     /**
      * The description of the sheet.

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -266,6 +266,22 @@ export abstract class BaseSheetSettingsModal extends BaseModal {
         return this.fieldSet.nameInput.value;
     }
 
+    protected confirmJobMultiChange(currentJob: JobName, currentIsMultiJob: boolean, newJob: JobName, newIsMultiJob: boolean): boolean {
+        if (newJob !== currentJob && !newIsMultiJob) {
+            const result = confirm(`You are attempting to change a sheet from ${currentJob} to ${newJob}. Weapons and other class-specific items will be de-selected if they are not equippable as ${newJob}.`);
+            if (!result) {
+                return false;
+            }
+        }
+        else if (currentIsMultiJob && !newIsMultiJob) {
+            const result = confirm(`You are attempting to change a sheet from multi-job to single-job. Items may need to be re-selected if they are not equippable as ${newJob}.`);
+            if (!result) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     protected abstract onSubmit(): void;
 }
 
@@ -294,17 +310,8 @@ export class SaveAsModal extends BaseSheetSettingsModal {
         const level: SupportedLevel = this.level;
         const newJob = this.selectedJob ?? this.existingSheet.classJobName;
         const multiJob = this.multiJob;
-        if (newJob !== this.existingSheet.classJobName && !multiJob) {
-            const result = confirm(`You are attempting to change a sheet from ${this.existingSheet.classJobName} to ${newJob}. Weapons and other class-specific items will be de-selected if they are not equippable as ${newJob}.`);
-            if (!result) {
-                return;
-            }
-        }
-        else if (this.existingSheet.isMultiJob && !multiJob) {
-            const result = confirm(`You are attempting to change a sheet from multi-job to single-job. Items may need to be re-selected if they are not equippable as ${newJob}.`);
-            if (!result) {
-                return;
-            }
+        if (!this.confirmJobMultiChange(this.existingSheet.classJobName, this.existingSheet.isMultiJob, newJob, multiJob)) {
+            return;
         }
         const newSheetSaveKey: string = this.existingSheet.saveAs(
             this.nameValue,

--- a/packages/frontend/src/scripts/components/new_sheet_form.ts
+++ b/packages/frontend/src/scripts/components/new_sheet_form.ts
@@ -18,7 +18,6 @@ import {recordSheetEvent} from "@xivgear/gearplan-frontend/analytics/analytics";
 import {JobIcon} from "./job_icon";
 import {RoleKey, SheetSummary} from "@xivgear/xivmath/geartypes";
 import {openSheetByKey} from "../base_ui";
-import {LoadingBlocker} from "@xivgear/common-ui/components/loader";
 
 export type NewSheetTempSettings = {
     ilvlSyncEnabled: boolean,

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -2154,6 +2154,10 @@ export class GearPlanSheetGui extends GearPlanSheet {
     }
 
     showChangePropertiesDialog(): void {
+        if (!this.saveKey) {
+            alert('You must save this sheet before changing its properties. Use "Save As" first.');
+            return;
+        }
         new ChangePropsModal(this).attachAndShowExclusively();
     }
 }

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -50,8 +50,7 @@ import {
     RACE_STATS,
     RaceName,
     STAT_ABBREVIATIONS,
-    SupportedLevel,
-    JOB_DATA
+    SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
 import {getCurrentHash, getCurrentState, processNav} from "../nav_hash";
 import {MateriaTotalsDisplay} from "./materia";
@@ -77,7 +76,7 @@ import {SimCurrentResult, SimResult, SimSettings, SimSpec, Simulation} from "@xi
 import {getRegisteredSimSpecs} from "@xivgear/core/sims/sim_registry";
 import {makeUrl, NavState, ONLY_SET_QUERY_PARAM} from "@xivgear/core/nav/common_nav";
 import {simMaintainersInfoElement} from "./sims";
-import {SaveAsModal, BaseSheetSettingsModal} from "./new_sheet_form";
+import {ChangePropsModal, SaveAsModal} from "./new_sheet_form";
 import {DropdownActionMenu} from "./dropdown_actions_menu";
 import {CustomFoodPopup, CustomItemPopup} from "./custom_item_manager";
 import {confirmDelete} from "@xivgear/common-ui/components/delete_confirm";
@@ -1478,10 +1477,11 @@ export class GearPlanSheetGui extends GearPlanSheet {
 
         const siFmt = formatSyncInfo(this.syncInfo, this.level);
         if (siFmt !== null) {
-            const span = quickElement('span', [], [siFmt]);
-            const ilvlSyncLabel = quickElement('div', ['like-a-button', 'level-sync-info'], [span]);
-            ilvlSyncLabel.title = 'To change the item level sync, click the "Save As" button to create a new sheet with a different level/ilvl.';
-            buttonsArea.appendChild(ilvlSyncLabel);
+            const ilvlSyncBtn = makeActionButton(siFmt, () => {
+                const modal = new ChangePropsModal(this);
+                modal.attachAndShowExclusively();
+            });
+            buttonsArea.appendChild(ilvlSyncBtn);
         }
 
         if (!this.isViewOnly) {
@@ -1533,12 +1533,22 @@ export class GearPlanSheetGui extends GearPlanSheet {
         }
         else {
             sheetOptions.addAction({
-                label: 'Save As',
+                label: 'Save As...',
                 action: () => {
                     const modal = new SaveAsModal(this, newSheet => openSheetByKey(newSheet.saveKey));
                     modal.attachAndShowExclusively();
                 },
             });
+            if (this.saveKey) {
+                sheetOptions.addAction({
+                    label: 'Change Level/Job/Sync',
+                    action: () => {
+                        const modal = new ChangePropsModal(this);
+                        modal.attachAndShowExclusively();
+                    },
+                });
+
+            }
         }
 
         if (!this.isViewOnly) {
@@ -2160,60 +2170,6 @@ export class GearPlanSheetGui extends GearPlanSheet {
         }
         new ChangePropsModal(this).attachAndShowExclusively();
     }
-}
-
-export class ChangePropsModal extends BaseSheetSettingsModal {
-    constructor(private readonly sheet: GearPlanSheetGui) {
-        super({
-            name: sheet.sheetName,
-            job: sheet.classJobName,
-            level: sheet.level,
-            ilvlSyncEnabled: sheet.ilvlSync !== undefined,
-            ilvlSyncLevel: sheet.ilvlSync,
-            allowedRoles: [JOB_DATA[sheet.classJobName].role],
-            multiJob: sheet.isMultiJob,
-        }, 'Apply');
-        this.headerText = 'Change Sheet Properties';
-    }
-
-    protected onSubmit(): void {
-        const desiredJob = this.selectedJob ?? this.sheet.classJobName;
-        const desiredMultiJob = this.multiJob;
-
-        const newName = this.nameValue;
-        const newLevel = this.level;
-        const newIlvl = this.ilvlSyncEnabled ? this.ilvlSync : undefined;
-
-        if (!this.confirmJobMultiChange(this.sheet.classJobName, this.sheet.isMultiJob, desiredJob, desiredMultiJob)) {
-            return;
-        }
-
-        const changed = (this.sheet.sheetName !== newName)
-            || (this.sheet.classJobName !== desiredJob)
-            || (this.sheet.isMultiJob !== desiredMultiJob)
-            || (this.sheet.level !== newLevel)
-            || (this.sheet.ilvlSync !== newIlvl);
-        if (!changed) {
-            this.close();
-            return;
-        }
-
-        // Apply in-place updates for all fields, then save and reload this sheet
-        this.sheet.sheetName = newName;
-        this.sheet.classJobName = desiredJob;
-        this.sheet.isMultiJob = desiredMultiJob;
-        this.sheet.level = newLevel as SupportedLevel;
-        this.sheet.ilvlSync = newIlvl;
-        this.sheet.saveData();
-        if (this.sheet.saveKey) {
-            openSheetByKey(this.sheet.saveKey);
-        }
-        this.close();
-    }
-}
-
-if (!customElements.get('change-props-modal')) {
-    customElements.define('change-props-modal', ChangePropsModal);
 }
 
 export class ImportSetsModal extends BaseModal {

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -2187,23 +2187,10 @@ export class ChangePropsModal extends BaseSheetSettingsModal {
         if (!this.confirmJobMultiChange(this.sheet.classJobName, this.sheet.isMultiJob, desiredJob, desiredMultiJob)) {
             return;
         }
-        const jobOrMultiChanged = (desiredJob !== this.sheet.classJobName) || (desiredMultiJob !== this.sheet.isMultiJob);
-        if (jobOrMultiChanged) {
-            // Create a new sheet when changing job or multi-job, then open it
-            const newKey: string = this.sheet.saveAs(
-                newName,
-                desiredJob,
-                newLevel as SupportedLevel,
-                newIlvl,
-                desiredMultiJob
-            );
-            // Navigate to the newly created sheet
-            openSheetByKey(newKey);
-            this.close();
-            return;
-        }
 
         const changed = (this.sheet.sheetName !== newName)
+            || (this.sheet.classJobName !== desiredJob)
+            || (this.sheet.isMultiJob !== desiredMultiJob)
             || (this.sheet.level !== newLevel)
             || (this.sheet.ilvlSync !== newIlvl);
         if (!changed) {
@@ -2211,11 +2198,12 @@ export class ChangePropsModal extends BaseSheetSettingsModal {
             return;
         }
 
-        // Apply in-place updates for name/level/ilvl sync
+        // Apply in-place updates for all fields, then save and reload this sheet
         this.sheet.sheetName = newName;
+        this.sheet.classJobName = desiredJob;
+        this.sheet.isMultiJob = desiredMultiJob;
         this.sheet.level = newLevel as SupportedLevel;
         this.sheet.ilvlSync = newIlvl;
-        // Save immediately and reload the current sheet
         this.sheet.saveData();
         if (this.sheet.saveKey) {
             openSheetByKey(this.sheet.saveKey);

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -2184,6 +2184,9 @@ export class ChangePropsModal extends BaseSheetSettingsModal {
         const newLevel = this.level;
         const newIlvl = this.ilvlSyncEnabled ? this.ilvlSync : undefined;
 
+        if (!this.confirmJobMultiChange(this.sheet.classJobName, this.sheet.isMultiJob, desiredJob, desiredMultiJob)) {
+            return;
+        }
         const jobOrMultiChanged = (desiredJob !== this.sheet.classJobName) || (desiredMultiJob !== this.sheet.isMultiJob);
         if (jobOrMultiChanged) {
             // Create a new sheet when changing job or multi-job, then open it


### PR DESCRIPTION
Closes #727 

Creates an equivalent of the save-as dialog but modifies in place. It will reload the sheet since we need to invalidate all of the existing GearItems.

This UI can be accessed via "More Actions", *or* by clicking on the lvl/ilvl sync pill (it's a clickable button now).

The actual dialog uses the same UI as the "Save As" dialog.