### PR TITLE
Add optional buff application delay to actions

### DIFF
--- a/packages/core/src/sims/ability_helpers.ts
+++ b/packages/core/src/sims/ability_helpers.ts
@@ -2,7 +2,9 @@ import {STANDARD_ANIMATION_LOCK, STANDARD_APPLICATION_DELAY} from "@xivgear/xivm
 import {Ability, ComboData} from "./sim_types";
 
 /**
- * Returns the application delay of an ability (from time of snapshot to time of damage/effects applying).
+ * Returns the application delay of an ability (from time of snapshot to time of damage applying).
+ * By default, if a buffApplicationDelay is not specified, this will be used for the application
+ * delay of the buffs the ability grants, too.
  *
  * @param ability The ability in question
  */
@@ -11,7 +13,7 @@ export function appDelay(ability: Ability) {
 }
 
 /**
- * Returns the buff application delay of an ability (from time of snapshot to time of damage/effects applying).
+ * Returns the buff application delay of an ability (from time of snapshot to time of effects applying).
  *
  * @param ability The ability in question
  */

--- a/packages/core/src/sims/ability_helpers.ts
+++ b/packages/core/src/sims/ability_helpers.ts
@@ -8,7 +8,7 @@ import {Ability, ComboData} from "./sim_types";
  *
  * @param ability The ability in question
  */
