### PR TITLE
Add fallback mechanism for xivapi calls to fail over to internal boilmaster instance

### DIFF
--- a/packages/frontend/src/scripts/main.ts
+++ b/packages/frontend/src/scripts/main.ts
@@ -8,6 +8,7 @@ import {setupAccountUi} from "./account/components/account_components";
 import {setupUserDataSync} from "./account/user_data";
 import {startSizeAnalytics} from "./analytics/analytics_helpers";
 import {ASYNC_SIM_LOADER} from "./sims/asyncloader/async_loader";
+import {installImageFallbackHelper} from "./util/image_fallback_helper";
 
 declare global {
     interface Window {
@@ -35,6 +36,8 @@ document.addEventListener("DOMContentLoaded", () => {
 
     // Stop double click selection
     installDoubleClickHandler();
+    // Xivapi to fallback image helper
+    installImageFallbackHelper();
     // Initial page load behavior
     initialLoad();
 

--- a/packages/frontend/src/scripts/util/image_fallback_helper.ts
+++ b/packages/frontend/src/scripts/util/image_fallback_helper.ts
@@ -1,0 +1,20 @@
+import {XIVAPI_BASE_URL, XIVAPI_BASE_URL_FALLBACK} from "@xivgear/core/external/xivapi";
+
+export function installImageFallbackHelper() {
+    document.addEventListener('error', doImageFallback, {
+        capture: true,
+    });
+}
+
+function doImageFallback(event: ErrorEvent) {
+    const image = event.target;
+    if (image instanceof HTMLImageElement) {
+        if (image.src?.includes(XIVAPI_BASE_URL))  {
+            image.src = image.src.replaceAll(XIVAPI_BASE_URL, XIVAPI_BASE_URL_FALLBACK);
+        }
+        if (image.srcset?.includes(XIVAPI_BASE_URL)) {
+            image.srcset = image.srcset.replaceAll(XIVAPI_BASE_URL, XIVAPI_BASE_URL_FALLBACK);
+        }
+    }
+}
+


### PR DESCRIPTION
This should fix non-loading of images, though it does look a bit jank.