### PR TITLE
7.4 default min ilvl bump + new potions

### DIFF
--- a/packages/core/src/sims/common/potion.ts
+++ b/packages/core/src/sims/common/potion.ts
@@ -38,7 +38,7 @@ function makePotion(name: string, stat: Mainstat, itemId: number, bonus: number,
     };
 }
 
-export const GemdraughtGrades = [1, 2, 3] as const;
+export const GemdraughtGrades = [1, 2, 3, 4] as const;
 export type GemdraughtGrade = typeof GemdraughtGrades[number];
 
 export type PotionStat = Exclude<Mainstat, 'vitality'>;
@@ -53,7 +53,7 @@ const statToPotItemId = {
 const gradeToStatCap: number[] & {
     // Enforce that this list has the same length as GemdraughtGrades
     length: typeof GemdraughtGrades["length"]
-} = [351, 392, 461] as const;
+} = [351, 392, 461, 541] as const;
 
 /**
  * Create a gemdraught for the given

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -573,7 +573,7 @@ export const LEVEL_STATS: Record<SupportedLevel, LevelStats> = {
 const defaultItemDispBase = {
     showNq: false,
     higherRelics: true,
-    minILvlFood: 740,
+    minILvlFood: 770,
     maxILvlFood: 999,
     showOneStatFood: false,
 } as const satisfies Partial<ItemDisplaySettings>;
@@ -642,7 +642,7 @@ export const LEVEL_ITEMS: Record<SupportedLevel, LevelItemInfo> = {
         defaultDisplaySettings: {
             ...defaultItemDispBase,
             // Raise this when more gear is available
-            minILvl: 740,
+            minILvl: 770,
             maxILvl: 999,
         },
     },
@@ -924,7 +924,7 @@ export function bluWdfromInt(gearIntStat: number): number {
 export const defaultItemDisplaySettings: ItemDisplaySettings = {
     minILvl: 680,
     maxILvl: 999,
-    minILvlFood: 740,
+    minILvlFood: 770,
     maxILvlFood: 999,
     higherRelics: true,
     showNq: false,


### PR DESCRIPTION
Bumps the default minimum item level for food and gear, and adds new 7.4 potions.