### PR TITLE
Return same URL if export in view only mode

### DIFF
--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -60,7 +60,6 @@ async function importExportSheet(request: SheetRequest, exportedPre: SheetExport
     const exportedInitial: SheetExport | SetExport = exportedPre;
     const initiallyFullSheet = 'sets' in exportedPre;
     const onlySetIndex: number | undefined = (nav !== undefined && "onlySetIndex" in nav) ? nav.onlySetIndex : undefined;
-
     if (onlySetIndex !== undefined) {
         if (!initiallyFullSheet) {
             request.log.warn("onlySetIndex does not make sense when isFullSheet is false");

--- a/packages/backend-resolver/src/server_builder.ts
+++ b/packages/backend-resolver/src/server_builder.ts
@@ -60,6 +60,7 @@ async function importExportSheet(request: SheetRequest, exportedPre: SheetExport
     const exportedInitial: SheetExport | SetExport = exportedPre;
     const initiallyFullSheet = 'sets' in exportedPre;
     const onlySetIndex: number | undefined = (nav !== undefined && "onlySetIndex" in nav) ? nav.onlySetIndex : undefined;
+
     if (onlySetIndex !== undefined) {
         if (!initiallyFullSheet) {
             request.log.warn("onlySetIndex does not make sense when isFullSheet is false");

--- a/packages/common-ui/src/components/modal.ts
+++ b/packages/common-ui/src/components/modal.ts
@@ -42,7 +42,7 @@ export abstract class BaseModal extends HTMLElement {
         return button;
     }
 
-    protected addCloseButton(label: string = 'close') {
+    protected addCloseButton(label: string = 'Close') {
         return this.addActionButton(label, () => this.close());
     }
 

--- a/packages/frontend/src/scripts/components/export_controller.ts
+++ b/packages/frontend/src/scripts/components/export_controller.ts
@@ -129,7 +129,7 @@ const embedLinkPerSet = {
             const exportedSheet = JSON.stringify(sheet.exportSheet(true));
             linkToSheet = await putShortLink(exportedSheet);
         }
-        
+
         for (const i in sets) {
             const set = sets[i];
             if (set.isSeparator) {
@@ -421,11 +421,7 @@ class SheetExportModal extends ExportModal<GearPlanSheet> {
         super('Export Full Sheet', SHEET_EXPORT_OPTIONS, sheet, sheet);
     }
 
-    // TODO Violet
-    // if nav path === static bis just fast path return exported set
     get previewUrl(): string {
-
-
         if (this.sheet.isViewOnly) {
             const baseUrl = document.location.toString();
             return baseUrl;
@@ -444,18 +440,11 @@ class SetExportModal extends ExportModal<CharacterGearSet> {
         super('Export Individual Set', SET_EXPORT_OPTIONS, set.sheet, set);
     }
 
-
-
-
-    // TODO Violet
-    // if nav path === static bis just fast path return exported set
-
     get previewUrl(): string {
         if (this.sheet.isViewOnly) {
             const baseUrl = document.location.toString();
             return baseUrl;
         }
-
 
         const exported = this.sheet.exportGearSet(this.item, true);
         const url = makeUrlSimple(VIEW_SET_HASH, JSON.stringify(exported));

--- a/packages/frontend/src/scripts/components/export_controller.ts
+++ b/packages/frontend/src/scripts/components/export_controller.ts
@@ -372,7 +372,7 @@ abstract class ExportModal<X> extends BaseModal {
     async refreshSelection() {
         const selectedType = this.selectedOption;
         this.textValue = '';
-        if (selectedType.exportInstantly) {
+        if (selectedType.exportInstantly || this.sheet.isViewOnly) {
             const content = await this.doExport(selectedType);
             this.setResultData(selectedType, content);
         }
@@ -435,7 +435,6 @@ class SheetExportModal extends ExportModal<GearPlanSheet> {
 }
 
 class SetExportModal extends ExportModal<CharacterGearSet> {
-
     constructor(set: CharacterGearSet) {
         super('Export Individual Set', SET_EXPORT_OPTIONS, set.sheet, set);
     }

--- a/packages/frontend/src/scripts/components/export_controller.ts
+++ b/packages/frontend/src/scripts/components/export_controller.ts
@@ -456,11 +456,6 @@ class SetExportModal extends ExportModal<CharacterGearSet> {
     }
 
     get previewUrl(): string {
-        if (this.sheet.isViewOnly) {
-            const baseUrl = document.location.toString();
-            return baseUrl;
-        }
-
         const exported = this.sheet.exportGearSet(this.item, true);
         const url = makeUrlSimple(VIEW_SET_HASH, JSON.stringify(exported));
         console.log("Preview url", url);


### PR DESCRIPTION
closes #520

If in view only mode, export will not export set anew, but instead use existing URL.

This has been a pretty big point of confusion when using the site anecdotally, and causes many, many unnecessary exports.

Also adds a pretty huge QoL change of having instant exports (i.e. don't need to press "generate") for already-exported sets.

<img width="620" height="406" alt="image" src="https://github.com/user-attachments/assets/261f2819-fb8e-4f3f-a7d4-fbcf00c32ad9" />
<img width="615" height="404" alt="image" src="https://github.com/user-attachments/assets/6386da68-71bb-4413-8da0-6225f646c68a" />
<img width="628" height="400" alt="image" src="https://github.com/user-attachments/assets/28078eb9-98cc-4a74-ad8d-97bac2022ce8" />


