### PR TITLE
Job stat exports

### DIFF
--- a/packages/backend-resolver/schemas/stats-schemas.json
+++ b/packages/backend-resolver/schemas/stats-schemas.json
@@ -56,9 +56,19 @@
       },
       "type": "object"
     },
+    "CombatRoleKey": {
+      "enum": [
+        "Healer",
+        "Melee",
+        "Ranged",
+        "Caster",
+        "Tank"
+      ],
+      "type": "string"
+    },
     "ComputedSetStatsExport": {
       "additionalProperties": false,
-      "description": "Serialized form of ComputedSetStats. Removes jobStats because it doesn't serialize well.",
+      "description": "Serialized form of ComputedSetStats. Includes the serializable portion of jobStats.",
       "properties": {
         "aaDelay": {
           "description": "Auto-attack delay",
@@ -174,6 +184,9 @@
           "$ref": "#/definitions/JobName",
           "description": "Current class/job"
         },
+        "jobStats": {
+          "$ref": "#/definitions/JobDataExport"
+        },
         "level": {
           "$ref": "#/definitions/SupportedLevel",
           "description": "Current level"
@@ -254,60 +267,61 @@
         }
       },
       "required": [
-        "level",
-        "levelStats",
-        "job",
-        "critChance",
-        "critMulti",
-        "dhitChance",
-        "dhitMulti",
-        "detMulti",
-        "spsDotMulti",
-        "sksDotMulti",
-        "tncMulti",
-        "tncIncomingMulti",
-        "wdMulti",
-        "wdMultiPetAction",
-        "mainStatMulti",
-        "aaStatMulti",
-        "gearStats",
-        "baseMainStatPlusRace",
-        "autoDhBonus",
-        "autoCritBuffMulti",
-        "autoDhitBuffMulti",
-        "mpPerTick",
-        "aaMulti",
         "aaDelay",
-        "defenseDamageTaken",
-        "magicDefenseDamageTaken",
-        "effectiveFoodBonuses",
-        "hp",
-        "vitality",
-        "strength",
-        "dexterity",
-        "intelligence",
-        "mind",
-        "piety",
-        "crit",
-        "dhit",
-        "determination",
-        "tenacity",
-        "spellspeed",
-        "skillspeed",
-        "wdPhys",
-        "wdMag",
-        "weaponDelay",
-        "defenseMag",
-        "defensePhys",
-        "gearHaste",
-        "extraMainStat",
-        "extraSecondaryStat",
-        "craftsmanship",
+        "aaMulti",
+        "aaStatMulti",
+        "autoCritBuffMulti",
+        "autoDhBonus",
+        "autoDhitBuffMulti",
+        "baseMainStatPlusRace",
         "control",
         "cp",
-        "perception",
+        "craftsmanship",
+        "crit",
+        "critChance",
+        "critMulti",
+        "defenseDamageTaken",
+        "defenseMag",
+        "defensePhys",
+        "detMulti",
+        "determination",
+        "dexterity",
+        "dhit",
+        "dhitChance",
+        "dhitMulti",
+        "effectiveFoodBonuses",
+        "extraMainStat",
+        "extraSecondaryStat",
         "gathering",
-        "gp"
+        "gearHaste",
+        "gearStats",
+        "gp",
+        "hp",
+        "intelligence",
+        "job",
+        "jobStats",
+        "level",
+        "levelStats",
+        "magicDefenseDamageTaken",
+        "mainStatMulti",
+        "mind",
+        "mpPerTick",
+        "perception",
+        "piety",
+        "skillspeed",
+        "sksDotMulti",
+        "spellspeed",
+        "spsDotMulti",
+        "strength",
+        "tenacity",
+        "tncIncomingMulti",
+        "tncMulti",
+        "vitality",
+        "wdMag",
+        "wdMulti",
+        "wdMultiPetAction",
+        "wdPhys",
+        "weaponDelay"
       ],
       "type": "object"
     },
@@ -668,6 +682,151 @@
       },
       "type": "object"
     },
