### PR TITLE
Editor popout

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -19,7 +19,7 @@
     <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myValues">
         <value>
-          <list size="60">
+          <list size="61">
             <item index="0" class="java.lang.String" itemvalue="nobr" />
             <item index="1" class="java.lang.String" itemvalue="noembed" />
             <item index="2" class="java.lang.String" itemvalue="comment" />
@@ -80,6 +80,7 @@
             <item index="57" class="java.lang.String" itemvalue="change-password-modal" />
             <item index="58" class="java.lang.String" itemvalue="finalize-password-reset-modal" />
             <item index="59" class="java.lang.String" itemvalue="change-props-modal" />
+            <item index="60" class="java.lang.String" itemvalue="popout-editor" />
           </list>
         </value>
       </option>

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -1978,7 +1978,7 @@ add-sim-dialog {
   }
 }
 
-gear-set-editor, separator-editor {
+gear-set-editor, separator-editor, div.gear-set-popout-open-placeholder {
   div.gear-set-editor-button-area {
     width: 100%;
     text-align: center;

--- a/packages/core/src/customgear/custom_item.ts
+++ b/packages/core/src/customgear/custom_item.ts
@@ -1,7 +1,7 @@
 import {
     CustomItemExport,
-    DisplayGearSlot,
     DisplayGearSlotInfo,
+    DisplayGearSlotMapping,
     DisplayGearSlotKey,
     GearAcquisitionSource,
     GearItem,
@@ -149,8 +149,8 @@ export class CustomItem implements GearItem {
         return this._data.slot;
     }
 
-    get displayGearSlot(): DisplayGearSlot {
-        return DisplayGearSlotInfo[this.displayGearSlotName];
+    get displayGearSlot(): DisplayGearSlotInfo {
+        return DisplayGearSlotMapping[this.displayGearSlotName];
     }
 
     get stats(): RawStats {

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -10,8 +10,8 @@ import {
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
 import {
-    DisplayGearSlot,
     DisplayGearSlotInfo,
+    DisplayGearSlotMapping,
     DisplayGearSlotKey,
     FoodItem,
     GearAcquisitionSource,
@@ -435,7 +435,7 @@ export class DataApiGearInfo implements GearItem {
     readonly iconUrl: URL;
     readonly equipLvl: number;
     readonly ilvl: number;
-    readonly displayGearSlot: DisplayGearSlot;
+    readonly displayGearSlot: DisplayGearSlotInfo;
     readonly displayGearSlotName: DisplayGearSlotKey;
     readonly occGearSlotName: OccGearSlotKey;
     // Base stats, including caps
@@ -534,7 +534,7 @@ export class DataApiGearInfo implements GearItem {
         else {
             console.error("Unknown slot data!", eqs);
         }
-        this.displayGearSlot = this.displayGearSlotName ? DisplayGearSlotInfo[this.displayGearSlotName] : undefined;
+        this.displayGearSlot = this.displayGearSlotName ? DisplayGearSlotMapping[this.displayGearSlotName] : undefined;
         const weaponDelayRaw = (data.delayMs);
         this.baseStats = new RawStats();
         this.baseStats.wdPhys = forceNq ? data.damagePhys : data.damagePhysHQ;
@@ -576,7 +576,7 @@ export class DataApiGearInfo implements GearItem {
         if (baseMatCount === 0) {
             // If there are no materia slots, then it might be a custom relic
             // TODO: is this branch still needed?
-            if (this.displayGearSlot !== DisplayGearSlotInfo.OffHand) {
+            if (this.displayGearSlot !== DisplayGearSlotMapping.OffHand) {
                 // Offhands never have materia slots
                 this.isCustomRelic = true;
             }

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -20,6 +20,12 @@ export const VIEW_SHEET_HASH = 'viewsheet';
 export const VIEW_SET_HASH = 'viewset';
 /** Prefix for embeds */
 export const EMBED_HASH = 'embed';
+
+/**
+ * Prefix for pop-out editor/viewer.
+ */
+export const POPUP_HASH = 'popup';
+
 /** Prefix for formula pages */
 export const CALC_HASH = 'math';
 /** Path separator */
@@ -78,6 +84,9 @@ export type NavPath = {
     type: 'bisbrowser',
     path: string[],
     // TODO: more?
+} | {
+    type: 'popup',
+    index: number,
 } | SheetBasePath & ({
     type: 'saved',
     saveKey: string
@@ -261,6 +270,12 @@ export function parsePath(state: NavState): NavPath | null {
         return {
             type: 'bisbrowser',
             path: [...path.slice(1)],
+        };
+    }
+    else if (mainNav === POPUP_HASH) {
+        return {
+            type: 'popup',
+            index: parseInt(path[1]),
         };
     }
     console.log('Unknown nav path', path);

--- a/packages/core/src/nav/common_nav.ts
+++ b/packages/core/src/nav/common_nav.ts
@@ -273,6 +273,9 @@ export function parsePath(state: NavState): NavPath | null {
         };
     }
     else if (mainNav === POPUP_HASH) {
+        // Popup is a special type of navigation, where it is expected that the GearPlanSheetGui instance is already
+        // stuffed into the window context by the opener of the window. The nav path contains the index of the set
+        // to display.
         return {
             type: 'popup',
             index: parseInt(path[1]),

--- a/packages/core/src/test/sims/sim_tests.ts
+++ b/packages/core/src/test/sims/sim_tests.ts
@@ -246,7 +246,7 @@ describe('Default sims', () => {
                                 return;
                             }
                             const gearSlot = EquipSlotInfo[slotKey].gearSlot;
-                            const item = sheet.itemsForDisplay.find((item) => item.displayGearSlot === gearSlot);
+                            const item = sheet.itemsForDisplay.find((item) => item.displayGearSlotName === gearSlot);
                             expect(item).to.not.be.undefined;
                             expect(item).to.not.be.null;
                             set.setEquip(slotKey, item);
@@ -281,7 +281,7 @@ describe('Default sims', () => {
                         return;
                     }
                     const gearSlot = EquipSlotInfo[slotKey].gearSlot;
-                    const item = sheet.itemsForDisplay.find((item) => item.displayGearSlot === gearSlot);
+                    const item = sheet.itemsForDisplay.find((item) => item.displayGearSlotName === gearSlot);
                     expect(item).to.not.be.undefined;
                     expect(item).to.not.be.null;
                     set.setEquip(slotKey, item);

--- a/packages/frontend/src/popout.less
+++ b/packages/frontend/src/popout.less
@@ -1,0 +1,191 @@
+@import "../../common-ui/styles/util.less";
+
+body.popout-view {
+
+  #popout-top-level {
+    overflow: auto;
+    text-align: center;
+    min-height: 100%;
+    position: relative;
+
+    > div.gear-sheet-editor-area {
+      //min-height: 100%;
+      box-sizing: border-box;
+    }
+
+    set-totals-display {
+      display: block;
+
+      div.stat-total {
+        background-color: var(--table-bg-color);
+        margin-top: 5px;
+        margin-bottom: 0;
+        .shadow();
+        // Save space by not showing DHT multi since it is fixed
+        &.stat-dhit {
+          min-width: 52px;
+
+          div.stat-total-lower-right {
+            display: none;
+          }
+        }
+      }
+    }
+  }
+
+  a.embed-open-full-link {
+    display: block;
+    box-shadow: var(--shadow-color) 0 3px 5px 0;
+
+
+    height: fit-content;
+
+    margin-left: auto;
+
+    margin-right: auto;
+
+    background-color: var(--table-bg-color);
+
+    --mmai-border-radius: 10px;
+
+    border-bottom-left-radius: var(--mmai-border-radius);
+
+    border-bottom-right-radius: var(--mmai-border-radius);
+
+    min-width: max-content;
+    max-width: calc(100% - 20px);
+    box-sizing: border-box;
+    width: 400px;
+    text-align: center;
+    padding: 10px;
+    position: sticky;
+
+    top: 0;
+
+    z-index: var(--zi-show-hide-menu-button);
+
+    &:hover {
+      background-color: var(--input-hover-background-color);
+    }
+
+    &:link {
+      text-decoration: none;
+    }
+  }
+
+  table {
+    //.standard-round-border();
+    //.standard-border();
+    //padding: 0 !important;
+    //margin: 5px !important;
+    tr:last-child {
+      //border: none !important;
+      //.standard-border !important;
+      td, th {
+        border-top: none;
+        //border: none !important;
+        //.standard-border();
+      }
+    }
+
+    &.gear-items-view-table, &.food-view-table {
+      border-spacing: 2px;
+      padding: 3px;
+    }
+
+    slot-materia-manager {
+      margin-right: 0;
+      width: 90px;
+    }
+  }
+
+  @media (width <= 1100px) {
+    .col-zero-stat {
+      display: none;
+    }
+
+    .stat-cell, .stat-cell-header {
+      padding: 0;
+      opacity: 75%;
+    }
+
+    table {
+
+      slot-materia-manager {
+        font-size: small;
+        width: 75px;
+      }
+    }
+  }
+
+  @media (width < 500px) {
+
+    width: 125vw;
+    //right: 12.5%;
+    //bottom: 12.5%;
+    transform: scale(80%);
+    min-height: 125vh;
+    max-height: 125vh;
+
+
+    gear-set-viewer {
+      padding: 0;
+      // This gets capped to 100% width anyway
+      --item-table-max-width: 800px;
+
+      table.gear-items-table, table.food-view-table {
+        border-radius: 0;
+      }
+    }
+
+    .narrow-only, .embed-narrow-only {
+      display: unset;
+    }
+
+    .wide-only, .embed-wide-only {
+      display: none;
+    }
+
+    table {
+      slot-materia-manager {
+        font-size: unset;
+        width: 85px;
+      }
+    }
+  }
+
+  @media (width < 380px) {
+
+
+    width: 150vw;
+    //right: 12.5%;
+    //bottom: 12.5%;
+    transform: scale(calc(2 / 3));
+    min-height: 150vh;
+    max-height: 150vh;
+  }
+
+  @media (width < 330px) {
+    .stat-cell, .stat-cell-header {
+      display: none;
+    }
+  }
+
+  //@media (width <= 1050px) {
+  //  gear-set-viewer {
+  //    .gear-table-sides-holder {
+  //      --item-table-max-width: min(600px, calc(50vw - 20px));
+  //    }
+  //  }
+  //  .stat-cell, .stat-cell-header {
+  //    display: none;
+  //  }
+  //}
+  @media (width > 850px) {
+    gear-set-viewer {
+      .gear-table-sides-holder {
+        --item-table-max-width: min(600px, calc(50vw - 20px));
+      }
+    }
+  }
+}

--- a/packages/frontend/src/popout.less
+++ b/packages/frontend/src/popout.less
@@ -99,24 +99,24 @@ body.popout-view {
     }
   }
 
-  @media (width <= 1100px) {
-    .col-zero-stat {
-      display: none;
-    }
-
-    .stat-cell, .stat-cell-header {
-      padding: 0;
-      opacity: 75%;
-    }
-
-    table {
-
-      slot-materia-manager {
-        font-size: small;
-        width: 75px;
-      }
-    }
-  }
+  //@media (width <= 1100px) {
+  //  .col-zero-stat {
+  //    display: none;
+  //  }
+  //
+  //  .stat-cell, .stat-cell-header {
+  //    padding: 0;
+  //    opacity: 75%;
+  //  }
+  //
+  //  table {
+  //
+  //    slot-materia-manager {
+  //      font-size: small;
+  //      width: 75px;
+  //    }
+  //  }
+  //}
 
   @media (width < 500px) {
 
@@ -128,12 +128,12 @@ body.popout-view {
     max-height: 125vh;
 
 
-    gear-set-viewer {
+    gear-set-viewer, gear-set-editor {
       padding: 0;
       // This gets capped to 100% width anyway
       --item-table-max-width: 800px;
 
-      table.gear-items-table, table.food-view-table {
+      table.gear-items-table, table.food-items-table {
         border-radius: 0;
       }
     }

--- a/packages/frontend/src/popout.less
+++ b/packages/frontend/src/popout.less
@@ -3,7 +3,7 @@
 body.popout-view {
 
   #popout-top-level {
-    overflow: auto;
+    //overflow: auto;
     text-align: center;
     min-height: 100%;
     position: relative;
@@ -11,6 +11,18 @@ body.popout-view {
     > div.gear-sheet-editor-area {
       //min-height: 100%;
       box-sizing: border-box;
+    }
+
+    popout-editor {
+      height: 100vh;
+      display: flex;
+      flex-direction: column;
+    }
+
+    .popup-toolbar-area {
+      .shadow-big();
+      position: relative;
+      z-index: var(--zi-toolbar-popout);
     }
 
     set-totals-display {

--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -24,7 +24,6 @@ import {quickElement} from "@xivgear/common-ui/components/util";
 import {ACCOUNT_STATE_TRACKER} from "./account/account_state";
 import {SHEET_MANAGER} from "./components/saved_sheet_impl";
 import {USER_DATA_SYNCER} from "./account/user_data";
-import {GearPlanSheet} from "@xivgear/core/sheet";
 
 declare global {
     interface Document {
@@ -35,7 +34,7 @@ declare global {
     interface Window {
         currentSheet?: GearPlanSheetGui;
         currentGearSet?: CharacterGearSet;
-        parentSheet?: GearPlanSheet;
+        parentSheet?: GearPlanSheetGui;
     }
 }
 const pageTitle = 'XivGear - FFXIV Gear Planner';

--- a/packages/frontend/src/scripts/base_ui.ts
+++ b/packages/frontend/src/scripts/base_ui.ts
@@ -24,6 +24,7 @@ import {quickElement} from "@xivgear/common-ui/components/util";
 import {ACCOUNT_STATE_TRACKER} from "./account/account_state";
 import {SHEET_MANAGER} from "./components/saved_sheet_impl";
 import {USER_DATA_SYNCER} from "./account/user_data";
+import {GearPlanSheet} from "@xivgear/core/sheet";
 
 declare global {
     interface Document {
@@ -34,6 +35,7 @@ declare global {
     interface Window {
         currentSheet?: GearPlanSheetGui;
         currentGearSet?: CharacterGearSet;
+        parentSheet?: GearPlanSheet;
     }
 }
 const pageTitle = 'XivGear - FFXIV Gear Planner';

--- a/packages/frontend/src/scripts/components/gear_edit_toolbar.ts
+++ b/packages/frontend/src/scripts/components/gear_edit_toolbar.ts
@@ -232,5 +232,54 @@ export class GearEditToolbar extends HTMLDivElement {
     }
 }
 
+export class PopoutGearEditToolbar extends HTMLDivElement {
+    private readonly statTierDisplay: StatTierDisplay;
+    private buttonsArea: ToolbarButtonsArea;
+
+    constructor(sheet: GearPlanSheetGui,
+                set: CharacterGearSet,
+                itemDisplaySettings: ItemDisplaySettings,
+                updateGearDisplayNow: () => void,
+                matFillCtrl: MateriaAutoFillController
+    ) {
+        super();
+        sheet = new Proxy<GearPlanSheetGui>(sheet, {
+            get(target: GearPlanSheetGui, p: string | symbol): unknown {
+                if (p === 'currentSet') {
+                    return set;
+                }
+                else {
+                    // @ts-expect-error p is not necessarily a known property
+                    return target[p];
+                }
+            },
+        });
+
+        this.classList.add('gear-set-editor-toolbar');
+
+        this.buttonsArea = new ToolbarButtonsArea();
+
+        // Gear filtering should only be done in main window
+
+        this.appendChild(this.buttonsArea);
+
+        const materiaPriority = new MateriaPriorityPicker(matFillCtrl, sheet);
+
+        this.buttonsArea.addPanelButton(["Materia", document.createElement('br'), "Fill/Lock"], materiaPriority);
+
+        // TODO: meld solver will trigger the popup on the main window
+        // this.buttonsArea.addPanelButtonModal(["Meld/Food", document.createElement('br'), "Solver"], () => sheet.showMeldSolveDialog());
+
+        this.statTierDisplay = new StatTierDisplay(sheet);
+        this.appendChild(this.statTierDisplay);
+    }
+
+    refresh(gearSet: CharacterGearSet) {
+        this.buttonsArea.currentSet = gearSet;
+        this.statTierDisplay.refresh(gearSet);
+    }
+}
+
 customElements.define('gear-edit-toolbar', GearEditToolbar, {extends: 'div'});
+customElements.define('popout-gear-edit-toolbar', PopoutGearEditToolbar, {extends: 'div'});
 customElements.define('gear-edit-toolbar-buttons-area', ToolbarButtonsArea, {extends: 'div'});

--- a/packages/frontend/src/scripts/components/items.ts
+++ b/packages/frontend/src/scripts/components/items.ts
@@ -1,6 +1,6 @@
 import {CharacterGearSet, ItemSingleStatDetail, previewItemStatDetail} from "@xivgear/core/gear";
 import {
-    DisplayGearSlot,
+    DisplayGearSlotKey,
     EquipmentSet,
     EquippedItem,
     EquipSlot,
@@ -598,7 +598,7 @@ export class GearItemsTable extends CustomTable<GearSlotItem, TableSelectionMode
     private selectionTracker: Map<keyof EquipmentSet, CustomRow<GearSlotItem> | GearSlotItem>;
     private showHideCallbacks: Map<keyof EquipmentSet, (value: boolean) => void> = new Map();
 
-    constructor(sheet: GearPlanSheet, private readonly gearSet: CharacterGearSet, itemMapping: Map<DisplayGearSlot, GearItem[]>, handledSlots: EquipSlotKey[], afterShowHideAll: () => void) {
+    constructor(sheet: GearPlanSheet, private readonly gearSet: CharacterGearSet, itemMapping: Map<DisplayGearSlotKey, GearItem[]>, handledSlots: EquipSlotKey[], afterShowHideAll: () => void) {
         super();
         this.classList.add("gear-items-table");
         this.classList.add("gear-items-edit-table");
@@ -1154,7 +1154,7 @@ export class ILvlRangePicker<ObjType> extends HTMLElement {
 
         const lowerBoundControl = new FieldBoundIntField(obj, minField);
         const upperBoundControl = new FieldBoundIntField(obj, maxField);
-        const borderListener = function(min: number, max: number) {
+        const borderListener = function (min: number, max: number) {
             if (min > max) {
                 lowerBoundControl.classList.add("invalid-numeric-input");
                 upperBoundControl.classList.add("invalid-numeric-input");

--- a/packages/frontend/src/scripts/components/popout_editor.ts
+++ b/packages/frontend/src/scripts/components/popout_editor.ts
@@ -1,0 +1,17 @@
+import {GearPlanSheet} from "@xivgear/core/sheet";
+import {GearSetEditor, GearSetViewer} from "./sheet";
+import {quickElement} from "@xivgear/common-ui/components/util";
+
+export class PopoutEditor extends HTMLElement {
+    constructor(sheet: GearPlanSheet, index: number) {
+        super();
+        const set = sheet.sets[index];
+        const readonly = sheet.isViewOnly;
+        const mainElement = readonly ? new GearSetViewer(sheet, set) : new GearSetEditor(sheet, set);
+        // TODO: toolbar
+        // const toolbar = readonly ? mainElement.toolbar : new GearEditToolbar(sheet, )
+        this.replaceChildren(quickElement('div', ['popup-main-area'], [mainElement]));
+    }
+}
+
+customElements.define('popout-editor', PopoutEditor);

--- a/packages/frontend/src/scripts/components/popout_editor.ts
+++ b/packages/frontend/src/scripts/components/popout_editor.ts
@@ -1,32 +1,56 @@
 import {GearPlanSheetGui, GearSetEditor, GearSetViewer} from "./sheet";
 import {quickElement} from "@xivgear/common-ui/components/util";
+import {GearEditToolbar, PopoutGearEditToolbar} from "./gear_edit_toolbar";
+import {PopoutMainElement} from "../popout";
+import {CharacterGearSet} from "@xivgear/core/gear";
 
-export class PopoutEditor extends HTMLElement {
+export class PopoutEditor extends HTMLElement implements PopoutMainElement {
     private readonly sheet: GearPlanSheetGui;
     private readonly index: number;
     private mainElement!: GearSetEditor | GearSetViewer;
+    private toolbar: PopoutGearEditToolbar | null = null;
+    readonly set: CharacterGearSet;
 
     constructor(sheet: GearPlanSheetGui, index: number) {
         super();
         this.sheet = sheet;
         this.index = index;
+        this.set = sheet.sets[index];
         this.build();
     }
 
     private build() {
-        const set = this.sheet.sets[this.index];
+        const set = this.set;
         const readonly = this.sheet.isViewOnly;
         this.mainElement = readonly ? new GearSetViewer(this.sheet, set) : new GearSetEditor(this.sheet, set);
         // TODO: toolbar
         // const toolbar = readonly ? mainElement.toolbar : new GearEditToolbar(sheet, )
-        this.replaceChildren(quickElement('div', ['popup-main-area'], [this.mainElement]));
+        if (readonly) {
+            // TBD as to what view-only will look like for popouts
+            this.replaceChildren(
+                quickElement('div', ['popup-main-area'], [this.mainElement])
+            );
+        }
+        else {
+            this.toolbar = new PopoutGearEditToolbar(this.sheet, set, this.sheet.itemDisplaySettings, () => this.sheet.gearDisplaySettingsUpdateNow(), this.sheet.makeMateriaAutoFillController(() => set));
+            set.addListener(() => this.toolbar.refresh(set));
+            this.toolbar.refresh(set);
+            this.replaceChildren(
+                quickElement('div', ['popup-toolbar-area', 'gear-sheet-midbar-area'], [this.toolbar]),
+                quickElement('div', ['popup-main-area'], [this.mainElement])
+            );
+        }
     }
 
     /**
      * Refresh the editor/viewer inside the popout to reflect updated settings.
      */
-    public filterSettingsRefresh() {
+    refreshContent() {
         this.mainElement.setup();
+    }
+
+    refreshToolbar() {
+        this.toolbar?.refresh(this.set);
     }
 
 }

--- a/packages/frontend/src/scripts/components/popout_editor.ts
+++ b/packages/frontend/src/scripts/components/popout_editor.ts
@@ -2,15 +2,33 @@ import {GearPlanSheetGui, GearSetEditor, GearSetViewer} from "./sheet";
 import {quickElement} from "@xivgear/common-ui/components/util";
 
 export class PopoutEditor extends HTMLElement {
+    private readonly sheet: GearPlanSheetGui;
+    private readonly index: number;
+    private mainElement!: GearSetEditor | GearSetViewer;
+
     constructor(sheet: GearPlanSheetGui, index: number) {
         super();
-        const set = sheet.sets[index];
-        const readonly = sheet.isViewOnly;
-        const mainElement = readonly ? new GearSetViewer(sheet, set) : new GearSetEditor(sheet, set);
+        this.sheet = sheet;
+        this.index = index;
+        this.build();
+    }
+
+    private build() {
+        const set = this.sheet.sets[this.index];
+        const readonly = this.sheet.isViewOnly;
+        this.mainElement = readonly ? new GearSetViewer(this.sheet, set) : new GearSetEditor(this.sheet, set);
         // TODO: toolbar
         // const toolbar = readonly ? mainElement.toolbar : new GearEditToolbar(sheet, )
-        this.replaceChildren(quickElement('div', ['popup-main-area'], [mainElement]));
+        this.replaceChildren(quickElement('div', ['popup-main-area'], [this.mainElement]));
     }
+
+    /**
+     * Refresh the editor/viewer inside the popout to reflect updated settings.
+     */
+    public filterSettingsRefresh() {
+        this.mainElement.setup();
+    }
+
 }
 
 customElements.define('popout-editor', PopoutEditor);

--- a/packages/frontend/src/scripts/components/popout_editor.ts
+++ b/packages/frontend/src/scripts/components/popout_editor.ts
@@ -1,9 +1,8 @@
-import {GearPlanSheet} from "@xivgear/core/sheet";
-import {GearSetEditor, GearSetViewer} from "./sheet";
+import {GearPlanSheetGui, GearSetEditor, GearSetViewer} from "./sheet";
 import {quickElement} from "@xivgear/common-ui/components/util";
 
 export class PopoutEditor extends HTMLElement {
-    constructor(sheet: GearPlanSheet, index: number) {
+    constructor(sheet: GearPlanSheetGui, index: number) {
         super();
         const set = sheet.sets[index];
         const readonly = sheet.isViewOnly;

--- a/packages/frontend/src/scripts/components/popout_editor.ts
+++ b/packages/frontend/src/scripts/components/popout_editor.ts
@@ -1,6 +1,6 @@
 import {GearPlanSheetGui, GearSetEditor, GearSetViewer} from "./sheet";
 import {quickElement} from "@xivgear/common-ui/components/util";
-import {GearEditToolbar, PopoutGearEditToolbar} from "./gear_edit_toolbar";
+import {PopoutGearEditToolbar} from "./gear_edit_toolbar";
 import {PopoutMainElement} from "../popout";
 import {CharacterGearSet} from "@xivgear/core/gear";
 

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -1624,6 +1624,11 @@ export class GearPlanSheetGui extends GearPlanSheet {
             if (this._editorAreaNode instanceof GearSetEditor) {
                 this._editorAreaNode.setup();
             }
+            this._openSetPopouts.forEach((win, set) => {
+                if (!win.closed) {
+                    win.postMessage({'type': 'filterSettingsChanged'});
+                }
+            });
             this.saveData();
         });
 

--- a/packages/frontend/src/scripts/components/sheet.ts
+++ b/packages/frontend/src/scripts/components/sheet.ts
@@ -32,7 +32,7 @@ import {
 import {
     ChanceStat,
     ComputedSetStats,
-    DisplayGearSlot,
+    DisplayGearSlotInfo, DisplayGearSlotKey,
     EquipSlotKey,
     EquipSlots,
     GearItem,
@@ -78,7 +78,7 @@ import {simpleKvTable} from "../sims/components/simple_tables";
 import {rangeInc} from "@xivgear/util/array_utils";
 import {SimCurrentResult, SimResult, SimSettings, SimSpec, Simulation} from "@xivgear/core/sims/sim_types";
 import {getRegisteredSimSpecs} from "@xivgear/core/sims/sim_registry";
-import {makeUrl, NavState, ONLY_SET_QUERY_PARAM} from "@xivgear/core/nav/common_nav";
+import {makeUrl, makeUrlSimple, NavState, ONLY_SET_QUERY_PARAM, POPUP_HASH} from "@xivgear/core/nav/common_nav";
 import {simMaintainersInfoElement} from "./sims";
 import {ChangePropsModal, SaveAsModal} from "./new_sheet_form";
 import {DropdownActionMenu} from "./dropdown_actions_menu";
@@ -890,6 +890,13 @@ export class GearSetEditor extends HTMLElement {
             makeActionButton([editIcon(), 'Edit Name/Description'], () => {
                 startRenameSet(writeProxy(this.gearSet, () => this.formatTitleDesc()));
             }),
+            makeActionButton([exportIcon(), 'Popout Editor'], () => {
+                const url = makeUrlSimple(POPUP_HASH, this.sheet.sets.indexOf(this.gearSet).toString());
+                // dev experience - disable JetBrains auto-reload since it will result in a non-working popup
+                url.searchParams.delete('_ij_reload');
+                const popup = window.open(url, "Editor", "popout,width=1024,height=768");
+                popup.parentSheet = this.sheet;
+            }),
             issuesButton,
         ]);
         if (this.sheet.isMultiJob) {
@@ -906,11 +913,11 @@ export class GearSetEditor extends HTMLElement {
         // Put items in categories by slot
         // Not enough to just use the items, because rings can be in either ring slot, so we
         // need options to reflect that.
-        const itemMapping: Map<DisplayGearSlot, GearItem[]> = new Map();
+        const itemMapping: Map<DisplayGearSlotKey, GearItem[]> = new Map();
         this.sheet.itemsForDisplay
             .filter(item => item.usableByJob(this.gearSet.job))
             .forEach((item) => {
-                const slot = item.displayGearSlot;
+                const slot = item.displayGearSlotName;
                 if (itemMapping.has(slot)) {
                     itemMapping.get(slot).push(item);
                 }

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -229,7 +229,7 @@ async function doNav(navState: NavState) {
                 // TODO: validate not null
                 const sheet = window.parentSheet;
                 const editor = new PopoutEditor(sheet, nav.index);
-                openPopout(editor);
+                openPopout(editor, () => editor.filterSettingsRefresh());
                 return;
             }
         }

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -30,7 +30,6 @@ import {
 import {recordError} from "@xivgear/common-ui/analytics/analytics";
 import {BisBrowser} from "./components/bis_browser";
 import {cleanUrlParams, getQueryParams, manipulateUrlParams} from "@xivgear/common-ui/nav/common_frontend_nav";
-import {GearSetEditor} from "./components/sheet";
 import {PopoutEditor} from "./components/popout_editor";
 import {openPopout} from "./popout";
 

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -228,7 +228,7 @@ async function doNav(navState: NavState) {
                 // TODO: validate not null
                 const sheet = window.parentSheet;
                 const editor = new PopoutEditor(sheet, nav.index);
-                openPopout(editor, () => editor.filterSettingsRefresh());
+                openPopout(editor);
                 return;
             }
         }

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -30,6 +30,9 @@ import {
 import {recordError} from "@xivgear/common-ui/analytics/analytics";
 import {BisBrowser} from "./components/bis_browser";
 import {cleanUrlParams, getQueryParams, manipulateUrlParams} from "@xivgear/common-ui/nav/common_frontend_nav";
+import {GearSetEditor} from "./components/sheet";
+import {PopoutEditor} from "./components/popout_editor";
+import {openPopout} from "./popout";
 
 // let expectedHash: string[] | undefined = undefined;
 
@@ -220,6 +223,13 @@ async function doNav(navState: NavState) {
                     console.error(e);
                     showFatalError('Error Loading BiS Index');
                 }
+                return;
+            }
+            case 'popup': {
+                // TODO: validate not null
+                const sheet = window.parentSheet;
+                const editor = new PopoutEditor(sheet, nav.index);
+                openPopout(editor);
                 return;
             }
         }

--- a/packages/frontend/src/scripts/popout.ts
+++ b/packages/frontend/src/scripts/popout.ts
@@ -1,0 +1,33 @@
+import {LoadingBlocker} from "@xivgear/common-ui/components/loader";
+import {recordEvent} from "@xivgear/common-ui/analytics/analytics";
+
+let popoutElement: HTMLDivElement;
+
+export function getPopoutDiv(): HTMLDivElement | undefined {
+    return popoutElement;
+}
+
+export function earlyPopooutInit() {
+    console.log("Popout early init");
+    const body = document.body;
+    body.childNodes
+        .forEach((element) => {
+            if ('style' in element) {
+                (element as HTMLElement).style.display = 'none';
+            }
+        });
+    popoutElement = document.createElement('div');
+    popoutElement.id = 'popout-top-level';
+    popoutElement.appendChild(new LoadingBlocker());
+    body.appendChild(popoutElement);
+    body.classList.add('popout-view');
+}
+
+export function openPopout(element: HTMLElement) {
+    recordEvent('openPopout');
+    console.log("openPopout start");
+    if (!popoutElement) {
+        earlyPopooutInit();
+    }
+    popoutElement.replaceChildren(element);
+}

--- a/packages/frontend/src/scripts/popout.ts
+++ b/packages/frontend/src/scripts/popout.ts
@@ -84,13 +84,21 @@ function startParentMonitor() {
     });
 }
 
-export function openPopout(element: HTMLElement) {
+export function openPopout(element: HTMLElement, displaySettingsChangedCallback?: () => void) {
     recordEvent('openPopout');
     console.log("openPopout start");
     if (!popoutElement) {
         earlyPopooutInit();
     }
     popoutElement.replaceChildren(element);
+    // Hook message receiver if provided
+    if (displaySettingsChangedCallback) {
+        window.addEventListener('message', (event: MessageEvent<{type: string}>) => {
+            if (event?.data?.type === 'filterSettingsChanged') {
+                displaySettingsChangedCallback();
+            }
+        });
+    }
     // Start monitoring the parent navigation state; if it changes, close the popup
     startParentMonitor();
 }

--- a/packages/frontend/src/scripts/popout.ts
+++ b/packages/frontend/src/scripts/popout.ts
@@ -98,6 +98,7 @@ export function openPopout(element: HTMLElement) {
 let currentContextNumber: number = 0;
 
 export function getNextPopoutContext(): string {
+    // TODO: inline the ++ operation
     currentContextNumber++;
     return `popout-${currentContextNumber}`;
 }

--- a/packages/frontend/src/scripts/popout.ts
+++ b/packages/frontend/src/scripts/popout.ts
@@ -2,9 +2,16 @@ import {LoadingBlocker} from "@xivgear/common-ui/components/loader";
 import {recordEvent} from "@xivgear/common-ui/analytics/analytics";
 
 let popoutElement: HTMLDivElement;
+// Interval ID for monitoring the parent window's navigation state
+let parentMonitorInterval: number | undefined;
+let initialOpenerHref: string | undefined;
 
 export function getPopoutDiv(): HTMLDivElement | undefined {
     return popoutElement;
+}
+
+export function isPopout() {
+    return window.parentSheet !== undefined;
 }
 
 export function earlyPopooutInit() {
@@ -23,6 +30,60 @@ export function earlyPopooutInit() {
     body.classList.add('popout-view');
 }
 
+function safeGetOpenerHref(): string | undefined {
+    try {
+        const op: Window | null = window.opener;
+        if (!op || op.closed) {
+            return undefined;
+        }
+        return op.location.href;
+    }
+    catch (e) {
+        // Cross-origin or inaccessible opener
+        return undefined;
+    }
+}
+
+function startParentMonitor() {
+    if (parentMonitorInterval !== undefined) {
+        return; // already monitoring
+    }
+    initialOpenerHref = safeGetOpenerHref();
+    parentMonitorInterval = window.setInterval(() => {
+        const op: Window | null = window.opener;
+        // If there is no opener, or it is closed, close this popup
+        if (!op || op.closed) {
+            doClose();
+            return;
+        }
+        // If we cannot read href (cross-origin) or it changed, consider it navigated away
+        const href = safeGetOpenerHref();
+        function doClose() {
+            if (parentMonitorInterval !== undefined) {
+                window.clearInterval(parentMonitorInterval);
+                parentMonitorInterval = undefined;
+            }
+            window.close();
+        }
+        if (href === undefined || (initialOpenerHref !== undefined && href !== initialOpenerHref)) {
+            doClose();
+            return;
+        }
+        if (window.parentSheet !== op.currentSheet) {
+            doClose();
+            return;
+        }
+    }, 500);
+
+    // Cleanup the interval when this popup is closing
+    window.addEventListener('beforeunload', () => {
+        if (parentMonitorInterval !== undefined) {
+            window.clearInterval(parentMonitorInterval);
+            parentMonitorInterval = undefined;
+        }
+    });
+}
+
 export function openPopout(element: HTMLElement) {
     recordEvent('openPopout');
     console.log("openPopout start");
@@ -30,4 +91,13 @@ export function openPopout(element: HTMLElement) {
         earlyPopooutInit();
     }
     popoutElement.replaceChildren(element);
+    // Start monitoring the parent navigation state; if it changes, close the popup
+    startParentMonitor();
+}
+
+let currentContextNumber: number = 0;
+
+export function getNextPopoutContext(): string {
+    currentContextNumber++;
+    return `popout-${currentContextNumber}`;
 }

--- a/packages/frontend/src/style.less
+++ b/packages/frontend/src/style.less
@@ -16,6 +16,10 @@
   @import "./embed.less";
 }
 
+@layer popout {
+  @import "./popout.less";
+}
+
 @layer ads {
   @import "../../common-ui/styles/ads.less";
 }
@@ -466,3 +470,12 @@ conflict-resolution-dialog {
     }
   }
 }
+
+popout-editor {
+  .popup-main-area {
+    overflow: auto;
+    height: 100%;
+  }
+}
+
+

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -12,7 +12,7 @@ import {RawBonusStats, StatModification, StatPreModifications} from "./xivstats"
 import {TranslatableString} from "@xivgear/i18n/translation";
 import {SpecialStatType} from "@xivgear/data-api-client/dataapi";
 
-export interface DisplayGearSlot {
+export interface DisplayGearSlotInfo {
 
 }
 
@@ -28,7 +28,7 @@ export const OccGearSlots = ['Weapon2H', 'Weapon1H', 'OffHand', 'Head', 'Body', 
 export type OccGearSlotKey = typeof OccGearSlots[number];
 
 // For future use, in the event that these actually require properties
-export const DisplayGearSlotInfo: Record<DisplayGearSlotKey, DisplayGearSlot> = {
+export const DisplayGearSlotMapping: Record<DisplayGearSlotKey, DisplayGearSlotInfo> = {
     Weapon: {},
     OffHand: {},
     Head: {},
@@ -43,7 +43,7 @@ export const DisplayGearSlotInfo: Record<DisplayGearSlotKey, DisplayGearSlot> = 
 } as const;
 
 export interface EquipSlot {
-    get gearSlot(): DisplayGearSlot;
+    get gearSlot(): DisplayGearSlotKey;
 
     slot: keyof EquipmentSet;
 
@@ -58,62 +58,62 @@ export const EquipSlotInfo: Record<EquipSlotKey, EquipSlot> = {
     Weapon: {
         slot: 'Weapon',
         name: 'Weapon',
-        gearSlot: DisplayGearSlotInfo.Weapon,
+        gearSlot: 'Weapon',
     },
     OffHand: {
         slot: 'OffHand',
         name: 'Off-Hand',
-        gearSlot: DisplayGearSlotInfo.OffHand,
+        gearSlot: 'OffHand',
     },
     Head: {
         slot: 'Head',
         name: 'Head',
-        gearSlot: DisplayGearSlotInfo.Head,
+        gearSlot: 'Head',
     },
     Body: {
         slot: 'Body',
         name: 'Body',
-        gearSlot: DisplayGearSlotInfo.Body,
+        gearSlot: 'Body',
     },
     Hand: {
         slot: 'Hand',
         name: 'Hand',
-        gearSlot: DisplayGearSlotInfo.Hand,
+        gearSlot: 'Hand',
     },
     Legs: {
         slot: 'Legs',
         name: 'Legs',
-        gearSlot: DisplayGearSlotInfo.Legs,
+        gearSlot: 'Legs',
     },
     Feet: {
         slot: 'Feet',
         name: 'Feet',
-        gearSlot: DisplayGearSlotInfo.Feet,
+        gearSlot: 'Feet',
     },
     Ears: {
         slot: 'Ears',
         name: 'Ears',
-        gearSlot: DisplayGearSlotInfo.Ears,
+        gearSlot: 'Ears',
     },
     Neck: {
         slot: 'Neck',
         name: 'Neck',
-        gearSlot: DisplayGearSlotInfo.Neck,
+        gearSlot: 'Neck',
     },
     Wrist: {
         slot: 'Wrist',
         name: 'Wrist',
-        gearSlot: DisplayGearSlotInfo.Wrist,
+        gearSlot: 'Wrist',
     },
     RingLeft: {
         slot: 'RingLeft',
         name: 'Left Ring',
-        gearSlot: DisplayGearSlotInfo.Ring,
+        gearSlot: 'Ring',
     },
     RingRight: {
         slot: 'RingRight',
         name: 'Right Ring',
-        gearSlot: DisplayGearSlotInfo.Ring,
+        gearSlot: 'Ring',
     },
 } as const;
 
@@ -152,7 +152,7 @@ export interface GearItem extends XivCombatItem {
     /**
      * Which gear slot to populate in the UI
      */
-    displayGearSlot: DisplayGearSlot;
+    displayGearSlot: DisplayGearSlotInfo;
     /**
      * Which gear slot to populate in the UI
      */


### PR DESCRIPTION
Allow gear set editor (maybe later, also the viewer) to pop out to another window for a specific set, so that you can have multiple set editors on-screen at once.

TODO:
- [X] Basic implementation
- [X] Auto close when main window is closed/navigated off the page
- [X] Placeholder UI to stop both the main window and popout from showing the same set
  - [x] Fix styling - lack of shadows
- [x] Toolbar on editor window (possibly limited functionality)
- [x] Sync display setting changes between windows