### PR TITLE
Support items that grant main/secondary attribute

### DIFF
--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -30,7 +30,6 @@ import {
     RawStatsPart,
     RelicStatModel
 } from "@xivgear/xivmath/geartypes";
-import {BaseParamToStatKey, RelevantBaseParam} from "./external/xivapitypes";
 import {getRelicStatModelFor} from "./relicstats/relicstats";
 import {requireArrayTyped, requireNumber, requireString} from "./external/data_validators";
 import {
@@ -827,8 +826,14 @@ export class DataApiGearInfo implements GearItem {
             .filter(item => item[1])
             .reverse();
         if (sortedStats.length < 2) {
-            this.primarySubstat = null;
-            this.secondarySubstat = null;
+            if (sortedStats.length === 1) {
+                this.primarySubstat = sortedStats[0][0] as keyof RawStats;
+                this.secondarySubstat = null;
+            }
+            else {
+                this.primarySubstat = null;
+                this.secondarySubstat = null;
+            }
         }
         else {
             this.primarySubstat = sortedStats[0][0] as keyof RawStats;

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -166,8 +166,16 @@ export class NewApiDataManager implements DataManager {
                                 case "gearHaste":
                                     // Don't bother capping haste since it doesn't work like a normal stat.
                                     return 999_999;
+                                case "extraMainStat":
+                                    // Main stats **should** all be the same
+                                    ilvlModifier = row.mind;
+                                    break;
+                                case "extraSecondaryStat":
+                                    // Secondary stats also should all be the same
+                                    ilvlModifier = row.directHitRate;
+                                    break;
                                 default:
-                                    console.warn(`Bad ilvl modifer! ${statsKey}:${slot}`);
+                                    console.warn(`Bad ilvl modifier! ${statsKey}:${slot}`);
                                     ilvlModifier = undefined;
                                     break;
                             }
@@ -234,7 +242,7 @@ export class NewApiDataManager implements DataManager {
             checkResponse(response);
             this._baseParams = response.data.items!.reduce<BaseParamMap>((baseParams, value) => {
                 // Each individual item also gets converted
-                baseParams[BaseParamToStatKey[value.name as RelevantBaseParam]] = {
+                baseParams[statById(value.rowId)] = {
                     meldParam: requireArrayTyped(value.meldParam, 'number'),
                     // This maps our internal stat keys to the xivapi percentages.
                     slots: {
@@ -308,6 +316,7 @@ export class NewApiDataManager implements DataManager {
         const statsPromise = Promise.all([itemsPromise, baseParamPromise]).then(() => {
             console.log(`Finishing item calculations for ${this._allItems.length} items`);
             this._allItems.forEach(item => {
+                // console.log(`Item ${item.id} ${item.name}`);
                 const itemIlvlPromise = this.getIlvlSyncData(baseParamPromise, item.ilvl);
                 let isyncLvl: number | null;
                 // Downsync by ilvl directly

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -691,8 +691,12 @@ export class DataApiGearInfo implements GearItem {
         const baseMatCount: number = data.materiaSlotCount;
         if (baseMatCount === 0) {
             // If there are no materia slots, then it might be a custom relic
-            // TODO: is this branch still needed?
-            if (this.displayGearSlot !== DisplayGearSlotMapping.OffHand) {
+
+            // Pre-order earrings and other items that directly provide main stat
+            if (this.baseStats.extraMainStat) {
+                this.isCustomRelic = false;
+            }
+            else if (this.displayGearSlot !== DisplayGearSlotMapping.OffHand) {
                 // Offhands never have materia slots
                 this.isCustomRelic = true;
             }

--- a/packages/core/src/test/datamanager_tests.ts
+++ b/packages/core/src/test/datamanager_tests.ts
@@ -72,6 +72,9 @@ describe('New Datamanager', () => {
             defenseMag: 0,
             defensePhys: 0,
             gearHaste: 999_999,
+
+            extraMainStat: 416,
+            extraSecondaryStat: 306,
         });
         eq(codexOfAscension.materiaSlots.length, 2);
         eq(codexOfAscension.isCustomRelic, false);
@@ -136,6 +139,8 @@ describe('New Datamanager', () => {
             spellspeed: 179,
             tenacity: 179,
             determination: 179,
+            extraMainStat: 177,
+            extraSecondaryStat: 179,
         }));
     });
     describe('syncs levels correctly', () => {

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -164,6 +164,8 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
         expect(menphina.stats.extraSecondaryStat).to.equal(79);
         expect(menphina.stats.vitality).to.equal(80);
         expect(menphina.stats.determination).to.equal(79);
+        expect(menphina.primarySubstat).to.eq('determination');
+        expect(menphina.secondarySubstat).to.be.null;
         const set = new CharacterGearSet(sheet);
         const statsBefore = set.computedStats;
         const dexterityBefore = statsBefore.dexterity;
@@ -188,6 +190,8 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
         expect(azeyma.unsyncedVersion.stats.extraSecondaryStat).to.equal(111);
         expect(azeyma.unsyncedVersion.stats.vitality).to.equal(115);
         expect(azeyma.unsyncedVersion.stats.determination).to.equal(111);
+        expect(azeyma.primarySubstat).to.eq('determination');
+        expect(azeyma.secondarySubstat).to.be.null;
         const set = new CharacterGearSet(sheet);
         const statsBefore = set.computedStats;
         const dexterityBefore = statsBefore.dexterity;

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -168,7 +168,7 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
     before(async () => {
         await sheet.load();
         sheet.partyBonus = 0;
-    }).timeout(30_000);
+    });
     it('Supports primary and secondary stats', () => {
         // Menphina's earring (i430 - no sync)
         const menphina = sheet.itemById(33648);
@@ -190,7 +190,7 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
         const dhitAfter = statsAfter.dhit;
         expect(dexterityAfter).to.eq(374 + 78);
         expect(dhitAfter).to.eq(380 + 79);
-    });
+    }).timeout(30_000);
     it('Respects ilvl downsync', () => {
         // Azeyma's earring (i560 - should be synced)
         const azeyma = sheet.itemById(41081);
@@ -216,10 +216,10 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
         const dhitAfter = statsAfter.dhit;
         expect(dexterityAfter).to.eq(374 + 78);
         expect(dhitAfter).to.eq(380 + 79);
+    }).timeout(30_000);
 
-    });
     it('Does not treat said items as custom relics', () => {
         const menphina = sheet.itemById(33648);
         expect(menphina.isCustomRelic).to.equal(false);
-    });
+    }).timeout(30_000);
 });

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -168,7 +168,7 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
     before(async () => {
         await sheet.load();
         sheet.partyBonus = 0;
-    });
+    }).timeout(30_000);
     it('Supports primary and secondary stats', () => {
         // Menphina's earring (i430 - no sync)
         const menphina = sheet.itemById(33648);

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -165,7 +165,8 @@ describe('bug #695 - offhands have wrong stats', () => {
 
 describe('Feature 24 - support items that give primary/secondary stat directly such as pre-order earrings', () => {
     const sheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, 'main stat test sheet', 'NIN', 80, 430, true);
-    before(async () => {
+    before(async function () {
+        this.timeout(30_000);
         await sheet.load();
         sheet.partyBonus = 0;
     });

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -152,11 +152,13 @@ describe('bug #695 - offhands have wrong stats', () => {
 
 
 describe('Feature 24 - support items that give primary/secondary stat directly such as pre-order earrings', () => {
-    it('Supports primary and secondary stats', async () => {
-        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, 'main stat test sheet', 'NIN', 80, 430, true);
+    const sheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, 'main stat test sheet', 'NIN', 80, 430, true);
+    before(async () => {
         await sheet.load();
         sheet.partyBonus = 0;
-        // Menphina's earring
+    });
+    it('Supports primary and secondary stats', () => {
+        // Menphina's earring (i430 - no sync)
         const menphina = sheet.itemById(33648);
         expect(menphina.stats.extraMainStat).to.equal(78);
         expect(menphina.stats.extraSecondaryStat).to.equal(79);
@@ -174,5 +176,34 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
         const dhitAfter = statsAfter.dhit;
         expect(dexterityAfter).to.eq(374 + 78);
         expect(dhitAfter).to.eq(380 + 79);
+    });
+    it('Respects ilvl downsync', () => {
+        // Azeyma's earring (i560 - should be synced)
+        const azeyma = sheet.itemById(41081);
+        expect(azeyma.stats.extraMainStat).to.equal(78);
+        expect(azeyma.stats.extraSecondaryStat).to.equal(79);
+        expect(azeyma.stats.vitality).to.equal(80);
+        expect(azeyma.stats.determination).to.equal(79);
+        expect(azeyma.unsyncedVersion.stats.extraMainStat).to.equal(115);
+        expect(azeyma.unsyncedVersion.stats.extraSecondaryStat).to.equal(111);
+        expect(azeyma.unsyncedVersion.stats.vitality).to.equal(115);
+        expect(azeyma.unsyncedVersion.stats.determination).to.equal(111);
+        const set = new CharacterGearSet(sheet);
+        const statsBefore = set.computedStats;
+        const dexterityBefore = statsBefore.dexterity;
+        const dhitBefore = statsBefore.dhit;
+        expect(dexterityBefore).to.equal(374);
+        expect(dhitBefore).to.equal(380);
+        set.setEquip("Ears", azeyma);
+        const statsAfter = set.computedStats;
+        const dexterityAfter = statsAfter.dexterity;
+        const dhitAfter = statsAfter.dhit;
+        expect(dexterityAfter).to.eq(374 + 78);
+        expect(dhitAfter).to.eq(380 + 79);
+
+    });
+    it('Does not treat said items as custom relics', () => {
+        const menphina = sheet.itemById(33648);
+        expect(menphina.isCustomRelic).to.equal(false);
     });
 });

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -190,7 +190,7 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
         const dhitAfter = statsAfter.dhit;
         expect(dexterityAfter).to.eq(374 + 78);
         expect(dhitAfter).to.eq(380 + 79);
-    }).timeout(30_000);
+    });
     it('Respects ilvl downsync', () => {
         // Azeyma's earring (i560 - should be synced)
         const azeyma = sheet.itemById(41081);
@@ -216,10 +216,10 @@ describe('Feature 24 - support items that give primary/secondary stat directly s
         const dhitAfter = statsAfter.dhit;
         expect(dexterityAfter).to.eq(374 + 78);
         expect(dhitAfter).to.eq(380 + 79);
-    }).timeout(30_000);
+    });
 
     it('Does not treat said items as custom relics', () => {
         const menphina = sheet.itemById(33648);
         expect(menphina.isCustomRelic).to.equal(false);
-    }).timeout(30_000);
-});
+    });
+}).timeout(30_000);

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -103,7 +103,7 @@ describe('bug #695 - offhands have wrong stats', () => {
                             return;
                         }
                     }
-                    failures.push(`Item ${item.name} i${item.ilvl} (${item.id}, ${item.occGearSlotName}) has ${primarySub} ${primarySubValue} !== ${primarySubCap} (cap)`);
+                    failures.push(`Item ${item.name} i${item.ilvl} (${item.id}, ${item.occGearSlotName}) has substat ${primarySub} ${primarySubValue} !== ${primarySubCap} (cap)`);
                 }
                 // This includes vitality
                 MAIN_STATS.forEach(mainStat => {
@@ -120,8 +120,20 @@ describe('bug #695 - offhands have wrong stats', () => {
                     ) {
                         return;
                     }
+                    if (mainStat === 'vitality' && item.jobs.length > 15) {
+                        // Preorder earrings - these seem to not follow the pattern exactly
+                        if (item.ilvl === 290 && item.stats.vitality === 46) {
+                            return;
+                        }
+                        else if (item.ilvl === 430 && item.stats.vitality === 80) {
+                            return;
+                        }
+                        else if (item.ilvl === 560 && item.stats.vitality === 115) {
+                            return;
+                        }
+                    }
                     if (value !== cap) {
-                        failures.push(`Item ${item.name} i${item.ilvl} (${item.id}, ${item.occGearSlotName}) has ${mainStat} ${value} !== ${cap} (cap)`);
+                        failures.push(`Item ${item.name} i${item.ilvl} (${item.id}, ${item.occGearSlotName}) has mainstat ${mainStat} ${value} !== ${cap} (cap)`);
                     }
                 });
                 const defStats: RawStatKey[] = ["defensePhys", "defenseMag"];
@@ -137,7 +149,7 @@ describe('bug #695 - offhands have wrong stats', () => {
                     }
                     // Allow a margin of error of one unless we find a confirmed-wrong case.
                     if (Math.abs(value - cap) > 1) {
-                        failures.push(`Item ${item.name} i${item.ilvl} (${item.id}, ${item.occGearSlotName}) has ${defStat} ${value} !== ${cap} (cap)`);
+                        failures.push(`Item ${item.name} i${item.ilvl} (${item.id}, ${item.occGearSlotName}) has defstat ${defStat} ${value} !== ${cap} (cap)`);
                     }
 
                 });

--- a/packages/core/src/test/item_stats_tests.ts
+++ b/packages/core/src/test/item_stats_tests.ts
@@ -1,8 +1,9 @@
-import {previewItemStatDetail} from "../gear";
+import {CharacterGearSet, previewItemStatDetail} from "../gear";
 import {GearItem, RawStatKey, RawStats} from "@xivgear/xivmath/geartypes";
 import {expect} from 'chai';
 import {NewApiDataManager} from "../datamanager_new";
 import {ALL_COMBAT_JOBS, MAIN_STATS} from "@xivgear/xivmath/xivconstants";
+import {HEADLESS_SHEET_PROVIDER} from "../sheet";
 
 
 describe('Individual item math', () => {
@@ -92,8 +93,8 @@ describe('bug #695 - offhands have wrong stats', () => {
                 const primarySubValue = item.stats[primarySub];
                 const primarySubCap = item.statCaps[primarySub];
                 if (primarySubValue !== primarySubCap) {
-                    // A few ilvls have different caps for piety and tenacity
-                    if (primarySub === 'piety' || primarySub === 'tenacity') {
+                    // A few ilvls have different caps for dhit and tenacity
+                    if (primarySub === 'dhit' || primarySub === 'tenacity') {
                         const ilvlSyncInfo = dm.getIlvlSyncInfo(item.ilvl);
                         const thisCap = ilvlSyncInfo.substatCap(item.occGearSlotName, primarySub);
                         // The cap for the "normal" substats
@@ -150,3 +151,28 @@ describe('bug #695 - offhands have wrong stats', () => {
 });
 
 
+describe('Feature 24 - support items that give primary/secondary stat directly such as pre-order earrings', () => {
+    it('Supports primary and secondary stats', async () => {
+        const sheet = HEADLESS_SHEET_PROVIDER.fromScratch(undefined, 'main stat test sheet', 'NIN', 80, 430, true);
+        await sheet.load();
+        sheet.partyBonus = 0;
+        // Menphina's earring
+        const menphina = sheet.itemById(33648);
+        expect(menphina.stats.extraMainStat).to.equal(78);
+        expect(menphina.stats.extraSecondaryStat).to.equal(79);
+        expect(menphina.stats.vitality).to.equal(80);
+        expect(menphina.stats.determination).to.equal(79);
+        const set = new CharacterGearSet(sheet);
+        const statsBefore = set.computedStats;
+        const dexterityBefore = statsBefore.dexterity;
+        const dhitBefore = statsBefore.dhit;
+        expect(dexterityBefore).to.equal(374);
+        expect(dhitBefore).to.equal(380);
+        set.setEquip("Ears", menphina);
+        const statsAfter = set.computedStats;
+        const dexterityAfter = statsAfter.dexterity;
+        const dhitAfter = statsAfter.dhit;
+        expect(dexterityAfter).to.eq(374 + 78);
+        expect(dhitAfter).to.eq(380 + 79);
+    });
+});

--- a/packages/frontend/src/scripts/components/sheet/editor/items.ts
+++ b/packages/frontend/src/scripts/components/sheet/editor/items.ts
@@ -443,13 +443,25 @@ function itemTableStatColumn(sheet: GearPlanSheet, set: CharacterGearSet, stat: 
                 return new RelicCellInfo(set, currentEquipment.gearItem, slotItem.slotId, stat as Substat, set.getStatDetail(slotItem.slotId, stat), !item.relicStatModel.excludedStats.includes(stat as Substat));
             }
             else {
+                // Future TODO: this makes the assumption that an item will never have extra main stat *and* provide a
+                // specific main stat directly.
+                let effectiveStat: RawStatKey;
+                if (item.stats.extraMainStat && stat === set.classJobStats.mainStat) {
+                    effectiveStat = 'extraMainStat';
+                }
+                else if (item.stats.extraSecondaryStat && stat === set.classJobStats.secondaryStat) {
+                    effectiveStat = 'extraSecondaryStat';
+                }
+                else {
+                    effectiveStat = stat;
+                }
                 // Not a relic, or not an editable stat. Display normally
                 const selected = set.getItemInSlot(slotItem.slotId) === item;
                 if (selected) {
-                    return set.getStatDetail(slotItem.slotId, stat);
+                    return set.getStatDetail(slotItem.slotId, effectiveStat);
                 }
                 else {
-                    return previewItemStatDetail(item, stat);
+                    return previewItemStatDetail(item, effectiveStat);
                 }
             }
         },
@@ -507,6 +519,24 @@ function itemTableStatColumn(sheet: GearPlanSheet, set: CharacterGearSet, stat: 
                 }
                 else if (value !== 'relic-zero') {
                     applyStatCellStyles(cell, value, stat);
+                    const item = cell.dataItem.item;
+                    // These items are a bit weird in that they don't really have a "big" or "small" stat
+                    if (item.stats.extraMainStat && stat === set.classJobStats.mainStat) {
+                        if (item.unsyncedVersion.stats.extraMainStat === item.unsyncedVersion.statCaps.extraMainStat) {
+                            cell.classList.add('primary');
+                        }
+                        else {
+                            cell.classList.add('secondary');
+                        }
+                    }
+                    else if (item.stats.extraSecondaryStat && stat === set.classJobStats.secondaryStat) {
+                        if (item.unsyncedVersion.stats.extraSecondaryStat === item.unsyncedVersion.statCaps.extraSecondaryStat) {
+                            cell.classList.add('primary');
+                        }
+                        else {
+                            cell.classList.add('secondary');
+                        }
+                    }
                 }
             }
             else {

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -445,6 +445,9 @@ export interface MeldableMateriaSlot {
 
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 export interface RawStats {
+    /**
+     * Raw HP provided by the item - does NOT include HP provided via vitality.
+     */
     hp: number,
     vitality: number,
     strength: number,
@@ -460,10 +463,23 @@ export interface RawStats {
     skillspeed: number,
     wdPhys: number,
     wdMag: number,
+    /**
+     * weaponDelay expressed as seconds (i.e. 3.54 = 3.54 seconds)
+     */
     weaponDelay: number,
-    defenseMag: number;
-    defensePhys: number;
-    gearHaste: number;
+    defenseMag: number,
+    defensePhys: number,
+    gearHaste: number,
+    /**
+     * Represents direct main stat bonuses. Only applicable to item stats - not used in computed stats, as it should be
+     * converted to the actual concrete stat at that point.
+     */
+    extraMainStat: number,
+    /**
+     * Represents direct secondary stat bonuses. Only applicable to item stats - not used in computed stats, as it should be
+     * converted to the actual concrete stat at that point.
+     */
+    extraSecondaryStat: number,
 }
 
 export type RawStatKey = keyof RawStats;
@@ -496,6 +512,8 @@ export class RawStats implements RawStats {
     defenseMag: number = 0;
     defensePhys: number = 0;
     gearHaste: number = 0;
+    extraMainStat: number = 0;
+    extraSecondaryStat: number = 0;
 
     constructor(values: ({ [K in RawStatKey]?: number } | undefined) = undefined) {
         if (values) {
@@ -554,6 +572,11 @@ export interface JobDataConst {
      * The primary stat
      */
     readonly mainStat: Mainstat;
+
+    /**
+     * The secondary substat for the purposes of items such as pre-order earrings.
+     */
+    readonly secondaryStat: Substat;
     /**
      * The primary stat as used for auto-attack calculations specifically
      */

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -122,6 +122,7 @@ export const RANGE_AUTO_POTENCY = 80;
 const STANDARD_HEALER: JobDataConst = {
     role: 'Healer',
     mainStat: 'mind',
+    secondaryStat: 'piety',
     autoAttackStat: 'strength',
     irrelevantSubstats: ['skillspeed', 'tenacity'],
     traitMulti: (level, attackType) => attackType === 'Auto-attack' ? 1.0 : 1.3, // Maim and Mend II
@@ -134,6 +135,7 @@ const STANDARD_HEALER: JobDataConst = {
 const STANDARD_TANK: JobDataConst = {
     role: 'Tank',
     mainStat: 'strength',
+    secondaryStat: 'tenacity',
     autoAttackStat: 'strength',
     irrelevantSubstats: ['spellspeed', 'piety'],
     meldParamIndex: 1,
@@ -145,6 +147,7 @@ const STANDARD_TANK: JobDataConst = {
 const STANDARD_MELEE: Omit<JobDataConst, 'meldParamIndex'> = {
     role: 'Melee',
     mainStat: 'strength',
+    secondaryStat: 'dhit',
     autoAttackStat: 'strength',
     irrelevantSubstats: ['spellspeed', 'tenacity', 'piety'],
     aaPotency: MELEE_AUTO_POTENCY,
@@ -172,6 +175,7 @@ const MELEE_MAIMING: JobDataConst = {
 const STANDARD_RANGED: JobDataConst = {
     role: 'Ranged',
     mainStat: 'dexterity',
+    secondaryStat: 'dhit',
     autoAttackStat: 'dexterity',
     irrelevantSubstats: ['spellspeed', 'tenacity', 'piety'],
     traitMulti: (level, attackType) => attackType === 'Auto-attack' ? 1.0 : 1.2, // Increased Action Damage II
@@ -184,6 +188,7 @@ const STANDARD_RANGED: JobDataConst = {
 const STANDARD_CASTER: JobDataConst = {
     role: 'Caster',
     mainStat: 'intelligence',
+    secondaryStat: 'dhit',
     autoAttackStat: 'strength',
     irrelevantSubstats: ['skillspeed', 'tenacity', 'piety'],
     traitMulti: (level, attackType) => attackType === 'Auto-attack' ? 1.0 : 1.3, // Maim and Mend II
@@ -739,6 +744,8 @@ export const STAT_FULL_NAMES: Record<RawStatKey, string> = {
     wdPhys: "Weapon Damage (Physical)",
     weaponDelay: "Auto-Attack Delay",
     gearHaste: "Gear Haste",
+    extraMainStat: "Extra Main Stat",
+    extraSecondaryStat: "Extra Secondary Stat",
 };
 
 /**
@@ -764,6 +771,9 @@ export const STAT_ABBREVIATIONS: Record<RawStatKey, string> = {
     wdPhys: "WDp",
     weaponDelay: "Dly",
     gearHaste: "Hst",
+    // Game calls these "Main Attribute" and "Secondary Attribute"
+    extraMainStat: "MA",
+    extraSecondaryStat: "SA",
 };
 
 /**
@@ -792,6 +802,8 @@ export function statById(id: number): keyof RawStats | undefined {
             return "wdPhys";
         case 13:
             return "wdMag";
+        case 14:
+            return "weaponDelay";
         case 19:
             return "tenacity";
         case 21:
@@ -813,6 +825,10 @@ export function statById(id: number): keyof RawStats | undefined {
             return "spellspeed";
         case 47:
             return "gearHaste";
+        case 55:
+            return 'extraMainStat';
+        case 56:
+            return 'extraSecondaryStat';
         default:
             return undefined;
     }

--- a/packages/xivmath/src/xivstats.ts
+++ b/packages/xivmath/src/xivstats.ts
@@ -22,7 +22,8 @@ import {
     detDmg,
     dhitChance,
     dhitDmg,
-    fl, flp,
+    fl,
+    flp,
     mainStatMulti,
     mpTick,
     sksTickMulti,
@@ -473,6 +474,16 @@ export class ComputedSetStatsImpl implements ComputedSetStats {
     get effectiveFoodBonuses(): RawStats {
         return this._effectiveFoodBonuses;
     }
+
+    get extraMainStat(): 0 {
+        // Always 0 at this point because the extra main stat is already factored into the actual main stat.
+        return 0;
+    }
+
+    get extraSecondaryStat(): 0 {
+        // Always 0 at this point because the extra secondary stat is already factored into the actual secondary stat.
+        return 0;
+    }
 }
 
 export function finalizeStats(
@@ -506,7 +517,10 @@ export function finalizeStatsInt(
 } {
     const combinedStats: RawStats = {...gearStats};
     const mainStatKey = classJobStats.mainStat;
+    const secondaryStatKey = classJobStats.secondaryStat;
     const aaStatKey = classJobStats.autoAttackStat;
+    combinedStats[mainStatKey] += gearStats.extraMainStat;
+    combinedStats[secondaryStatKey] += gearStats.extraSecondaryStat;
     combinedStats[mainStatKey] = fl(combinedStats[mainStatKey] * (1 + 0.01 * partyBonus));
     if (mainStatKey !== aaStatKey) {
         combinedStats[aaStatKey] = fl(combinedStats[aaStatKey] * (1 + 0.01 * partyBonus));


### PR DESCRIPTION
Support items like preorder earrings that directly provide main stat + secondary substat.

Implementation details:
- Add two new fields to RawStats, representing these new stats
- Fold them into the real stats in ComputedSetStats
- Update some of the item table formatting logic to show these as if they were normal stats

The main challenge is that a melee multi-job sheet would include NIN and VPR who have a different main stat (DEX instead of STR). This means that we can't do the folding at the GearItem level. It has to be done downstream of that. I would like to refactor it later to possibly add a new model layer between GearItem and EquippedItem.

Closes #24 