+    "JobDataExport": {
+      "additionalProperties": false,
+      "description": "Serialized form of  {@link  JobData } . Function-bearing fields and traits are omitted because they cannot be usefully represented in an export. The useful values from a trait are applied during stat calculation rather than stored in the trait definition.",
+      "properties": {
+        "aaPotency": {
+          "description": "Auto-attack potency amount",
+          "type": "number"
+        },
+        "autoAttackStat": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Mainstat",
+              "description": "The primary stat as used for auto-attack calculations specifically"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The primary stat as used for auto-attack calculations specifically"
+        },
+        "combatRole": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/CombatRoleKey",
+              "description": "The role of the job"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The role of the job"
+        },
+        "excludedRelicSubstats": {
+          "description": "Substats which are NOT already in  {@link  irrelevantSubstats  } , but which cannot be put onto custom relics.\n\ne.g. Healers and Tanks cannot put DHit on their custom relics.",
+          "items": {
+            "$ref": "#/definitions/Substat"
+          },
+          "type": "array"
+        },
+        "irrelevantSubstats": {
+          "description": "Substats which are completely irrelevant to this class, e.g. TNC on non-tanks",
+          "items": {
+            "$ref": "#/definitions/Substat"
+          },
+          "type": "array"
+        },
+        "jobStatMultipliers": {
+          "$ref": "#/definitions/JobMultipliers"
+        },
+        "mainStat": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Mainstat",
+              "description": "The primary stat"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The primary stat"
+        },
+        "maxLevel": {
+          "$ref": "#/definitions/SupportedLevel",
+          "description": "The maximum level of the job."
+        },
+        "meldParamIndex": {
+          "description": "Which BaseParam.MeldParam index to use for calculating stat caps. Makes hardcoded itemStatCapMultipliers obsolete. Since these only have numeric indices with no indication of which is which, it is derived from looking at gear pieces of the same ilvl and comparing their stats across different jobs. However, there are many rows which are identical for",
+          "type": "number"
+        },
+        "minLevel": {
+          "$ref": "#/definitions/SupportedLevel",
+          "description": "The minimum level of the job."
+        },
+        "offhand": {
+          "description": "True if this class uses 1H+Offhand rather than 2H weapons",
+          "type": "boolean"
+        },
+        "secondaryStat": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/Substat",
+              "description": "The secondary substat for the purposes of items such as pre-order earrings."
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "The secondary substat for the purposes of items such as pre-order earrings."
+        },
+        "type": {
+          "enum": [
+            "Combat",
+            "DoH",
+            "DoL"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "type",
+        "combatRole",
+        "mainStat",
+        "secondaryStat",
+        "autoAttackStat",
+        "meldParamIndex",
+        "aaPotency",
+        "excludedRelicSubstats",
+        "minLevel",
+        "maxLevel",
+        "jobStatMultipliers"
+      ],
+      "type": "object"
+    },
+    "JobMultipliers": {
+      "additionalProperties": false,
+      "properties": {
+        "dexterity": {
+          "type": "number"
+        },
+        "hp": {
+          "type": "number"
+        },
+        "intelligence": {
+          "type": "number"
+        },
+        "mind": {
+          "type": "number"
+        },
+        "strength": {
+          "type": "number"
+        },
+        "vitality": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "dexterity",
+        "hp",
+        "intelligence",
+        "mind",
+        "strength",
+        "vitality"
+      ],
+      "type": "object"
+    },
     "JobName": {
       "description": "Supported Jobs.",
       "enum": [
@@ -822,6 +981,16 @@
         "mainStatPowerMod"
       ],
       "type": "object"
+    },
+    "Mainstat": {
+      "enum": [
+        "strength",
+        "dexterity",
+        "intelligence",
+        "mind",
+        "vitality"
+      ],
+      "type": "string"
     },
     "MateriaFillMode": {
       "enum": [

--- a/packages/backend-resolver/src/test/stats_server_tests.ts
+++ b/packages/backend-resolver/src/test/stats_server_tests.ts
@@ -51,6 +51,22 @@ describe('stats server', () => {
                 const stats = firstSet.computedStats;
                 expect(stats.hp).to.equal(74421);
                 expect(stats.mind).to.equal(3374);
+                expect(stats.jobStats).to.include({
+                    type: 'Combat',
+                    combatRole: 'Healer',
+                    mainStat: 'mind',
+                    secondaryStat: 'piety',
+                    autoAttackStat: 'strength',
+                    meldParamIndex: 6,
+                    aaPotency: 90,
+                });
+                expect(stats.jobStats.jobStatMultipliers).to.be.an('object');
+                expect(stats.jobStats).to.not.have.any.keys(
+                    'traitMulti',
+                    'traits',
+                    'gcdDisplayOverrides',
+                    'extraItemFilter'
+                );
             }).timeout(30_000);
             it("can serve correct data with party size 0", async () => {
                 const response = await fastify.inject({

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -37,6 +37,7 @@ import {
     ItemSlotExport,
     JobData,
     JobDataConst,
+    JobDataExport,
     Materia,
     MateriaAutoFillController,
     MateriaAutoFillPrio,
@@ -1809,6 +1810,24 @@ export const ExportTypes = {
     FullStatsExport,
 } as const;
 
+function jobDataSerializationProxy(jobStats: JobData): JobDataExport {
+    return {
+        type: jobStats.type,
+        combatRole: jobStats.combatRole,
+        mainStat: jobStats.mainStat,
+        secondaryStat: jobStats.secondaryStat,
+        autoAttackStat: jobStats.autoAttackStat,
+        irrelevantSubstats: jobStats.irrelevantSubstats,
+        offhand: jobStats.offhand,
+        meldParamIndex: jobStats.meldParamIndex,
+        aaPotency: jobStats.aaPotency,
+        excludedRelicSubstats: jobStats.excludedRelicSubstats,
+        minLevel: jobStats.minLevel,
+        maxLevel: jobStats.maxLevel,
+        jobStatMultipliers: jobStats.jobStatMultipliers,
+    } satisfies JobDataExport;
+}
+
 /**
  * Transform a ComputedSetStats into a form that serializes properly. That is, it serializes the getters rather
  * than only the backing data. This is realistically what you would want out of the fulldata API endpoint.
@@ -1817,12 +1836,10 @@ export const ExportTypes = {
  */
 export function statsSerializationProxy(stats: ComputedSetStats): ComputedSetStatsExport {
     // The purpose of this is that the fullstats API won't correctly serialize the ComputedSetStatsImpl normally.
-    // We care about the
     return new Proxy(stats, {
         get(target, prop, receiver) {
-            // Remove this field, it doesn't serialize well anyway
             if (prop === 'jobStats') {
-                return undefined;
+                return jobDataSerializationProxy(target.jobStats);
             }
             // Check if the property is a getter on the prototype chain
             let descriptor = Object.getOwnPropertyDescriptor(target, prop as string);
@@ -1845,9 +1862,6 @@ export function statsSerializationProxy(stats: ComputedSetStats): ComputedSetSta
             let obj: object = target;
             while (obj) {
                 Reflect.ownKeys(obj).forEach((key) => {
-                    if (key === 'jobStats') {
-                        return;
-                    }
                     if (typeof key === 'string' && !key.startsWith('_')) {
                         const descriptor = Object.getOwnPropertyDescriptor(obj, key);
                         if (descriptor && typeof descriptor.get === 'function') {
@@ -1861,9 +1875,6 @@ export function statsSerializationProxy(stats: ComputedSetStats): ComputedSetSta
             return Array.from(keys);
         },
         getOwnPropertyDescriptor(target, prop) {
-            if (prop === 'jobStats') {
-                return undefined;
-            }
             const descriptor = Object.getOwnPropertyDescriptor(target, prop)
                 || Object.getOwnPropertyDescriptor(Object.getPrototypeOf(target), prop);
 

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -745,6 +745,27 @@ export type JobData = JobDataConst & {
     jobStatMultipliers: JobMultipliers,
 }
 
+/**
+ * Serialized form of {@link JobData}. Function-bearing fields and traits are omitted because they cannot be usefully
+ * represented in an export. The useful values from a trait are applied during stat calculation rather than stored in
+ * the trait definition.
+ */
+export type JobDataExport = Pick<JobData,
+    | 'type'
+    | 'combatRole'
+    | 'mainStat'
+    | 'secondaryStat'
+    | 'autoAttackStat'
+    | 'irrelevantSubstats'
+    | 'offhand'
+    | 'meldParamIndex'
+    | 'aaPotency'
+    | 'excludedRelicSubstats'
+    | 'minLevel'
+    | 'maxLevel'
+    | 'jobStatMultipliers'
+>;
+
 export interface JobTrait {
     minLevel?: number,
     maxLevel?: number,
@@ -1099,9 +1120,11 @@ export type SetExportExternalSingle = SetExport & {
 }
 
 /**
- * Serialized form of ComputedSetStats. Removes jobStats because it doesn't serialize well.
+ * Serialized form of ComputedSetStats. Includes the serializable portion of jobStats.
  */
-export type ComputedSetStatsExport = Omit<ComputedSetStats, "jobStats">;
+export type ComputedSetStatsExport = Omit<ComputedSetStats, "jobStats"> & {
+    readonly jobStats: JobDataExport,
+};
 
 /**
  * Special version of {@link SetExport} that comes from the /fulldata/ endpoint.
@@ -1497,4 +1520,3 @@ export type IlvlSyncInfo = {
     readonly ilvl: number;
     substatCap(slot: OccGearSlotKey, statsKey: RawStatKey): number;
 }
-


### PR DESCRIPTION
Re-adds job data to fulldata exports in a cut-down form to make it serializable.