### PR TITLE
Sort BiS browser

### DIFF
--- a/packages/core/src/external/static_bis.ts
+++ b/packages/core/src/external/static_bis.ts
@@ -1,3 +1,5 @@
+import {JobName} from "@xivgear/xivmath/xivconstants";
+
 export type BaseNode = {
     fileName: string,
     parent?: DirNode,
@@ -14,6 +16,11 @@ export type LeafNode = BaseNode & {
 export type DirNode = BaseNode & {
     type: 'dir',
     children: AnyNode[],
+}
+
+export type JobNode = DirNode & {
+    fileName: JobName;
+    job: JobName;
 }
 
 export type AnyNode = LeafNode | DirNode;

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -72,11 +72,11 @@ export const STANDARD_APPLICATION_DELAY = 0.6;
 export const AUTOATTACK_APPLICATION_DELAY = 0.6;
 
 export const ALL_COMBAT_JOBS = [
-    'WHM', 'SGE', 'SCH', 'AST',
     'PLD', 'WAR', 'DRK', 'GNB',
-    'DRG', 'MNK', 'NIN', 'SAM', 'RPR', 'VPR',
+    'WHM', 'SCH', 'AST', 'SGE',
+    'MNK', 'DRG', 'NIN', 'SAM', 'RPR', 'VPR',
     'BRD', 'MCH', 'DNC',
-    'BLM', 'SMN', 'RDM', 'BLU', 'PCT',
+    'BLM', 'SMN', 'RDM', 'PCT', 'BLU',
 ] as const;
 /**
  * Supported Jobs.


### PR DESCRIPTION
BiS browser is now sorted such that anything that looks like a job comes first, and jobs are sorted by the in-game order (hardcoded based on xivconstants `ALL_COMBAT_JOBS`)

Closes #848 