-export function appDelay(ability: Ability) {
+export function damageAppDelay(ability: Ability) {
     return ability.appDelay ?? STANDARD_APPLICATION_DELAY;
 }
 
@@ -18,7 +18,7 @@ export function appDelay(ability: Ability) {
  * @param ability The ability in question
  */
 export function buffAppDelay(ability: Ability) {
-    return ability.buffApplicationDelay ?? appDelay(ability);
+    return ability.buffApplicationDelay ?? damageAppDelay(ability);
 }
 
 function defaultComboData(ability: Ability, hasOtherCombos: boolean): ComboData {

--- a/packages/core/src/sims/ability_helpers.ts
+++ b/packages/core/src/sims/ability_helpers.ts
@@ -10,6 +10,15 @@ export function appDelay(ability: Ability) {
     return ability.appDelay ?? STANDARD_APPLICATION_DELAY;
 }
 
+/**
+ * Returns the buff application delay of an ability (from time of snapshot to time of damage/effects applying).
+ *
+ * @param ability The ability in question
+ */
+export function buffAppDelay(ability: Ability) {
+    return ability.buffApplicationDelay ?? appDelay(ability);
+}
+
 function defaultComboData(ability: Ability, hasOtherCombos: boolean): ComboData {
     if (ability.type === 'gcd' && hasOtherCombos) {
         return {

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -29,7 +29,7 @@ import {
 } from "@xivgear/xivmath/xivconstants";
 import {CooldownMode, CooldownTracker} from "./common/cooldown_manager";
 import {addValues, fixedValue, multiplyFixed, multiplyIndependent, ValueWithDev} from "@xivgear/xivmath/deviation";
-import {abilityEquals, animationLock, appDelay, buffAppDelay, completeComboData, FinalizedComboData} from "./ability_helpers";
+import {abilityEquals, animationLock, damageAppDelay, buffAppDelay, completeComboData, FinalizedComboData} from "./ability_helpers";
 import {abilityToDamageNew, combineBuffEffects, noBuffEffects} from "./sim_utils";
 import {BuffSettingsExport} from "./common/party_comp_settings";
 import {CycleSettings} from "./cycle_settings";
@@ -1092,7 +1092,7 @@ export class CycleProcessor<GaugeManagerType extends GaugeManager<unknown> = Gau
         // Enough time for entire GCD
         // if (gcdFinishedAt <= this.totalTime) {
         const dmgInfo = this.modifyDamage(abilityToDamageNew(this.stats, ability, combinedEffects), ability, buffs);
-        const appDelayFromSnapshot = appDelay(ability);
+        const appDelayFromSnapshot = damageAppDelay(ability);
         const appDelayFromStart = appDelayFromSnapshot + snapshotDelayFromStart;
         const finalBuffs: Buff[] = this._simple ? [] : Array.from(new Set<Buff>([
             ...preBuffs,

--- a/packages/core/src/sims/cycle_sim.ts
+++ b/packages/core/src/sims/cycle_sim.ts
@@ -29,7 +29,7 @@ import {
 } from "@xivgear/xivmath/xivconstants";
 import {CooldownMode, CooldownTracker} from "./common/cooldown_manager";
 import {addValues, fixedValue, multiplyFixed, multiplyIndependent, ValueWithDev} from "@xivgear/xivmath/deviation";
-import {abilityEquals, animationLock, appDelay, completeComboData, FinalizedComboData} from "./ability_helpers";
+import {abilityEquals, animationLock, appDelay, buffAppDelay, completeComboData, FinalizedComboData} from "./ability_helpers";
 import {abilityToDamageNew, combineBuffEffects, noBuffEffects} from "./sim_utils";
 import {BuffSettingsExport} from "./common/party_comp_settings";
 import {CycleSettings} from "./cycle_settings";
@@ -1129,7 +1129,8 @@ export class CycleProcessor<GaugeManagerType extends GaugeManager<unknown> = Gau
         // is the snapshot-to-application delta only, and the animation lock also needs to have the time so far
         // subtracted.
         // TODO: fix this limitation
-        const buffDelay = Math.max(0, Math.min(appDelayFromSnapshot, effectiveAnimLock - snapshotDelayFromStart));
+        const buffApplicationDelay = buffAppDelay(ability);
+        const buffDelay = Math.max(0, Math.min(buffApplicationDelay, effectiveAnimLock - snapshotDelayFromStart));
         // Activate buffs afterwards
         if (ability.activatesBuffs) {
             ability.activatesBuffs.forEach(buff => this.activateBuffWithDelay(buff, buffDelay));

--- a/packages/core/src/sims/melee/drg/drg_actions.ts
+++ b/packages/core/src/sims/melee/drg/drg_actions.ts
@@ -472,8 +472,8 @@ export const Geirskogul: DrgOgcdAbility = {
     name: "Geirskogul",
     id: 3555,
     potency: 200,
-    //appDelay: 0.67, // This is only *damage* delay, the buffs apply immediately and this is more important.
-    appDelay: 0,
+    appDelay: 0.67,
+    buffApplicationDelay: 0,
     activatesBuffs: [LifeOfTheDragon, NastrondReady],
     attackType: "Ability",
     cooldown: {

--- a/packages/core/src/sims/sim_types.ts
+++ b/packages/core/src/sims/sim_types.ts
@@ -351,11 +351,15 @@ export type BaseAbility = Readonly<LevelModifiable<{
      */
     appDelay?: number,
     /**
+     * If specified, will override the default application delay for abilities where the buff application delay differs
+     * from the damage application delay (e.g. Darkside, Life of the Dragon, Surging Tempest).
+     */
+    buffApplicationDelay?: number,
+    /**
      * If the ability uses alternate scalings, such as Living Shadow Strength
      * scaling or using the pet action Weapon Damage multiplier.
      */
     alternativeScalings?: AlternativeScaling[],
-
     /**
      * By default, actions will be translated on the UI when language is not English.
      * You can force translation on or off via this property.

--- a/packages/core/src/sims/tank/drk/drk_actions.ts
+++ b/packages/core/src/sims/tank/drk/drk_actions.ts
@@ -217,6 +217,7 @@ export const EdgeOfDarkness: DrkOgcdAbility = {
         time: 1,
     },
     appDelay: 0.62,
+    buffApplicationDelay: 0,
     activatesBuffs: [Darkside],
     updateMP: (gauge: DrkGauge) => {
         if (gauge.darkArts) {
@@ -238,6 +239,7 @@ export const EdgeOfShadow: DrkOgcdAbility = {
         time: 1,
     },
     appDelay: 0.62,
+    buffApplicationDelay: 0,
     activatesBuffs: [Darkside],
     updateMP: (gauge: DrkGauge) => {
         if (gauge.darkArts) {

--- a/packages/core/src/sims/tank/drk/drk_sheet_sim.ts
+++ b/packages/core/src/sims/tank/drk/drk_sheet_sim.ts
@@ -604,10 +604,9 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
             cp.advanceTo(1 - STANDARD_ANIMATION_LOCK);
         }
         this.use(cp, Actions.Unmend);
-        cp.advanceForLateWeave([potionMaxStr]);
         this.use(cp, potionMaxStr);
-        this.use(cp, Actions.HardSlash);
         this.use(cp, cp.getEdgeAction());
+        this.use(cp, Actions.HardSlash);
         if (cp.stats.level >= 80) {
             this.use(cp, Actions.LivingShadow);
         }
@@ -649,10 +648,9 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
             cp.advanceTo(1 - STANDARD_ANIMATION_LOCK);
         }
         this.use(cp, Actions.Unmend);
-        cp.advanceForLateWeave([potionMaxStr]);
         this.use(cp, potionMaxStr);
-        this.use(cp, Actions.HardSlash);
         this.use(cp, Actions.EdgeOfShadow);
+        this.use(cp, Actions.HardSlash);
         this.use(cp, Actions.LivingShadow);
         this.use(cp, Actions.SyphonStrike);
         this.use(cp, Actions.Souleater);
@@ -695,10 +693,9 @@ export class DrkSim extends BaseMultiCycleSim<DrkSimResult, DrkSettings, DrkCycl
             cp.advanceTo(1 - STANDARD_ANIMATION_LOCK);
         }
         this.use(cp, Actions.Unmend);
-        cp.advanceForLateWeave([potionMaxStr]);
         this.use(cp, potionMaxStr);
-        this.use(cp, Actions.HardSlash);
         this.use(cp, Actions.EdgeOfShadow);
+        this.use(cp, Actions.HardSlash);
         this.use(cp, Actions.LivingShadow);
         this.use(cp, Actions.SyphonStrike);
         this.use(cp, Actions.Souleater);


### PR DESCRIPTION
Adds an optional `buffApplicationDelay` to abilities that, if specified, will take precedence over the ability's `appDelay` for the application of buffs. 