### PR TITLE
Fix the errors from the early access to localStorage, change embed open link logic

### DIFF
--- a/packages/frontend/src/index.html
+++ b/packages/frontend/src/index.html
@@ -3,10 +3,18 @@
 <head>
     <link rel="stylesheet" href="./style.css"/>
     <script blocking="render">
-        if (localStorage.getItem('light-mode') === 'true') {
-            document.addEventListener('DOMContentLoaded', () => {
-                document.querySelector('body').classList.add('light-mode');
-            });
+        try {
+            if (localStorage.getItem('light-mode') === 'true') {
+                document.addEventListener('DOMContentLoaded', () => {
+                    document.querySelector('body').classList.add('light-mode');
+                });
+            }
+        } catch (e) {
+            // If we are in a cross-site context, even referencing 'localStorage' will throw an error.
+            // If not in an iframe, just re-throw it. Otherwise, silently ignore it.
+            if (window.self === window.top) {
+                throw e
+            }
         }
     </script>
     <meta charset="UTF-8">

--- a/packages/frontend/src/scripts/embed.ts
+++ b/packages/frontend/src/scripts/embed.ts
@@ -57,7 +57,7 @@ export async function openEmbed(sheet: GearPlanSheetGui) {
         // 75% chance to get the default
         const useDefault = Math.random() <= 0.75;
 
-        const buttonText = useDefault ? OPEN_FULL_OPTIONS[Math.floor(Math.random() * OPEN_FULL_OPTIONS.length * 0.999)] ?? 'Open Full';
+        const buttonText = useDefault ? OPEN_FULL_OPTIONS[0] : (OPEN_FULL_OPTIONS[Math.floor(Math.random() * OPEN_FULL_OPTIONS.length * 0.999)] ?? 'Open Full');
         const hash = getCurrentHash();
         const linkUrl = makeUrl(new NavState(hash.slice(1), undefined, getCurrentState().onlySetIndex));
         linkUrl.searchParams.delete(ONLY_SET_QUERY_PARAM);

--- a/packages/frontend/src/scripts/embed.ts
+++ b/packages/frontend/src/scripts/embed.ts
@@ -72,7 +72,7 @@ export async function openEmbed(sheet: GearPlanSheetGui) {
 
         openFullLink.addEventListener('click', () => {
             recordSheetEvent("openEmbedToFull", sheet, {
-                buttonText: buttonText,
+                buttonText: useDefault ? `${buttonText} (default)` : buttonText,
             });
         });
 

--- a/packages/frontend/src/scripts/embed.ts
+++ b/packages/frontend/src/scripts/embed.ts
@@ -54,7 +54,10 @@ export async function openEmbed(sheet: GearPlanSheetGui) {
         console.log("openEmbed mid");
         const editorArea = sheet.editorArea;
 
-        const buttonText = OPEN_FULL_OPTIONS[Math.floor(Math.random() * OPEN_FULL_OPTIONS.length * 0.999)] ?? 'Open Full';
+        // 75% chance to get the default
+        const useDefault = Math.random() <= 0.75;
+
+        const buttonText = useDefault ? OPEN_FULL_OPTIONS[Math.floor(Math.random() * OPEN_FULL_OPTIONS.length * 0.999)] ?? 'Open Full';
         const hash = getCurrentHash();
         const linkUrl = makeUrl(new NavState(hash.slice(1), undefined, getCurrentState().onlySetIndex));
         linkUrl.searchParams.delete(ONLY_SET_QUERY_PARAM);


### PR DESCRIPTION
Fixes the umami error spam that was resulting from trying to access localStorage early, before the shim is installed.

Also makes it so that 75% of the time, you get the default "Click to Open Full View" text on an embed since it seemed to be the most effective.