### PR TITLE
Update Lilies fix  whm_new_sheet_sim.ts

### DIFF
--- a/packages/core/src/sims/healer/whm_new_sheet_sim.ts
+++ b/packages/core/src/sims/healer/whm_new_sheet_sim.ts
@@ -143,8 +143,8 @@ const glare4: GcdAbility = {
 };
 
 class WhmGaugeManager implements GaugeManager<WhmGaugeState> {
-    private _blueLilies: number = 0;
-    private _redLilies: number = 0;
+    private _blueLilies: number = 3;
+    private _redLilies: number = 3;
 
     get blueLilies(): number {
         return this._blueLilies;


### PR DESCRIPTION
7.4 WHM update.
Full stacks of Lilies and the Blood Lily in full bloom will be granted to white mage upon the beginning of duties.