### PR TITLE
[GNB] Fix Gnashing Fang holding at weird speeds

### DIFF
--- a/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
+++ b/packages/frontend/src/scripts/sims/tank/gnb_sheet_sim_ui.ts
@@ -1,4 +1,4 @@
-import {FieldBoundCheckBox, labeledCheckbox, quickElement} from "@xivgear/common-ui/components/util";
+import {FieldBoundCheckBox, FieldBoundFloatField, labeledCheckbox, labelFor, quickElement} from "@xivgear/common-ui/components/util";
 import {BaseMultiCycleSimGui} from "../multicyclesim_ui";
 import {DisplayRecordFinalized, isFinalizedAbilityUse} from "@xivgear/core/sims/cycle_sim";
 import {CustomColumnSpec} from "@xivgear/common-ui/table/tables";
@@ -71,6 +71,12 @@ export class GnbSimGui extends BaseMultiCycleSimGui<GnbSimResult, GnbSettings> {
         configDiv.appendChild(labeledCheckbox("Use Potion", potCb));
 
         const pretendMicroclipsDontExistCB = new FieldBoundCheckBox(settings, "pretendThatMicroclipsDontExist");
+
+        const holdiness = new FieldBoundFloatField(settings, 'holdiness' );
+        holdiness.id = 'holdiness';
+        const label = labelFor('# GCDs to hold Gnashing for nearby No Mercy override: ', holdiness);
+        configDiv.appendChild(label);
+        configDiv.appendChild(holdiness);
 
         configDiv.appendChild(labeledCheckbox("Assume that Gnashing Fang microclips don't exist", pretendMicroclipsDontExistCB));
         return configDiv;


### PR DESCRIPTION
Some fixes for Gunbreaker including:
- Lionheart combo no longer gets interrupted by Gnashing at weird speeds
- The logic to put Burst Strike before Lionheart had a minor bug causing it to delay Gnashing at weird speeds

Per-GCD overrides for holding behaviour added. Seemed like the best way to fix the problem for now until I come up with something smarter.

Added explicit override for holding behaviour so that it can more easily be played around with outside of development contexts.