### PR TITLE
Fixes a couple visual issues with popouts, and one with the compat checker modal

### DIFF
--- a/packages/common-ui/styles/modern.less
+++ b/packages/common-ui/styles/modern.less
@@ -121,6 +121,7 @@ body.modern {
       > tr:nth-child(2) {
         position: sticky;
         z-index: 99;
+        // Offsets the padding of the scrollable area
         top: -8px;
         background-color: transparent;
 

--- a/packages/frontend/src/compatchecker.less
+++ b/packages/frontend/src/compatchecker.less
@@ -20,10 +20,7 @@ compat-checker-overview-modal {
   }
 
   .description {
-    // why does this work
-    display: table-caption;
-    width: 100%;
-    padding-bottom: 10px;
+    .non-expanding-block;
   }
 
   table {

--- a/packages/frontend/src/popout.less
+++ b/packages/frontend/src/popout.less
@@ -14,9 +14,14 @@ body.popout-view {
     }
 
     popout-editor {
-      height: 100vh;
+      height: 100%;
       display: flex;
       flex-direction: column;
+      .popup-main-area {
+        overflow: auto;
+        height: 100%;
+        padding-top: 8px;
+      }
     }
 
     .popup-toolbar-area {

--- a/packages/frontend/src/style.less
+++ b/packages/frontend/src/style.less
@@ -485,11 +485,4 @@ conflict-resolution-dialog {
   }
 }
 
-popout-editor {
-  .popup-main-area {
-    overflow: auto;
-    height: 100%;
-  }
-}
-
 


### PR DESCRIPTION
- Compat checker text is no longer squished on Chrome
- Popout sticky header is positioned correctly
- Popout no longer loses height if too narrow