### PR TITLE
[DNC] adjust buffs

### DIFF
--- a/packages/core/src/sims/buffs.ts
+++ b/packages/core/src/sims/buffs.ts
@@ -101,13 +101,28 @@ export const StarryMuse = {
     statusId: 3685,
 } as const satisfies PartyBuff;
 
+export const StandardFinishBuff = {
+    name: "Standard Finish",
+    saveKey: "Standard Finish",
+    job: "DNC",
+    duration: 60,
+    cooldown: 30,
+    selfOnly: false,
+    effects: {
+        dmgIncrease: 0.05,
+    },
+    startTime: 0,
+    statusId: 1821,
+    // TODO: The first application won't apply to itself,
+    // but subseqent applications should if the buff hasn't been dropped
+} as const satisfies PartyBuff;
+
 export const Devilment = {
     name: "Devilment",
     saveKey: "Devilment",
     job: "DNC",
     duration: 20,
     cooldown: 120,
-    optional: true,
     selfOnly: false,
     effects: {
         dhitChanceIncrease: 0.20,
@@ -244,7 +259,7 @@ export const OffGuardBuff = {
 
 export const ALL_BUFFS = [
     Dokumori, Litany, Brotherhood, ArcaneCircleBuff, SearingLight, Embolden, StarryMuse,
-    Devilment, TechnicalFinish, BattleVoice, RadiantFinale, Chain, Divination,
+    StandardFinishBuff, Devilment, TechnicalFinish, BattleVoice, RadiantFinale, Chain, Divination,
     AstCard, OffGuardBuff,
 ] as const;
 

--- a/packages/core/src/sims/ranged/dnc_sim.ts
+++ b/packages/core/src/sims/ranged/dnc_sim.ts
@@ -1,6 +1,6 @@
 import {AutoAttack, GcdAbility, OgcdAbility, SimSpec} from "@xivgear/core/sims/sim_types";
 import {CharacterGearSet} from "@xivgear/core/gear";
-import {TechnicalFinish} from "@xivgear/core/sims/buffs";
+import {StandardFinishBuff, TechnicalFinish} from "@xivgear/core/sims/buffs";
 import {ExternalCountSettings, CountSimResult, BaseUsageCountSim, SkillCount} from "@xivgear/core/sims/processors/count_sim";
 
 export const dncDtSheetSpec: SimSpec<DncDtSim, DncDtSimSettings> = {
@@ -87,6 +87,7 @@ const standardFinish: GcdAbility = {
     attackType: 'Weaponskill',
     gcd: 1.50,
     fixedGcd: true,
+    activatesBuffs: [StandardFinishBuff],
     id: 16003,
 } as const satisfies GcdAbility;
 
@@ -150,6 +151,7 @@ const finishingMove: GcdAbility = {
     potency: 850,
     attackType: 'Weaponskill',
     gcd: 2.50,
+    activatesBuffs: [StandardFinishBuff],
     // TODO: dt skill
     id: 40001,
 } as const satisfies GcdAbility;


### PR DESCRIPTION
Changes to address feedback via Discord:
- Adds Standard Finish personal/partner buff
- Makes Devilment personal/partner buff non-optional when creating a DNC sim