### PR TITLE
Remove special animation lock value from Intervene

### DIFF
--- a/packages/core/src/sims/tank/pld/pld_actions.ts
+++ b/packages/core/src/sims/tank/pld/pld_actions.ts
@@ -330,7 +330,6 @@ export const Intervene: PldOgcdAbility = {
     type: 'ogcd',
     name: "Intervene",
     id: 16461,
-    animationLock: 0.8,
     attackType: "Ability",
     potency: 150,
     cooldown: {


### PR DESCRIPTION
uses default 0.6, EIE