### PR TITLE
WIP: show custom relics as alts

### DIFF
--- a/packages/core/src/test/items/alt_items_test.ts
+++ b/packages/core/src/test/items/alt_items_test.ts
@@ -52,6 +52,20 @@ describe('alt items logic', () => {
             // Should contain this because it is not equipped.
             expect(nuAlts).to.contain(uniqueRing2);
         });
+        it('should list a custom relic as an alt if it could make the same stats as another relic', () => {
+            // Majestic Manderville Wings (i645) 39937
+            const mmb = sheet.itemById(39937);
+            // Should be equivalent to Mandervillious Wings (i665) 40949
+            const mw = sheet.itemById(40949);
+            // These are both synced down
+            const set = new CharacterGearSet(sheet);
+            const emmb = set.toEquippedItem(mmb);
+            emmb.relicStats.crit = 293;
+            emmb.relicStats.determination = 293;
+            emmb.relicStats.piety = 72;
+            const alts = set.getAltItemsFor(mmb);
+            expect(alts).to.contain(mw);
+        });
     });
 });
 

--- a/packages/frontend/src/scripts/components/job/job_icon.ts
+++ b/packages/frontend/src/scripts/components/job/job_icon.ts
@@ -85,6 +85,8 @@ export class JobIcon extends HTMLImageElement {
 
         this.addEventListener('load', loadListener);
         this.addEventListener('error', e => {
+            // TODO: this seems to have an issue with the alt URL loading - we remove the 'load' listener here, but
+            // that means that when it finally loads successfully, we don't remove the placeholder styling.
             e.preventDefault();
             this.classList.remove('loaded');
             this.classList.add('image-error-loading');


### PR DESCRIPTION
Not substantially started yet, just a placeholder PR.

There are two ways to go with this:
1. The full option - look at valid combinations of relic stats and accurately display relics as alts for any item which might be replaceable by a relic. This is harder but more complete.
2. The easy option - treat relics as interchangeable with other relics only. Look at the relic stat models plus stat caps.
3. The easiest option - treat relics as interchangeable within the same relic "type" (i.e. full custom vs choose from fixed options).

Optino 1 requires a more substantial refactor because it would need to consider the item "as equipped" rather than "as it exists in the data files" - for example, there may or may not be a valid non-relic alternative to a relic based on the stats chosen on the relic.