### PR TITLE
Customize materia overcap limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 **/.nyc_output/
 **/.DS_Store
 /.idea/queries/
+/.idea/dataSources/

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -19,7 +19,7 @@
     <inspection_tool class="HtmlUnknownTag" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="myValues">
         <value>
-          <list size="64">
+          <list size="65">
             <item index="0" class="java.lang.String" itemvalue="nobr" />
             <item index="1" class="java.lang.String" itemvalue="noembed" />
             <item index="2" class="java.lang.String" itemvalue="comment" />
@@ -84,6 +84,7 @@
             <item index="61" class="java.lang.String" itemvalue="compat-checker-overview-modal" />
             <item index="62" class="java.lang.String" itemvalue="compat-checker-set-modal" />
             <item index="63" class="java.lang.String" itemvalue="meld-solver-progress-display" />
+            <item index="64" class="java.lang.String" itemvalue="materia-autofill-settings-modal" />
           </list>
         </value>
       </option>

--- a/packages/common-ui/styles/common.less
+++ b/packages/common-ui/styles/common.less
@@ -2191,9 +2191,10 @@ div.gear-sheet-toolbar-holder {
         box-sizing: content-box;
         padding: 5px 8px;
         margin-bottom: 10px;
-
-        > svg {
-          padding-right: 5px;
+        &.icon-text-button {
+          > svg {
+            padding-right: 5px;
+          }
         }
       }
     }

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -5,7 +5,7 @@ import {
     LEVEL_ITEMS,
     MATERIA_LEVEL_MAX_NORMAL,
     MATERIA_LEVEL_MAX_OVERMELD,
-    MATERIA_SLOTS_MAX,
+    MATERIA_SLOTS_MAX, MateriaSubstat,
     statById,
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
@@ -1018,7 +1018,7 @@ export function processRawMateriaInfo(data: ApiMateriaData): Materia[] {
             id: itemId,
             iconUrl: new URL(itemData.icon.url),
             stats: stats,
-            primaryStat: stat,
+            primaryStat: stat as MateriaSubstat,
             primaryStatValue: stats[stat],
             materiaGrade: grade,
             isHighGrade: (grade % 2) === 0 && grade >= 6,

--- a/packages/core/src/datamanager_new.ts
+++ b/packages/core/src/datamanager_new.ts
@@ -5,7 +5,8 @@ import {
     LEVEL_ITEMS,
     MATERIA_LEVEL_MAX_NORMAL,
     MATERIA_LEVEL_MAX_OVERMELD,
-    MATERIA_SLOTS_MAX, MateriaSubstat,
+    MATERIA_SLOTS_MAX,
+    MateriaSubstat,
     statById,
     SupportedLevel
 } from "@xivgear/xivmath/xivconstants";
@@ -352,7 +353,7 @@ export class NewApiDataManager implements DataManager {
                             if (i.displayGearSlotName === 'Weapon') {
                                 return true;
                             }
-                            if (i.displayGearSlotName === 'OffHand' && i.usableByJob('FSH'))  {
+                            if (i.displayGearSlotName === 'OffHand' && i.usableByJob('FSH')) {
                                 // Include FSH offhand
                                 console.log(`Including FSH offhand ${i.id}`);
                                 return true;

--- a/packages/core/src/gear.ts
+++ b/packages/core/src/gear.ts
@@ -7,7 +7,7 @@ import {
     getRaceStats,
     JobName,
     MAIN_STATS,
-    MATERIA_ACCEPTABLE_OVERCAP_LOSS,
+    DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS,
     MateriaSubstat,
     NORMAL_GCD,
     RaceName,
@@ -911,6 +911,7 @@ export class CharacterGearSet {
                     // TODO: we also have gearItem.substatCap we can use to make it more direct
                     const override = this.sheet.classJobStats.gcdDisplayOverrides?.(this.sheet.level) ?? [];
                     for (const stat of statPrio) {
+                        const maxWaste = prio.maxWaste[stat] ?? DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS;
                         if (stat === 'skillspeed') {
                             const over = override.find(over => over.basis === 'sks' && over.isPrimary);
                             const attackType = over ? over.attackType : 'Weaponskill';
@@ -947,7 +948,7 @@ export class CharacterGearSet {
                             console.error(`Failed to calculate substat cap for ${stat} on ${gearItem.id} (${gearItem.id})`);
                             return 1000;
                         })();
-                        if (newMateria.primaryStatValue + slotStats[stat] - MATERIA_ACCEPTABLE_OVERCAP_LOSS < cap) {
+                        if (newMateria.primaryStatValue + slotStats[stat] - maxWaste <= cap) {
                             meldSlot.equippedMateria = newMateria;
                             continue materiaLoop;
                         }

--- a/packages/core/src/sheet.ts
+++ b/packages/core/src/sheet.ts
@@ -16,6 +16,7 @@ import {
     JobName,
     LEVEL_ITEMS,
     MAIN_STATS,
+    DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS,
     MateriaSubstat,
     RaceName,
     SPECIAL_STAT_KEYS,
@@ -43,6 +44,7 @@ import {
     MateriaAutoFillPrio,
     MateriaFillMode,
     MateriaSlot,
+    MateriaWasteLimits,
     MeldableMateriaSlot,
     NormalOccGearSlotKey,
     OccGearSlotKey,
@@ -271,10 +273,12 @@ export class GearPlanSheet {
             // if the import does not include hidden item info, reset this to the default.
             this._itemDisplaySettings.showHidden = defaults.showHidden;
         }
+        const maxWaste: MateriaWasteLimits = {...(importedData.mfMaxWaste ?? {})};
         this.materiaAutoFillPrio = {
             statPrio: importedData.mfp ?? [...DefaultMateriaFillPrio.filter(stat => this.isStatRelevant(stat))],
             // Just picking a bogus value so the user understands what it is
             minGcd: importedData.mfMinGcd ?? 2.05,
+            maxWaste: maxWaste,
         };
         this.materiaFillMode = importedData.mfm ?? 'retain_item';
 
@@ -419,6 +423,13 @@ export class GearPlanSheet {
             return mat.materiaGrade <= lvlItemInfo.maxMateria
                 // && mat.materiaGrade >= lvlItemInfo.minMateria
                 && this.isStatRelevant(mat.primaryStat);
+        });
+        this._relevantMateria.forEach(mat => {
+            const stat = mat.primaryStat;
+            if (stat in this.materiaAutoFillPrio.maxWaste) {
+                return;
+            }
+            this.materiaAutoFillPrio.maxWaste[stat] = DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS;
         });
         this.recheckCustomItems();
         for (const importedSet of saved.sets) {
@@ -592,6 +603,7 @@ export class GearPlanSheet {
             mfm: this.materiaFillMode,
             mfp: this.materiaAutoFillPrio.statPrio,
             mfMinGcd: this.materiaAutoFillPrio.minGcd,
+            mfMaxWaste: this.materiaAutoFillPrio.maxWaste,
             ilvlSync: this.ilvlSync,
             description: this.description,
             customItems: this._customItems.map(ci => ci.export()),

--- a/packages/core/src/solving/gearset_generation.ts
+++ b/packages/core/src/solving/gearset_generation.ts
@@ -12,7 +12,7 @@ import {
 } from "@xivgear/xivmath/geartypes";
 import {
     ALL_COMBAT_SUB_STATS,
-    MATERIA_ACCEPTABLE_OVERCAP_LOSS,
+    DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS,
     MateriaSubstat,
     NORMAL_GCD
 } from "@xivgear/xivmath/xivconstants";
@@ -375,8 +375,9 @@ export class GearsetGenerator {
                     const lostToOvercap = Math.max(0, materia.primaryStatValue - (newStatAmount - oldStatAmount));
                     const newStatsKey = this.statsToKey(newStats);
 
+                    // TODO: this uses DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS rather than
                     // Ignore anything that will cause large amounts of overcap, any skip any non-unique stat totals
-                    if (lostToOvercap <= MATERIA_ACCEPTABLE_OVERCAP_LOSS && !itemsToAdd.has(newStatsKey)) {
+                    if (lostToOvercap <= DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS && !itemsToAdd.has(newStatsKey)) {
                         const newMelds: MeldableMateriaSlot[] = this.cloneMelds(existingCombination.item.melds);
                         newMelds[slotNum].equippedMateria = materia;
                         itemsToAdd.set(newStatsKey, new ItemWithStats(new EquippedItem(equippedItem.gearItem, newMelds), newStats));

--- a/packages/frontend/src/materia-waste.less
+++ b/packages/frontend/src/materia-waste.less
@@ -1,0 +1,20 @@
+materia-autofill-settings-modal {
+
+  .modal-inner {
+    max-width: 300px;
+  }
+
+  .materia-max-waste-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    margin: 5px;
+
+    input.materia-max-waste-input {
+      width: 4em;
+      text-align: right;
+    }
+  }
+}
+

--- a/packages/frontend/src/scripts/components/sheet/editor/materia.ts
+++ b/packages/frontend/src/scripts/components/sheet/editor/materia.ts
@@ -6,17 +6,27 @@ import {
     Materia,
     MATERIA_FILL_MODES,
     MateriaAutoFillController,
+    MateriaAutoFillPrio,
     MateriaFillMode,
     MeldableMateriaSlot,
     RawStatKey
 } from "@xivgear/xivmath/geartypes";
-import {MateriaSubstat, MAX_GCD, STAT_ABBREVIATIONS, STAT_FULL_NAMES} from "@xivgear/xivmath/xivconstants";
+import {
+    DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS,
+    MateriaSubstat,
+    MateriaSubstats,
+    MAX_GCD,
+    STAT_ABBREVIATIONS,
+    STAT_FULL_NAMES
+} from "@xivgear/xivmath/xivconstants";
 import {
     el,
     FieldBoundDataSelect,
     FieldBoundFloatField,
+    FieldBoundIntOrUndefField,
     labelFor,
     makeActionButton,
+    nonNegative,
     quickElement
 } from "@xivgear/common-ui/components/util";
 import {GearPlanSheet} from "@xivgear/core/sheet";
@@ -24,8 +34,17 @@ import {recordEvent} from "@xivgear/common-ui/analytics/analytics";
 import {GearPlanSheetGui} from "../sheet_gui";
 import {recordCurrentSheetEvent} from "../../../analytics/analytics";
 import {MODAL_CONTROL} from "@xivgear/common-ui/modalcontrol";
-import {makeLockIcon, makeNewSheetIcon, makePlusIcon, makeTrashIcon} from "@xivgear/common-ui/components/icons";
+import {
+    makeLockIcon,
+    makeNewSheetIcon,
+    makePlusIcon,
+    makeTrashIcon,
+    settingsIcon
+} from "@xivgear/common-ui/components/icons";
 import {getMateriaFillModeName, materiaShortLabel} from "@xivgear/core/materia/materia_utils";
+import {BaseModal} from "@xivgear/common-ui/components/modal";
+import {writeProxy} from "@xivgear/util/proxies";
+import {elt} from "@xivgear/common-ui/components/templates";
 
 /**
  * Component for managing all materia slots on an item
@@ -477,12 +496,20 @@ export class MateriaPriorityPicker extends HTMLElement {
             prioController.fillEmpty();
             recordEvent("fillEmpty");
         }, 'Fill all empty materia slots according to the chosen priority.');
-        fillEmptyNow.classList.add('materia-fill-button');
+        fillEmptyNow.classList.add('materia-fill-button', 'icon-text-button');
+
         const fillAllNow = makeActionButton([makeNewSheetIcon(), 'Fill All'], () => {
             prioController.fillAll();
             recordEvent("fillAll");
         }, 'Empty out and re-fill all materia slots according to the chosen priority.');
-        fillAllNow.classList.add('materia-fill-button');
+        fillAllNow.classList.add('materia-fill-button', 'icon-text-button');
+
+        const maxWasteSettings = makeActionButton([settingsIcon()], () => {
+            new MateriaAutoFillSettingsModal(prioController, sheet).attachAndShowTop();
+            recordEvent("openMateriaAutoFillSettings");
+        }, 'Configure the maximum stat waste allowed by materia auto-fill.');
+        maxWasteSettings.classList.add('materia-fill-button');
+        maxWasteSettings.setAttribute('aria-label', 'Configure materia auto-fill settings');
 
         const lockAllEquipped = makeActionButton('Lock Filled', () => {
             prioController.lockFilled();
@@ -541,12 +568,43 @@ export class MateriaPriorityPicker extends HTMLElement {
             ...(isCombat ? [minGcdText, minGcdInput, document.createElement('br')] : []),
             fillModeLabel, fillModeDropdown,
             document.createElement('br'),
-            fillEmptyNow, fillAllNow,
+            fillEmptyNow, fillAllNow, maxWasteSettings,
             document.createElement('br'),
             lockAllEquipped, lockAllEmpty, unlockAll, unequipAll,
             document.createElement('br'),
             tips
         );
+    }
+}
+
+export class MateriaAutoFillSettingsModal extends BaseModal {
+    constructor(prioController: MateriaAutoFillController, sheet: GearPlanSheetGui) {
+        super();
+        this.headerText = 'Materia Auto-Fill Settings';
+
+        const explanation = elt('p')`Configure the maximum overcap loss for each stat. The materia autofiller will not consider a particular materia if it would lose more than the given value.`;
+        const settings = quickElement('div', ['materia-max-waste-settings']);
+        const prio: MateriaAutoFillPrio = prioController.prio;
+        const maxWaste = writeProxy(prio.maxWaste, () => prioController.callback());
+        const mats = sheet.relevantMateria;
+        const stats = MateriaSubstats.filter(stat => mats.some(materia => materia.primaryStat === stat));
+
+        for (const stat of stats) {
+            const input = new FieldBoundIntOrUndefField(maxWaste, stat, {
+                postValidators: [nonNegative],
+            });
+            input.classList.add('materia-max-waste-input');
+            input.placeholder = String(DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS);
+            input.title = `Maximum ${STAT_FULL_NAMES[stat]} points allowed to be wasted.`;
+            const row = quickElement('div', ['materia-max-waste-row'], [
+                labelFor(`${STAT_FULL_NAMES[stat]}:`, input),
+                input,
+            ]);
+            settings.appendChild(row);
+        }
+
+        this.contentArea.append(explanation, settings);
+        this.addCloseButton();
     }
 }
 
@@ -756,3 +814,4 @@ customElements.define("slot-materia-popup", SlotMateriaManagerPopup);
 customElements.define("materia-priority-picker", MateriaPriorityPicker);
 customElements.define("materia-drag-order", MateriaDragList);
 customElements.define("materia-dragger", MateriaDragger);
+customElements.define("materia-autofill-settings-modal", MateriaAutoFillSettingsModal);

--- a/packages/frontend/src/scripts/nav_hash.ts
+++ b/packages/frontend/src/scripts/nav_hash.ts
@@ -6,7 +6,6 @@ import {
     NO_REDIR_HASH,
     ONLY_SET_QUERY_PARAM,
     parsePath,
-    QUERY_PATH_MAX_LENGTH,
     SELECTION_INDEX_QUERY_PARAM,
     splitHashLegacy,
     tryParseOptionalIntParam

--- a/packages/frontend/src/style.less
+++ b/packages/frontend/src/style.less
@@ -25,6 +25,7 @@
 }
 
 @import "./compatchecker.less";
+@import "./materia-waste.less";
 
 custom-item-popup, custom-food-popup {
   table {

--- a/packages/xivmath/src/geartypes.ts
+++ b/packages/xivmath/src/geartypes.ts
@@ -267,7 +267,7 @@ export interface Materia extends XivCombatItem {
     /**
      * The stat given by the materia
      */
-    primaryStat: RawStatKey,
+    primaryStat: MateriaSubstat,
     /**
      * The value of the stat given by the materia
      */
@@ -886,6 +886,10 @@ export interface SheetExport {
      */
     mfMinGcd?: number,
     /**
+     * The maximum stat waste allowed by materia auto-fill, by stat.
+     */
+    mfMaxWaste?: MateriaWasteLimits,
+    /**
      * If ilvl sync is enabled, this represents what level the sheet should be synced to
      */
     ilvlSync?: number,
@@ -1221,9 +1225,12 @@ export type MateriaAutoFillController = {
     unequipUnlocked(): void;
 }
 
+export type MateriaWasteLimits = Partial<Record<MateriaSubstat, number>>;
+
 export interface MateriaAutoFillPrio {
     statPrio: (MateriaSubstat)[];
     minGcd: number;
+    maxWaste: MateriaWasteLimits;
 }
 
 export const MATERIA_FILL_MODES = ['leave_empty', 'autofill', 'retain_slot_else_prio', 'retain_item_else_prio', 'retain_slot', 'retain_item'] as const;

--- a/packages/xivmath/src/xivconstants.ts
+++ b/packages/xivmath/src/xivconstants.ts
@@ -60,7 +60,7 @@ export const MAX_ILVL = 999;
  * considered an overcap. e.g. if we have a +36 materia, and we only have 34 points
  * until the cap, consider that okay.
  */
-export const MATERIA_ACCEPTABLE_OVERCAP_LOSS = 2;
+export const DEFAULT_MATERIA_ACCEPTABLE_OVERCAP_LOSS = 2;
 
 export const STANDARD_ANIMATION_LOCK = 0.6;
 


### PR DESCRIPTION
Add the ability to customize the max materia waste. This is mostly intended for DoH/DoL since CP/GP scales differently than other stats.

<img width="65" height="69" alt="image" src="https://github.com/user-attachments/assets/1429c3df-0318-4861-b18b-1d34853baed7" />

<img width="349" height="363" alt="image" src="https://github.com/user-attachments/assets/e0039efe-16e6-4f2e-9d65-8f73b1a3be41" />

This also fixes an inconsistency between the filler and the meld solver. The meld solver does NOT follow these new settings, but they now both treat the overcap limit as being inclusive of the limit itself (i.e. if cap is 2, then allow a waste of 2 but not 3).