### PR TITLE
Fix bottom div spacing on mobile

### DIFF
--- a/packages/common-ui/styles/responsive.less
+++ b/packages/common-ui/styles/responsive.less
@@ -69,7 +69,9 @@ body:not(.embed-view) {
         }
 
         gear-set-viewer {
-          padding: 0;
+          // Small padding top, no padding sides, larger padding bottom.
+          padding: 10px 0 100px;
+
           // This gets capped to 100% width anyway
           --item-table-max-width: 800px;
 


### PR DESCRIPTION
If you are in the narrow view (<675px wide), then there isn't enough bottom padding to display the food stats if there is an ad there.