### PR TITLE
Fix iOS safari bisbrowser bug

### DIFF
--- a/packages/common-ui/src/util/detect_safari.ts
+++ b/packages/common-ui/src/util/detect_safari.ts
@@ -1,0 +1,5 @@
+export const isSafari: boolean = (() => {
+    const ua = navigator.userAgent.toLowerCase();
+    return ua.includes('safari') && !ua.includes('chrome');
+})();
+

--- a/packages/frontend/src/scripts/components/bis_browser.ts
+++ b/packages/frontend/src/scripts/components/bis_browser.ts
@@ -14,6 +14,7 @@ import {JOB_DATA, JOB_IDS, JobName} from "@xivgear/xivmath/xivconstants";
 import {makeActionButton, mySheetsIcon, quickElement} from "@xivgear/common-ui/components/util";
 import {capitalizeFirstLetter} from "@xivgear/util/strutils";
 import {JobIcon} from "./job_icon";
+import {isSafari} from "@xivgear/common-ui/util/detect_safari";
 
 type NodeInfo = {
     name: string,
@@ -101,10 +102,14 @@ class BisTable extends CustomTable<AnyNode, TableSelectionModel<AnyNode>> {
 
     protected makeDataRow(node: AnyNode): CustomRow<AnyNode> {
         const out = super.makeDataRow(node);
-        const linkOverlay = quickElement('a', ['row-overlay-link'], []);
-        linkOverlay.href = makeUrlSimple(node.type === 'file' ? BIS_HASH : BIS_BROWSER_HASH, ...node.path).toString();
-        linkOverlay.addEventListener('click', (e) => e.preventDefault());
-        out.afterElements.push(linkOverlay);
+        // https://bugs.webkit.org/show_bug.cgi?id=240961
+        // Can't use this on Safari because of this bug
+        if (!isSafari) {
+            const linkOverlay = quickElement('a', ['row-overlay-link'], []);
+            linkOverlay.href = makeUrlSimple(node.type === 'file' ? BIS_HASH : BIS_BROWSER_HASH, ...node.path).toString();
+            linkOverlay.addEventListener('click', (e) => e.preventDefault());
+            out.afterElements.push(linkOverlay);
+        }
         // out.append(linkOverlay);
         return out;
     }

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -99,13 +99,9 @@ import {setDataManagerErrorReporter} from "@xivgear/core/data_api_client";
 import {SpecialStatType} from "@xivgear/data-api-client/dataapi";
 import {SHEET_MANAGER} from "./saved_sheet_impl";
 import {cleanUrl} from "@xivgear/common-ui/nav/common_frontend_nav";
+import {isSafari} from "@xivgear/common-ui/util/detect_safari";
 
 const noSeparators = (set: CharacterGearSet) => !set.isSeparator;
-
-const isSafari: boolean = (() => {
-    const ua = navigator.userAgent.toLowerCase();
-    return ua.includes('safari') && !ua.includes('chrome');
-})();
 
 // Set up error reporting for DataManager
 setDataManagerErrorReporter((response, params) => {


### PR DESCRIPTION
Makes it so that on Safari, the bisbrowser won't have any <a> elements.

They end up covering the entire table because of https://bugs.webkit.org/show_bug.cgi?id=240961 , thus touching anywhere on the table opens up whatever the last item in the list is since that one ends up on top. 