### PR TITLE
override default cycle settings instead

### DIFF
--- a/packages/sims/src/melee/rpr/rpr_sheet_sim.ts
+++ b/packages/sims/src/melee/rpr/rpr_sheet_sim.ts
@@ -20,8 +20,6 @@ export interface RprSheetSimResult extends CycleSimResult {
 }
 
 export interface RprSimSettings extends SimSettings {
-    // the length of the fight in seconds
-    fightTime: number;
 }
 
 export interface RprSimSettingsExternal extends ExternalCycleSettings<RprSimSettings> {
@@ -421,29 +419,28 @@ export class RprSheetSim extends BaseMultiCycleSim<RprSheetSimResult, RprSimSett
     shortName = "rpr-sheet-sim";
     displayName = rprSheetSpec.displayName;
     manuallyActivatedBuffs = [ArcaneCircleBuff];
-    cycleSettings: CycleSettings = {
-        useAutos: true,
-        totalTime: this.settings.fightTime,
-        cycles: 0,
-        which: 'totalTime',
-        cutoffMode: 'prorate-gcd',
-    };
-
 
     constructor(settings?: RprSimSettingsExternal) {
         super('RPR', settings);
     }
 
-    makeDefaultSettings(): RprSimSettings {
+    override defaultCycleSettings(): CycleSettings {
         return {
+            ...super.defaultCycleSettings(),
             // 8:30 Killtime. This is chosen as a default because
             // RPR's full uptime standard rotation falls apart
             // at 10:30 and beyond. 8:30 is the longest time that
             // doesn't need adjustments and is also a potential parse KT target.
             // Worth noting that an immediately post burst KT biases towards having
             // more abilities in buffs than average (relevant when crit/DH buffs are present)
-            fightTime: (8 * 60) + 30,
+            totalTime: (8 * 60) + 35,
+            cycles: 0,
+            which: 'totalTime',
         };
+    }
+
+    makeDefaultSettings(): RprSimSettings {
+        return {};
     }
 
     protected createCycleProcessor(settings: MultiCycleSettings): RprCycleProcessor {


### PR DESCRIPTION
Better way to handle the previous PR changing RPR's default sim time